### PR TITLE
Fixed "AutoYaST fails to configure network" (bsc#949193).

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 19 12:17:07 UTC 2015 - mvidner@suse.com
+
+- Fixed a regression where AutoYaST flag keep_install_network=false
+  was ignored (bsc#949193, introduced in 3.1.112.2).
+- 3.1.112.10
+
+-------------------------------------------------------------------
 Fri Oct  2 13:44:00 UTC 2015 - mvidner@suse.com
 
 - Fixed "Relax-NG parser error : Some defines for ipv6_forward

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.112.9
+Version:        3.1.112.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/lan_auto.rb
+++ b/src/clients/lan_auto.rb
@@ -87,13 +87,13 @@ module Yast
       elsif @func == "Change"
         @ret = LanAutoSequence("")
       elsif @func == "Import"
+        @new = FromAY(@param)
         # see bnc#498993
         # in case keep_install_network is set to true (in AY)
         # we'll keep values from installation
         # and merge with XML data (bnc#712864)
-        @param = NetworkAutoYast.instance.merge_configs(@param) if @param["keep_install_network"]
+        @new = NetworkAutoYast.instance.merge_configs(@new) if @new["keep_install_network"]
 
-        @new = FromAY(@param)
         Lan.Import(@new)
         LanUdevAuto.Import(@new)
         @ret = true
@@ -245,6 +245,7 @@ module Yast
         end
       end
 
+      input["devices"] = devices
       input["hwcfg"] = hwcfg
 
       # DHCP:: config: some of it is in the DNS part of the profile

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -662,7 +662,11 @@ module Yast
       Write()
     end
 
-    # Import data
+    # Import data.
+    # It expects data described networking.rnc
+    # and then passed through {LanAutoClient#FromAY}.
+    # Most prominently, instead of a flat list called "interfaces"
+    # we import a 2-level map of typed "devices"
     # @param [Hash] settings settings to be imported
     # @return true on success
     def Import(settings)
@@ -689,14 +693,17 @@ module Yast
       true
     end
 
-    # Export data
-    # @return dumped settings (later acceptable by Import())
+    # Export data.
+    # They need to be passed through {LanAutoClient#ToAY} to become
+    # what networking.rnc describes.
+    # Most prominently, instead of a flat list called "interfaces"
+    # we export a 2-level map of typed "devices"
+    # @return dumped settings
     def Export
       devices = NetworkInterfaces.Export("")
       udev_rules = LanUdevAuto.Export(devices)
       ay = {
         "dns"                  => DNS.Export,
-        # FIXME: MOD "modules"	: Modules,
         "s390-devices"         => Ops.get_map(
           udev_rules,
           "s390-devices",


### PR DESCRIPTION
[L3 bug 949193](https://bugzilla.suse.com/show_bug.cgi?id=949193)

The fix for bsc#874259 erroneously removed the "devices" part of FromAY
return value. As a result no interfaces were configured, always keeping
what was used for the installation.

(still testing whether the fix actually helps)