### PR TITLE
Set the textdomain, otherwise `_()` does not translate properly

### DIFF
--- a/test/firewall_stage1_proposal_test.rb
+++ b/test/firewall_stage1_proposal_test.rb
@@ -27,6 +27,7 @@ module Yast
         res["preformatted_proposal"]
       end
       let(:ssh_string) do
+        Yast.textdomain "network"
         format(
           Yast._("SSH port will be open (<a href=\"%s\">block</a>)"),
           "firewall--disable_ssh_port_in_proposal"


### PR DESCRIPTION
`_()` does not translate if the text domain has not been set,

```
LC_ALL=cs_CZ.utf8 rspec test/firewall_stage1_proposal_test.rb
```
fails with
```diff
@@ -1,2 +1,6 @@
-SSH port will be open (<a href="firewall--disable_ssh_port_in_proposal">block</a>)
+<ul>
+<li>Firewall bude povolen (<a href="firewall--disable_firewall_in_proposal">zakázat</a>)</li>
+<li>Port SSH bude otevřen (<a href="firewall--disable_ssh_port_in_proposal">uzavřít</a>)</li>
+<li>Služba SSH bude zakázána (<a href="firewall--enable_sshd_in_proposal">povolit</a>)</li>
+</ul>
```

After setting the `textdomain` it passes correctly.