### PR TITLE
Relax-NG ... Some defines for ipv6_forward needs the combine attribute

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Oct  2 13:44:00 UTC 2015 - mvidner@suse.com
+
+- Fixed "Relax-NG parser error : Some defines for ipv6_forward
+  needs the combine attribute" when checking validity
+  of any AutoYaST profile (bsc#948206).
+- 3.1.112.9
+
+-------------------------------------------------------------------
 Wed Sep 23 09:06:08 UTC 2015 - mfilka@suse.com
 
 - bnc#866742

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.112.8
+Version:        3.1.112.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -221,15 +221,11 @@ dhclient_hostname_option = element dhclient_hostname_option { text }
 
 routing =
   element routing {
-    ip_forward? &
-    ipv4_forward? &
-    ipv6_forward? &
+    element ip_forward   { BOOLEAN }? &
+    element ipv4_forward { BOOLEAN }? &
+    element ipv6_forward { BOOLEAN }? &
     routes?
   }
-
-ip_forward = element ip_forward { BOOLEAN }
-ipv4_forward = element ipv4_forward { BOOLEAN }
-ipv6_forward = element ipv6_forward { BOOLEAN }
 
 routes =
   element routes {


### PR DESCRIPTION
L3: https://bugzilla.suse.com/show_bug.cgi?id=948206
That bug also needs https://github.com/yast/yast-auth-client/pull/44