### PR TITLE
Fixed network_autoconfiguration_test stubbing on s390 (bnc#883836).

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 13 08:40:28 UTC 2014 - mvidner@suse.com
+
+- Fixed network_autoconfiguration_test stubbing on s390 (bnc#883836).
+- 3.1.79
+
+-------------------------------------------------------------------
 Tue Aug 12 16:58:55 CEST 2014 - locilka@suse.com
 
 - Reading and adjusting the SuSEfirewall2 configuration has been

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.78
+Version:        3.1.79
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -115,7 +115,7 @@ describe Yast::NetworkAutoconfiguration do
     allow(Yast::NetworkInterfaces).
       to receive(:GetType).           with(/eth\d+/).      and_return "eth"
     allow(Yast::NetworkInterfaces).
-      to receive(:GetType).           with("").             and_return nil
+      to receive(:GetType).           with("").            and_return nil
 
     # stub program execution
     # - interfaces are up
@@ -152,6 +152,7 @@ describe Yast::NetworkAutoconfiguration do
 
     # miscellaneous uninteresting but hard to avoid stuff
 
+    allow(Yast::Arch).to receive(:architecture).and_return "x86_64"
     allow(Yast::Confirm).to receive(:Detection).and_return true
     expect(Yast::SCR).
       to receive(:Read).


### PR DESCRIPTION
This particular test does not want to test s390 specialties so make it
see a boring machine.

This build will show whether the fix has worked: https://build.suse.de/package/live_build_log/home:mvidner:branches:SUSE:SLE-12:GA/yast2-network/standard/s390x
