### PR TITLE
s390.ycp - added top level {} block

### DIFF
--- a/src/lan/s390.ycp
+++ b/src/lan/s390.ycp
@@ -6,6 +6,7 @@
  *
  * Functions for accessing and handling s390 specific needs.
  */
+{
 
 import "FileUtils";
 
@@ -88,4 +89,6 @@ define map<string, any> s390_ReadQethConfig( string devname)
     y2debug( "s390_ReadQethConfig: %1", result);
 
     return result;
+}
+
 }


### PR DESCRIPTION
(needed for YCP->Ruby conversion)
