### PR TITLE
Setup DNS according AY profile correctly when a static net configuration is provided to linuxrc

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Apr 26 20:19:12 UTC 2016 - mfilka@suse.com
+
+- bnc#971175
+  - /etc/hosts is correctly updated with static address, hostname
+    when static net configuration is done via linuxrc and hostname
+    is provided by AY profile
+- 3.1.140.4 
+
+-------------------------------------------------------------------
 Mon Feb 22 11:52:09 UTC 2016 - mfilka@suse.com
 
 - bnc#960703

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.140.3
+Version:        3.1.140.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/firewall_stage1_proposal.rb
+++ b/src/clients/firewall_stage1_proposal.rb
@@ -277,7 +277,7 @@ module Yast
       Convert.to_symbol(dialog_ret)
     end
 
-    private
+  private
 
     def preformatted_proposal
       firewall_proposal = if SuSEFirewall4Network.Enabled1stStage

--- a/src/clients/save_network.rb
+++ b/src/clients/save_network.rb
@@ -247,13 +247,14 @@ module Yast
       nil
     end
 
-    # Creates DNS configuration on target
+    # Creates target's default DNS configuration
+    #
+    # It uses DNS configuration as defined in AY profile (if any) or
+    # proposes a predefined default values.
     def configure_dns
-      if Mode.autoinst
-        NetworkAutoYast.instance.configure_dns
-      else
-        NetworkAutoconfiguration.instance.configure_dns
-      end
+      ret = false
+      ret = NetworkAutoYast.instance.configure_dns if Mode.autoinst
+      ret = NetworkAutoconfiguration.instance.configure_dns if !ret
 
       DNS.create_hostname_link
     end

--- a/src/clients/save_network.rb
+++ b/src/clients/save_network.rb
@@ -245,15 +245,27 @@ module Yast
       nil
     end
 
+    # Creates DNS configuration on target
+    def configure_dns
+      if Mode.autoinst
+        NetworkAutoYast.instance.configure_dns
+      else
+        NetworkAutoconfiguration.instance.configure_dns
+      end
+
+      DNS.create_hostname_link
+    end
+
     # It does an automatic configuration of installed system
     #
     # Basically, it runs several proposals.
     def configure_target
       NetworkAutoconfiguration.instance.configure_virtuals
-      NetworkAutoconfiguration.instance.configure_dns
-      NetworkAutoconfiguration.instance.configure_hosts
 
-      DNS.create_hostname_link
+      configure_dns
+
+      # this depends on DNS configuration
+      NetworkAutoconfiguration.instance.configure_hosts
 
       set_network_service
 

--- a/src/clients/save_network.rb
+++ b/src/clients/save_network.rb
@@ -36,8 +36,6 @@ module Yast
     include Logger
 
     def main
-      Yast.import "UI"
-
       textdomain "network"
 
       Yast.import "DNS"

--- a/src/clients/save_network.rb
+++ b/src/clients/save_network.rb
@@ -252,9 +252,9 @@ module Yast
     # It uses DNS configuration as defined in AY profile (if any) or
     # proposes a predefined default values.
     def configure_dns
-      ret = false
-      ret = NetworkAutoYast.instance.configure_dns if Mode.autoinst
-      NetworkAutoconfiguration.instance.configure_dns if !ret
+      configured = false
+      configured = NetworkAutoYast.instance.configure_dns if Mode.autoinst
+      NetworkAutoconfiguration.instance.configure_dns if !configured
 
       DNS.create_hostname_link
     end

--- a/src/clients/save_network.rb
+++ b/src/clients/save_network.rb
@@ -254,7 +254,7 @@ module Yast
     def configure_dns
       ret = false
       ret = NetworkAutoYast.instance.configure_dns if Mode.autoinst
-      ret = NetworkAutoconfiguration.instance.configure_dns if !ret
+      NetworkAutoconfiguration.instance.configure_dns if !ret
 
       DNS.create_hostname_link
     end

--- a/src/clients/save_network.rb
+++ b/src/clients/save_network.rb
@@ -84,6 +84,8 @@ module Yast
     SYSCONFIG = "/etc/sysconfig/network/"
 
     def CopyConfiguredNetworkFiles
+      return if Mode.autoinst && !NetworkAutoYast.instance.keep_net_config?
+
       log.info(
         "Copy network configuration files from 1st stage into installed system"
       )

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -567,7 +567,7 @@ module Yast
       ret
     end
 
-    private
+  private
 
     def overview_buttons
       ret = {}

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -1014,7 +1014,7 @@ module Yast
       true
     end
 
-    private
+  private
 
     # Checks if the device should be filtered out in ReadHardware
     def filter_out(device_info, driver)

--- a/src/lib/network/edit_nic_name.rb
+++ b/src/lib/network/edit_nic_name.rb
@@ -82,7 +82,7 @@ module Yast
       new_name || @old_name
     end
 
-    private
+  private
 
     # Opens dialog for editing NIC name
     def open

--- a/src/lib/network/install_inf_convertor.rb
+++ b/src/lib/network/install_inf_convertor.rb
@@ -44,7 +44,7 @@ module Yast
       write_global_netconfig
     end
 
-    private
+  private
 
     def create_ifcfg
       ifcfg = ""

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -107,7 +107,7 @@ module Yast
       Host.Write
     end
 
-    private
+  private
 
     def network_cards
       LanItems.Read

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -136,7 +136,7 @@ module Yast
 
     # Checks if the profile asks for keeping installation network configuration
     def keep_net_config?
-      ret = ay_networking_section["keep_install_network"]
+      ret = ay_networking_section.fetch("keep_install_network", false)
 
       log.info("NetworkAutoYast: keep installation network: #{ret}")
 

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -125,7 +125,7 @@ module Yast
     #
     # FIXME: it currently don't write DNS configuration. It is used for initialization
     # of DNS setup according AY profile in 1st stage as part of network setup was moved
-    # here already and some parts of network configuration needs to know it. DNS write 
+    # here already and some parts of network configuration needs to know it. DNS write
     # is still done in 2nd stage.
     def configure_dns
       ay_dns_config = ay_networking_section["dns"]
@@ -138,7 +138,7 @@ module Yast
       log.info("dhcp hostname: #{DNS.dhcp_hostname}")
       log.info("write hostname: #{DNS.write_hostname}")
 
-      return true
+      true
     end
 
     # Checks if the profile asks for keeping installation network configuration

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -134,6 +134,15 @@ module Yast
       log.info("write hostname: #{DNS.write_hostname}")
     end
 
+    # Checks if the profile asks for keeping installation network configuration
+    def keep_net_config?
+      ret = ay_networking_section["keep_install_network"]
+
+      log.info("NetworkAutoYast: keep installation network: #{ret}")
+
+      ret
+    end
+
     private
 
     # Merges two devices map into one.

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -143,7 +143,7 @@ module Yast
       ret
     end
 
-    private
+  private
 
     # Merges two devices map into one.
     #

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -122,16 +122,23 @@ module Yast
     end
 
     # Initializates DNS setup according AY profile
+    #
+    # FIXME: it currently don't write DNS configuration. It is used for initialization
+    # of DNS setup according AY profile in 1st stage as part of network setup was moved
+    # here already and some parts of network configuration needs to know it. DNS write 
+    # is still done in 2nd stage.
     def configure_dns
       ay_dns_config = ay_networking_section["dns"]
 
-      return if !ay_dns_config
+      return false if !ay_dns_config
 
       DNS.Import(ay_dns_config)
 
       log.info("NetworkAutoYast: DNS / Hostname configuration")
       log.info("dhcp hostname: #{DNS.dhcp_hostname}")
       log.info("write hostname: #{DNS.write_hostname}")
+
+      return true
     end
 
     # Checks if the profile asks for keeping installation network configuration

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -15,6 +15,7 @@ module Yast
     include Singleton
     include Logger
 
+    Yast.import "DNS"
     Yast.import "Lan"
     Yast.import "LanItems"
     Yast.import "Linuxrc"
@@ -118,6 +119,19 @@ module Yast
       end
 
       NetworkService.EnableDisableNow
+    end
+
+    # Initializates DNS setup according AY profile
+    def configure_dns
+      ay_dns_config = ay_networking_section["dns"]
+
+      return if !ay_dns_config
+
+      DNS.Import(ay_dns_config)
+
+      log.info("NetworkAutoYast: DNS / Hostname configuration")
+      log.info("dhcp hostname: #{DNS.dhcp_hostname}")
+      log.info("write hostname: #{DNS.write_hostname}")
     end
 
     private

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -123,10 +123,12 @@ module Yast
 
     # Initializates DNS setup according AY profile
     #
-    # FIXME: it currently don't write DNS configuration. It is used for initialization
+    # FIXME: it currently doesn't write DNS configuration. It is used for initialization
     # of DNS setup according AY profile in 1st stage as part of network setup was moved
     # here already and some parts of network configuration needs to know it. DNS write
     # is still done in 2nd stage.
+    #
+    # @return [Boolean] true when configuration was present and loaded from the profile
     def configure_dns
       ay_dns_config = ay_networking_section["dns"]
 

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -670,7 +670,7 @@ module Yast
       nil
     end
 
-    private
+  private
 
     def read_hostname_from_install_inf
       install_inf_hostname = SCR.Read(path(".etc.install_inf.Hostname")) || ""

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -1111,7 +1111,7 @@ module Yast
     publish function: :AutoPackages, type: "map ()"
     publish function: :HaveXenBridge, type: "boolean ()"
 
-    private
+  private
 
     def activate_network_service
       if LanItems.force_restart

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2500,7 +2500,7 @@ module Yast
         SCR.Execute(path(".target.bash_output"), command1),
         from: "any",
         to:   "map <string, any>"
-      )
+    )
       if Ops.get_integer(output1, "exit", -1) == 0 &&
           Builtins.size(Ops.get_string(output1, "stderr", "")) == 0
         Builtins.y2milestone("Success : %1", output1)
@@ -2543,7 +2543,7 @@ module Yast
       result
     end
 
-    private
+  private
 
     # This helper allows YARD to extract DSL-defined attributes.
     # Unfortunately YARD has problems with the Capitalized ones,
@@ -2575,7 +2575,7 @@ module Yast
       Host.set_names(ip, [])
     end
 
-    public
+  public
 
     # @attribute Items
     # @return [Hash<Integer, Hash<String, Object> >]

--- a/src/modules/Routing.rb
+++ b/src/modules/Routing.rb
@@ -481,7 +481,7 @@ module Yast
     publish function: :SetDevices, type: "boolean (list)"
     publish function: :Summary, type: "string ()"
 
-    private
+  private
 
     def ifroute_term(device)
       raise ArgumentError if device.nil? || device.empty?

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -210,4 +210,45 @@ describe "NetworkAutoYast" do
       end
     end
   end
+
+  describe "#configure_dns" do
+    let(:network_autoyast) { Yast::NetworkAutoYast.instance }
+
+    it "imports DNS configuration when available in profile" do
+      Yast.import "DNS"
+
+      allow(network_autoyast)
+        .to receive(:ay_networking_section)
+        .and_return("dns" => { "dhcp_hostname" => false })
+
+      expect(Yast::DNS).to receive(:Import)
+
+      network_autoyast.configure_dns
+    end
+  end
+
+  describe "#keep_net_config?" do
+    let(:network_autoyast) { Yast::NetworkAutoYast.instance }
+
+    def keep_install_network_value(value)
+      allow(network_autoyast)
+        .to receive(:ay_networking_section)
+        .and_return(value)
+    end
+
+    it "succeedes when keep_install_network is set in AY profile" do
+      keep_install_network_value("keep_install_network" => true)
+      expect(network_autoyast.keep_net_config?).to be true
+    end
+
+    it "fails when keep_install_network is not set in AY profile" do
+      keep_install_network_value("keep_install_network" => false)
+      expect(network_autoyast.keep_net_config?).to be false
+    end
+
+    it "fails when keep_install_network is not present in AY profile" do
+      keep_install_network_value({})
+      expect(network_autoyast.keep_net_config?).to be false
+    end
+  end
 end


### PR DESCRIPTION
[bsc#971175](https://bugzilla.suse.com/show_bug.cgi?id=971175), turning L3 patch into maintenance update

TODO: wait for maintenance request for SLE-12-SP1 confirmation