### PR TITLE
Export DNS config at the end of installation even when provided via linuxrc

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Dec  2 13:26:12 UTC 2015 - mfilka@suse.com
+
+- bnc#957377
+  - When exporting AutoYaST profile, it contains dns configuration
+    even when this config was provided via linuxrc.
+- 3.1.112.13
+
+-------------------------------------------------------------------
 Wed Nov 25 08:02:22 UTC 2015 - mfilka@suse.com
 
 - bnc#951330

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.112.12
+Version:        3.1.112.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -516,6 +516,11 @@ module Yast
     # @return autoinstallation settings
     def Export
       expdns = {}
+
+      # It should be case only for installer (1st stage). When resolver / hostname
+      # was configured via linuxrc, yast needn't to be aware of it. bnc#957377
+      Read() if !@initialized
+
       if Ops.greater_than(Builtins.size(@hostname), 0)
         Ops.set(expdns, "hostname", @hostname)
       end


### PR DESCRIPTION
[bsc#957377](https://bugzilla.suse.com/show_bug.cgi?id=957377)
