### PR TITLE
Add deep_copy calls missing because of a Y2R bug

### DIFF
--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -1490,8 +1490,10 @@ module Yast
 
       address_dhcp_contents = VBox("BOOTPROTO")
       just_address_contents = is_ptp ?
-        address_p2p_contents :
-        no_dhcp ? address_static_contents : address_dhcp_contents
+        deep_copy(address_p2p_contents) :
+        no_dhcp ?
+          deep_copy(address_static_contents) :
+          deep_copy(address_dhcp_contents)
 
       address_contents = VBox(
         Left(label),


### PR DESCRIPTION
See https://github.com/yast/y2r/issues/47.
