### PR TITLE
Refactoring: replaced proprietary timed dialog in ConfirmVirtProposal

### DIFF
--- a/src/lib/network/confirm_virt_proposal.rb
+++ b/src/lib/network/confirm_virt_proposal.rb
@@ -4,93 +4,35 @@ require 'yast'
 
 module Yast
 
-  Yast.import "UI"
-  Yast.import "LanItems"
-  Yast.import "Popup"
-
   # The class represents a simple dialog which asks user for confirmation of
   # network.service restart during installation.
   class ConfirmVirtProposal
 
+    include Singleton
     include UIShortcuts
-    extend I18n
+    include I18n
 
-    def self.run
-      open
+    Yast.import "Popup"
+    Yast.import "Label"
 
-      # for autoinstallation popup has timeout 10 seconds (#192181)
-      # timeout for every case (bnc#429562)
-      ret = UI.TimeoutUserInput(10 * 1000)
-
-      close
-
-      ret
-    end
-
-  private
-
-    def self.open
+    # Shows a confirmation timed dialogue
+    #
+    # Returns :ok when user agreed, :cancel otherwise
+    def run
       textdomain "network"
 
-      UI.OpenDialog(
-        Opt(:decorated),
-        HBox(
-          HSpacing(1),
-          HCenter(
-            HSquash(
-              VBox(
-                HCenter(
-                  HSquash(
-                    VBox(
-                      # This is the heading of the popup box
-                      Left(Heading(_("Confirm Network Restart"))),
-                      VSpacing(0.5),
-                      # This is in information message. Next come the
-                      # hardware class name (network cards).
-                      HVCenter(
-                        Label(
-                          _(
-                            "Because of the bridged network, YaST2 needs to restart the network to apply the settings."
-                          )
-                        )
-                      ),
-                      VSpacing(0.5)
-                    )
-                  )
-                ),
-                ButtonBox(
-                  HWeight(
-                    1,
-                    PushButton(
-                      Id(:ok),
-                      Opt(:default, :okButton),
-                      Label.OKButton
-                    )
-                  ),
-                  # PushButton label
-                  HWeight(
-                    1,
-                    PushButton(
-                      Id(:cancel),
-                      Opt(:cancelButton),
-                      Label.CancelButton
-                    )
-                  )
-                ),
-                VSpacing(0.2)
-              )
-            )
-          ),
-          HSpacing(1)
-        )
+      ret = Popup.TimedAnyQuestion(
+        _("Confirm Network Restart"),
+        _(
+          "Because of the bridged network, YaST2 needs to restart the network to apply the settings."
+        ),
+        Label.OKButton,
+        Label.CancelButton,
+        :focus_yes,
+        10
       )
 
-      UI.SetFocus(Id(:ok))
+      ret ? :ok : :cancel
     end
-
-    def self.close
-      UI.CloseDialog
-    end
-
   end
 end

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -641,7 +641,7 @@ module Yast
         if Stage.cont && @virt_net_proposal == true &&
             (Linuxrc.usessh || Linuxrc.vnc || Linuxrc.display_ip)
 
-          if ConfirmVirtProposal.run == :ok
+          if ConfirmVirtProposal.instance.run == :ok
             Builtins.y2milestone(
               "Restarting network because of bridged proposal"
             )


### PR DESCRIPTION
using Popup.TimedAnyQuestion. It simplifies and DRY the code. Moreover
user now is informed that dialog has timeout (it wasn't clear before)
