### PR TITLE
Fix keep install network

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 15 10:46:18 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix handling of AutoYaST parameter keep_install_network
+- 3.1.119
+
+-------------------------------------------------------------------
 Thu Jun 11 07:51:16 UTC 2015 - mfilka@suse.com
 
 - fate#318804

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.118
+Version:        3.1.119
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/lan_auto.rb
+++ b/src/clients/lan_auto.rb
@@ -93,7 +93,7 @@ module Yast
         # in case keep_install_network is set to true (in AY)
         # we'll keep values from installation
         # and merge with XML data (bnc#712864)
-        @param = NetworkAutoYast.instance.merge_configs(@params) if @param["keep_install_network"]
+        @param = NetworkAutoYast.instance.merge_configs(@param) if @param["keep_install_network"]
 
         @new = FromAY(@param)
         Lan.Import(@new)


### PR DESCRIPTION
@mchf: I've getting an error when using the `keep_install_network` parameter on AutoYaST:

<pre>Details: undefined method `map' for nil:NilClass
Caller: /usr/share/YaST2/modules/LanUdevAuto.rb:199:in `Write'</pre>

 Taking a look at the code, maybe there's a typo.  I've tried this fix and at least installation ends up properly. If that's not the problem, just feel free to ditch this PR away :)