### PR TITLE
propose new object API for devices

### DIFF
--- a/src/lib/network/configuration/base.rb
+++ b/src/lib/network/configuration/base.rb
@@ -1,0 +1,8 @@
+module Network
+  module Configuration
+    class Base
+      # @note Writting to device can do only Network::Device
+      attr_accessor :device
+    end
+  end
+end

--- a/src/lib/network/configuration/dhcp.rb
+++ b/src/lib/network/configuration/dhcp.rb
@@ -1,0 +1,38 @@
+require "network/configuration/base"
+
+require "yast"
+
+Yast.import "NetworkInterfaces"
+Yast.import "LanItems"
+
+module Network
+  module Configuration
+    class DHCP
+      def save
+        if !Yast::LanItems.FindAndSelect(device.name)
+          raise "Failed to save configuration for device #{device.name}"
+        end
+
+        Yast::LanItems.SetItem
+
+        #tricky part if ifcfg is not set
+        # yes, this code smell and show bad API of LanItems
+        if (Yast::LanItems.getCurrentItem["ifcfg"] || "").empty?
+          Yast::NetworkInterfaces.Add
+          Yast::LanItems.operation = :edit
+          current = Yast::LanItems.Items[Yast::LanItems.current]
+          current["ifcfg"] = device.name
+        end
+
+        Yast::LanItems.bootproto = "dhcp"
+        Yast::LanItems.ipaddr = ""
+        Yast::LanItems.netmask = ""
+        # TODO make it attribute when needed
+        Yast::LanItems.startmode = "auto"
+        Yast::LanItems.Commit
+
+        Yast::NetworkInterfaces.Write(device.name)
+      end
+    end
+  end
+end

--- a/src/lib/network/configuration/none.rb
+++ b/src/lib/network/configuration/none.rb
@@ -1,0 +1,17 @@
+require "network/configuration/base"
+
+require "yast"
+
+Yast.import "NetworkInterfaces"
+
+module Network
+  module Configuration
+    class None < Base
+      def save
+        dev_id = Yast::NetworkInterfaces.Delete(device.name)
+        Yast::NetworkInterfaces.Commit
+        Yast::NetworkInterfaces.Write(device.name) #write only this device
+      end
+    end
+  end
+end

--- a/src/lib/network/device.rb
+++ b/src/lib/network/device.rb
@@ -1,0 +1,41 @@
+require "yast/scr"
+require "yast/path"
+
+module Network
+  class Device
+    attr_reader :configuration
+    attr_reader :name
+
+    def initialize(name)
+      @name = name
+    end
+
+    def start
+      save
+      run "ifup '#{name}'"
+    end
+
+    def stop
+      run "ifdown '#{name}'"
+    end
+
+    def global_address?
+      run "ip -o addr show dev '#{name}' scope global up"
+    end
+
+    def configuration=(conf)
+      conf.device = self
+      @configuration = conf
+    end
+
+    def save
+      @configuration.save
+    end
+
+  private
+    RUN_PATH = Yast::Path.new(".target.bash")
+    def run command
+      Yast::SCR.Execute(RUN_PATH, command) == 0
+    end
+  end
+end


### PR DESCRIPTION
Hi,
I propose new API for network for purpose of new installer and as I hope good enough to replace in future old API, which is really unintuitive.

example usage as I see it for NI simple task ( for each device try to set up DHCP, start it and if it not work, then stop it and remove DHCP config )

``` ruby
def enable_dhcp_devices(device_name)
  device = Network::Device.new(device_name)
  device.configuration = Network::Configuration::DHCP.new
  device.start
  if device.global_address?
     return
  else
    device.stop
    device.configuration = Network::Configuration::None.new
    device.save
  end
end
```

in future we can improve when there is use case for it (I have in mind modules to extend configuration for specific devices with proper object hierarchy or Factory pattern for device, so it can be much easier cached).

@mchf @mvidner opinions?
