### PR TITLE
Merge #347 to SP1

### DIFF
--- a/src/clients/lan_auto.rb
+++ b/src/clients/lan_auto.rb
@@ -88,13 +88,13 @@ module Yast
       elsif @func == "Change"
         @ret = LanAutoSequence("")
       elsif @func == "Import"
+        @new = FromAY(@param)
         # see bnc#498993
         # in case keep_install_network is set to true (in AY)
         # we'll keep values from installation
         # and merge with XML data (bnc#712864)
-        @param = NetworkAutoYast.instance.merge_configs(@param) if @param["keep_install_network"]
+        @new = NetworkAutoYast.instance.merge_configs(@new) if @new["keep_install_network"]
 
-        @new = FromAY(@param)
         Lan.Import(@new)
         LanUdevAuto.Import(@new)
         @ret = true

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -660,7 +660,11 @@ module Yast
       Write()
     end
 
-    # Import data
+    # Import data.
+    # It expects data described networking.rnc
+    # and then passed through {LanAutoClient#FromAY}.
+    # Most prominently, instead of a flat list called "interfaces"
+    # we import a 2-level map of typed "devices"
     # @param [Hash] settings settings to be imported
     # @return true on success
     def Import(settings)
@@ -687,14 +691,17 @@ module Yast
       true
     end
 
-    # Export data
-    # @return dumped settings (later acceptable by Import())
+    # Export data.
+    # They need to be passed through {LanAutoClient#ToAY} to become
+    # what networking.rnc describes.
+    # Most prominently, instead of a flat list called "interfaces"
+    # we export a 2-level map of typed "devices"
+    # @return dumped settings
     def Export
       devices = NetworkInterfaces.Export("")
       udev_rules = LanUdevAuto.Export(devices)
       ay = {
         "dns"                  => DNS.Export,
-        # FIXME: MOD "modules"	: Modules,
         "s390-devices"         => Ops.get_map(
           udev_rules,
           "s390-devices",


### PR DESCRIPTION
#347 is 'Fixed "AutoYaST fails to configure network" [bsc#949193](https://bugzilla.suse.com/show_bug.cgi?id=949193)'

NOTE that due to changes done in the development branch (master AKA SLE-12-SP1) in the meantime, the original bug bsc#949193 is not present, as evidenced by this new test:
yast/autoyast-integration-test#42

It also seemed that a different bug ([bsc#874259#c157](https://bugzilla.suse.com/show_bug.cgi?id=874259#c157)) was present but my testing did not confirm that.

Therefore no version+changelog entry, just merging forward.
