### PR TITLE
Device renaming during ssh|vnc AY installation

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Mon Nov 16 05:52:07 UTC 2015 - mfilka@suse.com
+
+- bnc#944349
+  - do not set links down when running AY installation over vnc.
+    VNC installation do not freeze.
+  - renaming network devices during ssh/vnc installation is
+    supported
+-3.1.135
+
+-------------------------------------------------------------------
 Sun Nov  8 20:55:53 UTC 2015 - mfilka@suse.com
 
 - bnc#944349

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.134
+Version:        3.1.135
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/save_network.rb
+++ b/src/clients/save_network.rb
@@ -299,10 +299,10 @@ module Yast
         key = rule["value"].downcase
         # currently we're interrested only on those interfaces which are already
         # configured - such interfaces cannot be restarted during second stage
-        matching_item = LanItems.Items.find { |_, i| i["hwinfo"]["busid"].downcase == key || i["hwinfo"]["mac"].downcase == key }
+        _, matching_item = LanItems.Items.find { |_, i| i["hwinfo"]["busid"].downcase == key || i["hwinfo"]["mac"].downcase == key }
         next if !matching_item
 
-        name_from = matching_item[1]["ifcfg"]
+        name_from = matching_item["ifcfg"]
 
         log.info("- renaming <#{name_from}> -> <#{name_to}>")
 

--- a/src/clients/save_network.rb
+++ b/src/clients/save_network.rb
@@ -49,6 +49,7 @@ module Yast
       Yast.import "Storage"
       Yast.import "LanItems"
       Yast.import "Profile"
+      Yast.import "Linuxrc"
 
       Yast.include self, "network/routines.rb"
       Yast.include self, "network/complex.rb"
@@ -275,8 +276,8 @@ module Yast
     # Once properly analyzed and tested then starting of whole network second
     # stage can be moved here.
     def ay_mode_configuration
-      # TODO: run only when in {ssh|vnc} mode of AY
       return if !Mode.autoinst
+      return if !(Linuxrc.usessh || Linuxrc.vnc)
 
       ay_profile = Profile.current
 

--- a/src/clients/save_network.rb
+++ b/src/clients/save_network.rb
@@ -46,7 +46,6 @@ module Yast
       Yast.import "String"
       Yast.import "Mode"
       Yast.import "Arch"
-      Yast.import "LanUdevAuto"
       Yast.import "Storage"
 
       Yast.include self, "network/routines.rb"

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -645,7 +645,7 @@ module Yast
           # - remove it completely
           # removing is less error prone when tracking name changes, so it was chosen.
           item_udev_net = RemoveKeyFromUdevRule(item_udev_net, "KERNEL")
-          SetLinkDown(dev_name)
+          SetLinkDown(dev_name) if !Mode.autoinst
 
           @force_restart = true
         end
@@ -736,7 +736,7 @@ module Yast
         SetItemName(item_id, renamed_to(item_id))
       end
 
-      LanItems.WriteUdevRules if !Mode.autoinst && LanUdevAuto.AllowUdevModify
+      LanItems.WriteUdevRules if LanUdevAuto.AllowUdevModify
 
       # FIXME: hack: no "netcard" filter as biosdevname names it diferently (bnc#712232)
       NetworkInterfaces.Write("")

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -645,6 +645,7 @@ module Yast
           # - remove it completely
           # removing is less error prone when tracking name changes, so it was chosen.
           item_udev_net = RemoveKeyFromUdevRule(item_udev_net, "KERNEL")
+          # setting links down during AY is forbidden bcs it can freeze ssh installation
           SetLinkDown(dev_name) if !Mode.autoinst
 
           @force_restart = true

--- a/src/modules/LanUdevAuto.rb
+++ b/src/modules/LanUdevAuto.rb
@@ -207,7 +207,7 @@ module Yast
       end
 
       if !rules.empty? && AllowUdevModify()
-        SetAllLinksDown() if !Linuxrc.usessh
+        SetAllLinksDown() if !(Linuxrc.usessh || Linuxrc.vnc)
 
         log.info("Writing AY udev rules for network")
 


### PR DESCRIPTION
bnc#944349

the most important part of the patch is moving device renaming from 2nd into 1st stage

Do not merge yet, still under testing.