### PR TITLE
Fixed handling of "no info returned from GetDeviceMap(...)"

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Sep  2 09:20:54 CEST 2015 - locilka@suse.com
+
+- bnc#911571
+  - fixed LanOverview to handle missing information for a network
+    interface, solution inspired by Adam Spiers' patch.
+- 3.1.129
+
+-------------------------------------------------------------------
 Thu Aug 27 20:29:41 UTC 2015 - mfilka@suse.com
 
 - bnc#846201

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.128
+Version:        3.1.129
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -1337,7 +1337,8 @@ module Yast
 
         LanItems.type = NetworkInterfaces.GetType(ifcfg_name)
         if !ifcfg_name.empty?
-          ifcfg_conf = GetDeviceMap(key)
+          ifcfg_conf = GetDeviceMap(key) || {}
+          log.error "Failed to get device map for #{key}, interface #{ifcfg_name}" if ifcfg_conf.empty?
           ifcfg_desc = ifcfg_conf["NAME"]
           descr = ifcfg_desc if !ifcfg_desc.nil? && !ifcfg_desc.empty?
           descr = CheckEmptyName(LanItems.type, descr)

--- a/test/build_lan_overview_test.rb
+++ b/test/build_lan_overview_test.rb
@@ -63,4 +63,22 @@ describe "LanItemsClass#BuildLanOverview" do
     expect(overview).not_to eql unknown_device_overview
     expect(overview).to eql german_translation_overview
   end
+
+  # bsc#911571
+  context "when no ifcfg DeviceMap information is available" do
+    it "returns a summary and links" do
+      allow(Yast::LanItems)
+        .to receive(:Items)
+        .and_return(wlan_items)
+      allow(Yast::LanItems)
+        .to receive(:GetDeviceMap)
+        .and_return(nil)
+      allow(Yast::NetworkInterfaces)
+        .to receive(:Current)
+        .and_return(wlan_ifcfg)
+
+      overview = Yast::LanItems.BuildLanOverview
+      expect(overview[0]).to match("Wireless Network Card")
+    end
+  end
 end


### PR DESCRIPTION
- bsc#911571
- Similar solution proposed and tested by Adam Spiers
- I've tested this only using a unit test