### PR TITLE
Fixed duplicated keys in hash literals (.changes only)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 30 16:18:26 UTC 2015 - mvidner@suse.com
+
+- Fixed warnings like 'duplicated key at line 230 ignored:
+  "rt73usb"' (boo#930870)
+  (recording a fix present in 3.1.116 already).
+
+-------------------------------------------------------------------
 Thu Jun 25 14:15:06 UTC 2015 - mfilka@suse.com
 
 - bnc#922765, bnc#923990


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=930870
was filed for a fix that hadn't had a bugzilla entry:
bac49d9681e73e6c8326849630b6cccdfb609b6d  https://github.com/yast/yast-network/pull/305

