### PR TITLE
bnc#920089 - Changed dialog window size for entering static routes

### DIFF
--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -151,35 +151,46 @@ module Yast
 
       UI.OpenDialog(
         Opt(:decorated),
+        MinWidth(60,
         VBox(
           HSpacing(1),
           VBox(
             HBox(
-              InputField(
-                Id(:destination),
-                Opt(:hstretch),
-                _("&Destination"),
-                Ops.get_string(entry, 1, "")
+              HWeight(70,
+                InputField(
+                  Id(:destination),
+                  Opt(:hstretch),
+                  _("&Destination"),
+                  Ops.get_string(entry, 1, "")
+                )
               ),
-              InputField(
-                Id(:genmask),
-                Opt(:hstretch),
-                _("Ge&nmask"),
-                Ops.get_string(entry, 3, "-")
+              HSpacing(1),
+              HWeight(30,
+                InputField(
+                  Id(:genmask),
+                  Opt(:hstretch),
+                  _("Ge&nmask"),
+                  Ops.get_string(entry, 3, "-")
+                )
               )
             ),
             HBox(
-              InputField(
-                Id(:gateway),
-                Opt(:hstretch),
-                _("&Gateway"),
-                Ops.get_string(entry, 2, "-")
+              HWeight(70,
+                InputField(
+                  Id(:gateway),
+                  Opt(:hstretch),
+                  _("&Gateway"),
+                  Ops.get_string(entry, 2, "-")
+                )
               ),
-              ComboBox(
-                Id(:device),
-                Opt(:editable, :hstretch),
-                _("De&vice"),
-                devs
+              HSpacing(1),
+              HWeight(30,
+                ComboBox(
+                  Id(:device),
+                  Opt(:editable, :hstretch),
+                  _("De&vice"),
+                  devs
+                )
               )
             ),
             # ComboBox label
@@ -196,6 +207,7 @@ module Yast
             PushButton(Id(:cancel), Label.CancelButton)
           )
         )
+                 )
       )
 
       # Allow declaring route without iface (for gateway) #93996

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -152,62 +152,62 @@ module Yast
       UI.OpenDialog(
         Opt(:decorated),
         MinWidth(60,
-        VBox(
-          HSpacing(1),
           VBox(
-            HBox(
-              HWeight(70,
-                InputField(
-                  Id(:destination),
-                  Opt(:hstretch),
-                  _("&Destination"),
-                  Ops.get_string(entry, 1, "")
+            HSpacing(1),
+            VBox(
+              HBox(
+                HWeight(70,
+                  InputField(
+                    Id(:destination),
+                    Opt(:hstretch),
+                    _("&Destination"),
+                    Ops.get_string(entry, 1, "")
+                  )
+                ),
+                HSpacing(1),
+                HWeight(30,
+                  InputField(
+                    Id(:genmask),
+                    Opt(:hstretch),
+                    _("Ge&nmask"),
+                    Ops.get_string(entry, 3, "-")
+                  )
                 )
               ),
-              HSpacing(1),
-              HWeight(30,
-                InputField(
-                  Id(:genmask),
-                  Opt(:hstretch),
-                  _("Ge&nmask"),
-                  Ops.get_string(entry, 3, "-")
-                )
-              )
-            ),
-            HBox(
-              HWeight(70,
-                InputField(
-                  Id(:gateway),
-                  Opt(:hstretch),
-                  _("&Gateway"),
-                  Ops.get_string(entry, 2, "-")
+              HBox(
+                HWeight(70,
+                  InputField(
+                    Id(:gateway),
+                    Opt(:hstretch),
+                    _("&Gateway"),
+                    Ops.get_string(entry, 2, "-")
+                  )
+                ),
+                HSpacing(1),
+                HWeight(30,
+                  ComboBox(
+                    Id(:device),
+                    Opt(:editable, :hstretch),
+                    _("De&vice"),
+                    devs
+                  )
                 )
               ),
-              HSpacing(1),
-              HWeight(30,
-                ComboBox(
-                  Id(:device),
-                  Opt(:editable, :hstretch),
-                  _("De&vice"),
-                  devs
-                )
+              # ComboBox label
+              InputField(
+                Id(:options),
+                Opt(:hstretch),
+                Label.Options,
+                Ops.get_string(entry, 5, "")
               )
             ),
-            # ComboBox label
-            InputField(
-              Id(:options),
-              Opt(:hstretch),
-              Label.Options,
-              Ops.get_string(entry, 5, "")
+            HSpacing(1),
+            HBox(
+              PushButton(Id(:ok), Opt(:default), Label.OKButton),
+              PushButton(Id(:cancel), Label.CancelButton)
             )
-          ),
-          HSpacing(1),
-          HBox(
-            PushButton(Id(:ok), Opt(:default), Label.OKButton),
-            PushButton(Id(:cancel), Label.CancelButton)
           )
         )
-                 )
       )
 
       # Allow declaring route without iface (for gateway) #93996


### PR DESCRIPTION
Bug 920089 - [yast2-network] - jj: The ncurses window for adding a static route is ridiculously small 

- Added MinWidth for dialog window
- Added proportional sizing for elements
- Added space between elements