### PR TITLE
Fixed writing proxy configuration from install.inf (bnc#885957)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Aug 28 11:16:20 UTC 2014 - lslezak@suse.cz
+
+- write the proxy credentials from install.inf separately, make it
+  compatible with the proxy module used at installed system
+  (bnc#885957)
+- 3.1.89
+
+-------------------------------------------------------------------
 Wed Aug 27 14:39:13 UTC 2014 - mfilka@suse.com
 
 - bnc#893638

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.88
+Version:        3.1.89
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/install_inf_convertor_test.rb
+++ b/test/install_inf_convertor_test.rb
@@ -202,6 +202,7 @@ describe "InstallInfConvertor" do
 
   describe "#write_proxy" do
     let(:proxy_url) { "http://example.com:3128" }
+    let(:auth_proxy_url) { "http://user:passwd@example.com:3128" }
 
     it "writes proxy configuration if defined in install.inf" do
       expect(Yast::InstallInfConvertor::InstallInf).to receive(:[])
@@ -220,6 +221,31 @@ describe "InstallInfConvertor" do
       expect(Yast::Proxy).to receive(:Import) do |config|
         # proxy is enabled and the URL is set
         expect(config).to include("enabled" => true, "http_proxy" => proxy_url)
+      end
+      expect(Yast::Proxy).to receive(:Write).and_return(true)
+
+      expect(Yast::InstallInfConvertor.instance.send(:write_proxy)).to be_true
+    end
+
+    it "writes proxy credentials separately" do
+      expect(Yast::InstallInfConvertor::InstallInf).to receive(:[])
+        .with("ProxyURL").and_return(auth_proxy_url)
+
+      expect(Yast::Proxy).to receive(:Read).and_return(true)
+      expect(Yast::Proxy).to receive(:Export).and_return(
+        "enabled"        => false,
+        "http_proxy"     => "",
+        "https_proxy"    => "",
+        "ftp_proxy"      => "",
+        "no_proxy"       => "localhost, 127.0.0.1",
+        "proxy_user"     => "",
+        "proxy_password" => ""
+      )
+      expect(Yast::Proxy).to receive(:Import) do |config|
+        # proxy is enabled and the URL without credentials is set
+        expect(config).to include("enabled" => true, "http_proxy" => proxy_url,
+          "proxy_user" => "user", "proxy_password" => "passwd"
+        )
       end
       expect(Yast::Proxy).to receive(:Write).and_return(true)
 


### PR DESCRIPTION
- Write the proxy credentials separately, make it compatible with the proxy module used at installed system
- Tested in the latest build   :white_check_mark: 
- 3.1.89
