### PR TITLE
use "ip addr" and "ip route" for network test logs

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 25 08:09:48 UTC 2012 - mkubecek@suse.cz
+
+- use "ip addr" and "ip route" for network test logs rather than
+  ifconfig and route
+
+-------------------------------------------------------------------
 Mon Jul 16 09:01:25 UTC 2012 - mfilka@suse.com
 
 - bnc#767946 - configuring dummy netwok interface error

--- a/src/installation/inst_do_net_test.ycp
+++ b/src/installation/inst_do_net_test.ycp
@@ -237,16 +237,16 @@ and correct the settings.</p>
     
 	// label of combobox where the log is selected
 	logs = add (logs, $[ `menuname : _("Kernel Network Interfaces"),
-			     `filename : "ifconfig.log" ]);
-	run_command = "/sbin/ifconfig > '" + String::Quote (logdir) + "/ifconfig.log'";
+			     `filename : "ip_addr.log" ]);
+	run_command = "/sbin/ip addr show > '" + String::Quote (logdir) + "/ip_addr.log'";
 	ret_command = (integer) SCR::Execute (.target.bash, run_command,
 		      $["LANG" : GetLanguageUTF8 ()]);
 	if (ret_command != 0) y2error("Command '%1' failed -> %2", run_command, ret_command);
 
 	// label of combobox where the log is selected
 	logs = add (logs, $[ `menuname : _("Kernel Routing Table"),
-			     `filename : "route.log" ]);
-	run_command = "/sbin/route -n > '" + String::Quote (logdir) + "/route.log'";
+			     `filename : "ip_route.log" ]);
+	run_command = "/sbin/ip route show > '" + String::Quote (logdir) + "/ip_route.log'";
 	ret_command = (integer) SCR::Execute (.target.bash, run_command,
 		      $["LANG" : GetLanguageUTF8 ()]);
 	if (ret_command != 0) y2error("Command '%1' failed -> %2", run_command, ret_command);

--- a/src/modules/NetHwDetection.ycp
+++ b/src/modules/NetHwDetection.ycp
@@ -147,14 +147,14 @@ global define boolean Start() {
 	return false;
     }
 
-y2milestone("IFCONFIG1: %1", SCR::Execute(.target.bash_output, "/sbin/ifconfig"));
+y2milestone("IFCONFIG1: %1", SCR::Execute(.target.bash_output, "/sbin/ip addr show"));
     boolean ret = false;
     if(StartEthInterface()) {
 	running = true;
 	ret = true;
     }
 
-y2milestone("IFCONFIG2: %1", SCR::Execute(.target.bash_output, "/sbin/ifconfig"));
+y2milestone("IFCONFIG2: %1", SCR::Execute(.target.bash_output, "/sbin/ip addr show"));
     y2milestone("Detection start result: %1", ret);
     return ret;
 }
@@ -170,7 +170,7 @@ global define boolean Stop() {
     }
     running = false;
 
-y2milestone("IFCONFIG3: %1", SCR::Execute(.target.bash_output, "/sbin/ifconfig"));
+y2milestone("IFCONFIG3: %1", SCR::Execute(.target.bash_output, "/sbin/ip addr show"));
 
     y2milestone("Detection stop ");
     return true;


### PR DESCRIPTION
In network test logs, show output of "ip addr show" and
"ip route show" rather than "ifconfig" and "route".
