### PR TITLE
Fix error when aborting the configuration of a WiFi interface (SLE12-GA)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 22 13:24:15 UTC 2016 - mvidner@suse.com
+
+- Fixed an Internal error when aborting the configuration of a
+  WiFi interface (bsc#950902).
+- 3.1.112.14
+
+-------------------------------------------------------------------
 Wed Dec  2 13:26:12 UTC 2015 - mfilka@suse.com
 
 - bnc#957377

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.112.13
+Version:        3.1.112.14
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/network/lan/wireless.rb
+++ b/src/include/network/lan/wireless.rb
@@ -546,6 +546,7 @@ module Yast
 
         if ret == :abort || ret == :cancel
           if ReallyAbort()
+            LanItems.Rollback()
             break
           else
             next
@@ -867,6 +868,7 @@ module Yast
 
         if ret == :abort || ret == :cancel
           if ReallyAbort()
+            LanItems.Rollback()
             break
           else
             next
@@ -1098,6 +1100,7 @@ module Yast
 
         if ret == :abort || ret == :cancel
           if ReallyAbort()
+            LanItems.Rollback()
             break
           else
             next


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=950902
https://trello.com/c/niS3zpbD/420-5-sles-12-sp1-p2-950902-yast2-network-yast2-lan-error-when-configuring-wireless-interface