### PR TITLE
Do not check for installed packages and do not try to install packages in inst-sys

### DIFF
--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -133,6 +133,10 @@ module Yast
     # @param [Array<String>] packages list of required packages (["rpm", "bash"])
     # @return `next if packages installation is successfull, `abort otherwise
     def PackagesInstall(packages)
+      # FIXME: in inst-sys grep for packages in /.packages.*
+      #        but these packages need to be in order first
+      return :next if Stage.initial
+
       packages = deep_copy(packages)
       return :next if packages == []
       Builtins.y2debug("Checking packages: %1", packages)


### PR DESCRIPTION
- bnc#888130: Yast LAN wants to install some packages, which is impossible anyway
- the required packages are there, but no RPM database to check it

The patch just makes Yast LAN to skip checking for packages

I'll create new changes file entry and raise the version when approved, because there is another PR in review now.
