### PR TITLE
Fix AutoYaST schema in SLE 12 GA

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 13 10:32:22 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix validation of AutoYaST profiles (bsc#954412)
+- 3.1.112.11
+
+-------------------------------------------------------------------
 Mon Oct 19 12:17:07 UTC 2015 - mvidner@suse.com
 
 - Fixed a regression where AutoYaST flag keep_install_network=false

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.112.10
+Version:        3.1.112.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -64,6 +64,7 @@ interface =
     element bonding_slave7 { text }? &
     element bonding_slave8 { text }? &
     element bonding_slave9 { text }? &
+    element bonding_module_opts { text }? &
     element aliases        { Anything }? &
     broadcast? &
     network? &
@@ -75,7 +76,13 @@ interface =
     wireless? &
     wifi_settings? &
 
-    dhclient_set_down_link?
+    bridge_settings? &
+    vlan_settings? &
+
+    dhclient_set_down_link? &
+    dhclient_set_default_route? &
+
+    element firewall { "yes" | "no" }?
   }
 
 
@@ -112,6 +119,7 @@ remote_ipaddr = element remote_ipaddr { text }
 bootproto = element bootproto { text }
 broadcast = element broadcast { text }
 dhclient_set_down_link = element dhclient_set_down_link { text }
+dhclient_set_default_route = element dhclient_set_default_route { "yes" | "no" }
 ipaddr = element ipaddr { text }
 prefixlen = element prefixlen { text }
 usercontrol = element usercontrol { text }
@@ -182,6 +190,24 @@ wireless_wpa_anonid = element wireless_wpa_anonid { text }
 wireless_wpa_identity = element wireless_wpa_identity { text }
 wireless_wpa_password = element wireless_wpa_password { text }
 wireless_wpa_psk = element wireless_wpa_psk { text }
+
+#
+# Bridge
+#
+bridge_settings = (
+  element bridge              { "yes" | "no" }? &
+  element bridge_ports        { text }? &
+  element bridge_stp          { "on" | "off" }? &
+  element bridge_forwarddelay { text }?
+)
+
+#
+# VLAN
+#
+vlan_settings = (
+  element etherdevice { text }? &
+  element vlan_id     { text }?
+)
 
 #
 # MODULES


### PR DESCRIPTION
I'm adding the `FIREWALL` element because I found it in the `ifcfg-lo` in a SLE 12 machine.

Fixes [bsc#954412](https://bugzilla.suse.com/show_bug.cgi?id=954412) for this module.