### PR TITLE
Use a more flexible rubygem requirement syntax (bnc#895069)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep  8 08:55:09 UTC 2014 - mvidner@suse.com
+
+- Use a more flexible rubygem requirement syntax (bnc#895069)
+- 3.1.95
+
+-------------------------------------------------------------------
 Fri Sep  5 09:48:22 UTC 2014 - mfilka@suse.com
 
 - bnc#894053

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.94
+Version:        3.1.95
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -48,7 +48,7 @@ BuildRequires:  yast2-storage >= 2.21.11
 Requires:       yast2-storage >= 2.21.11
 
 # testsuite
-BuildRequires:       rubygem-rspec
+BuildRequires:       rubygem(rspec)
 
 PreReq:         /bin/rm
 


### PR DESCRIPTION
https://en.opensuse.org/openSUSE:Packaging_Ruby#Format_of_automatically_generated_Provides:_headers
