### PR TITLE
Versions between SLE 12 and master have diverged long time ago

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -4,7 +4,7 @@ Mon May 18 12:59:27 CEST 2015 - locilka@suse.com
 - bsc#916376
   - proposing iSCSI-related configuration in firewall proposal
     in first stage if iSCSI is in use
-- 3.1.113
+- 3.1.112.1
 
 -------------------------------------------------------------------
 Fri Mar  6 13:48:24 UTC 2015 - mfilka@suse.com

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.113
+Version:        3.1.112.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- This is a simple "fix" for the divergence so we do not keep this problem on the plate anymore
- 3.1.113 is a "new" SLE 12 version, created just today and not yet submitted to SLE 12 BS