### PR TITLE
Support vncmanager2

### DIFF
--- a/src/include/network/remote/dialogs.rb
+++ b/src/include/network/remote/dialogs.rb
@@ -60,9 +60,17 @@ module Yast
           # RadioButton label
           Left(
             RadioButton(
-              Id(:allow),
-              _("&Allow Remote Administration"),
-              Remote.IsEnabled
+              Id(:allow_vncmanager),
+              _("&Allow Remote Administration With Session Management"),
+              Remote.Mode == :vncmanager
+            )
+          ),
+          # RadioButton label
+          Left(
+            RadioButton(
+              Id(:allow_xinetd),
+              _("&Allow Remote Administration Without Session Management"),
+              Remote.Mode == :xinetd
             )
           ),
           # RadioButton label
@@ -70,7 +78,7 @@ module Yast
             RadioButton(
               Id(:disallow),
               _("&Do Not Allow Remote Administration"),
-              Remote.IsDisabled
+              Remote.Mode == :disabled
             )
           )
         )
@@ -141,12 +149,15 @@ module Yast
       if ret == :next
         CWMFirewallInterfaces.OpenFirewallStore(firewall_widget, "", event)
 
-        allowed = Convert.to_boolean(UI.QueryWidget(Id(:allow), :Value))
+        allowed_xinetd = Convert.to_boolean(UI.QueryWidget(Id(:allow_xinetd), :Value))
+        allowed_vncmanager = Convert.to_boolean(UI.QueryWidget(Id(:allow_vncmanager), :Value))
 
-        if allowed
-          Remote.Enable
+        if allowed_xinetd
+          Remote.SetMode :xinetd
+        elsif allowed_vncmanager
+          Remote.SetMode :vncmanager
         else
-          Remote.Disable
+          Remote.SetMode :disabled
         end
       end
 

--- a/src/include/network/remote/dialogs.rb
+++ b/src/include/network/remote/dialogs.rb
@@ -91,8 +91,7 @@ module Yast
               "<p>If this feature is enabled, you can\n" \
               "administer this machine remotely from another machine. Use a VNC\n" \
               "client, such as krdc (connect to <tt>&lt;hostname&gt;:%1</tt>), or\n" \
-              "a Java-capable Web browser (connect to <tt>http://&lt;hostname&gt;:%2/</tt>).\n" \
-              "This form of remote administration is less secure than using SSH.</p>\n"
+              "a Java-capable Web browser (connect to <tt>https://&lt;hostname&gt;:%2/</tt>).\n"
           ),
           5901,
           5801

--- a/test/remote_test.rb
+++ b/test/remote_test.rb
@@ -11,6 +11,10 @@ module Yast
   import "Packages"
 
   describe Remote do
+    before do
+      allow(Packages).to receive(:vnc_packages).and_return %w(some names)
+    end
+
     describe ".Reset" do
       context "on vnc installation" do
         before do
@@ -35,6 +39,103 @@ module Yast
       end
     end
 
+    describe ".Read" do
+      before do
+        allow(Yast::SCR).to receive(:Read).with(
+          Yast::Path.new(".sysconfig.displaymanager.DISPLAYMANAGER_REMOTE_ACCESS")
+        ).and_return("yes")
+
+        allow(Yast::SCR).to receive(:Read).with(
+          Yast::Path.new(".sysconfig.displaymanager.DISPLAYMANAGER")
+        ).and_return("xdm")
+
+        allow(SuSEFirewall).to receive(:Read).and_return true
+      end
+
+      context "vncmanager mode is on" do
+        before do
+          allow(Service).to receive(:Enabled).with("display-manager").and_return true
+          allow(Service).to receive(:Enabled).with("xinetd").and_return true
+          allow(Service).to receive(:Enabled).with("vncmanager").and_return true
+
+          allow(Yast::SCR).to receive(:Read).with(
+            Yast::Path.new(".etc.xinetd_conf.services")
+          ).and_return([
+            {"service" => "vnc1", "enabled" => false},
+            {"service" => "vnchttpd1", "enabled" => true}
+          ])
+        end
+
+        it "recognizes vncmanager mode" do
+          Remote.Read
+          expect(Remote.Mode).to eql(:vncmanager)
+        end
+      end
+
+      context "xinetd mode is on" do
+        before do
+          allow(Service).to receive(:Enabled).with("display-manager").and_return true
+          allow(Service).to receive(:Enabled).with("xinetd").and_return true
+          allow(Service).to receive(:Enabled).with("vncmanager").and_return false
+
+          allow(Yast::SCR).to receive(:Read).with(
+            Yast::Path.new(".etc.xinetd_conf.services")
+          ).and_return([
+            {"service" => "vnc1", "enabled" => true},
+            {"service" => "vnchttpd1", "enabled" => true}
+          ])
+        end
+
+        it "recognizes xinetd mode" do
+          Remote.Read
+          expect(Remote.Mode).to eql(:xinetd)
+        end
+      end
+
+      context "xinetd service is off" do
+        before do
+          allow(Service).to receive(:Enabled).with("display-manager").and_return true
+          allow(Service).to receive(:Enabled).with("xinetd").and_return false
+          allow(Service).to receive(:Enabled).with("vncmanager").and_return false
+
+          allow(Yast::SCR).to receive(:Read).with(
+            Yast::Path.new(".etc.xinetd_conf.services")
+          ).and_return([
+            {"service" => "vnc1", "enabled" => true},
+            {"service" => "vnchttpd1", "enabled" => true}
+          ])
+        end
+
+        it "recognizes disabled mode" do
+          Remote.Read
+          expect(Remote.Mode).to eql(:disabled)
+        end
+      end
+    end
+
+    describe ".enable_disable_remote_administration" do
+      context "with VNC enabled" do
+        before do
+          Remote.Enable
+        end
+
+        it "sets mode to xinetd" do
+          expect(Remote.Mode).to eql(:xinetd)
+        end
+      end
+
+      context "with VNC disabled" do
+        before do
+          Remote.Disable
+        end
+
+        it "sets mode to disabled" do
+          expect(Remote.Mode).to eql(:disabled)
+        end
+      end
+
+    end
+
     describe ".configure_display_manager" do
       before do
         stub_scr_write
@@ -42,31 +143,31 @@ module Yast
         allow(Package).to receive(:Installed).with("xinetd").and_return true
       end
 
-      context "with VNC enabled" do
+      context "with VNC in xinetd mode" do
         before do
-          Remote.Enable
+          Remote.SetMode(:xinetd)
         end
 
         it "installs packages provided by Packages.vnc_packages" do
           allow(Service).to receive(:Enable).and_return true
+          allow(Service).to receive(:Disable).and_return true
 
-          expect(Packages).to receive(:vnc_packages).and_return %w(some names)
           expect(Package).to receive(:InstallAll).with(%w(some names)).and_return true
           expect(Remote.configure_display_manager).to eql(true)
         end
 
         it "enables the services" do
-          allow(Packages).to receive(:vnc_packages)
           allow(Package).to receive(:InstallAll).and_return true
 
           expect(Service).to receive(:Enable).with("display-manager").and_return true
           expect(Service).to receive(:Enable).with("xinetd").and_return true
+          expect(Service).to receive(:Disable).with("vncmanager").and_return true
           expect(Remote.configure_display_manager).to eql(true)
         end
 
         it "writes the VNC configuration" do
-          allow(Packages).to receive(:vnc_packages)
           allow(Service).to receive(:Enable).twice.and_return true
+          allow(Service).to receive(:Disable).once.and_return true
           allow(Package).to receive(:InstallAll).and_return true
 
           expect(Remote.configure_display_manager).to eql(true)
@@ -74,16 +175,53 @@ module Yast
           expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_REMOTE_ACCESS")).to eq("yes")
           expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_ROOT_LOGIN_REMOTE")).to eq("yes")
 
-          # vnc1 and vnchttp1 services are enabled
+          # vnc1 and vnchttpd1 services are enabled
           services = written_value_for(".etc.xinetd_conf.services")
-          services = services.select { |s| s["service"] =~ /vnc/ }
-          expect(services.map { |s| s["enabled"] }).to eq([true, true])
+          services = services.select { |s| s["service"] =~ /vnc/ }.map { |s| [ s["service"], s["enabled"] ] }.to_h
+          expect(services).to eq({ "vnc1" => true, "vnchttpd1" => true })
+        end
+      end
+
+      context "with VNC in vncmanager mode" do
+        before do
+          Remote.SetMode(:vncmanager)
+        end
+
+        it "installs packages provided by Packages.vnc_packages" do
+          allow(Service).to receive(:Enable).and_return true
+
+          expect(Package).to receive(:InstallAll).with(%w(some names vncmanager)).and_return true
+          expect(Remote.configure_display_manager).to eql(true)
+        end
+
+        it "enables the services" do
+          allow(Package).to receive(:InstallAll).and_return true
+
+          expect(Service).to receive(:Enable).with("display-manager").and_return true
+          expect(Service).to receive(:Enable).with("xinetd").and_return true
+          expect(Service).to receive(:Enable).with("vncmanager").and_return true
+          expect(Remote.configure_display_manager).to eql(true)
+        end
+
+        it "writes the VNC configuration" do
+          allow(Service).to receive(:Enable).exactly(3).times.and_return true
+          allow(Package).to receive(:InstallAll).and_return true
+
+          expect(Remote.configure_display_manager).to eql(true)
+
+          expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_REMOTE_ACCESS")).to eq("yes")
+          expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_ROOT_LOGIN_REMOTE")).to eq("yes")
+
+          # vnchttpd1 service is enabled but vnc1 is disabled
+          services = written_value_for(".etc.xinetd_conf.services")
+          services = services.select { |s| s["service"] =~ /vnc/ }.map { |s| [ s["service"], s["enabled"] ] }.to_h
+          expect(services).to eq({ "vnc1" => false, "vnchttpd1" => true })
         end
       end
 
       context "with VNC disabled" do
         before do
-          Remote.Disable
+          Remote.SetMode(:disabled)
         end
 
         it "does not install packages" do
@@ -102,10 +240,10 @@ module Yast
           expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_REMOTE_ACCESS")).to eq("no")
           expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_ROOT_LOGIN_REMOTE")).to eq("no")
 
-          # vnc1 and vnchttp1 services are enabled
+          # vnc1 and vnchttpd1 services are disabled
           services = written_value_for(".etc.xinetd_conf.services")
-          services = services.select { |s| s["service"] =~ /vnc/ }
-          expect(services.map { |s| s["enabled"] }).to eq([false, false])
+          services = services.select { |s| s["service"] =~ /vnc/ }.map { |s| [ s["service"], s["enabled"] ] }.to_h
+          expect(services).to eq({ "vnc1" => false, "vnchttpd1" => false })
         end
       end
     end
@@ -154,13 +292,23 @@ module Yast
             expect(Service).to receive(:Reload).with("xinetd").and_return(true)
             Remote.restart_services
           end
+
+          it "disables vncmanager" do
+            expect(Service).to receive(:Stop).with("vncmanager").and_return(true)
+            Remote.restart_services
+          end
         end
 
         context "xinetd is inactive" do
           let(:active_xinetd) { false }
 
-          it "does nothing with services" do
+          it "does nothing with xinetd service" do
             expect(Service).not_to receive(:Reload)
+            Remote.restart_services
+          end
+
+          it "disables vncmanager" do
+            expect(Service).to receive(:Stop).with("vncmanager").and_return(true)
             Remote.restart_services
           end
         end


### PR DESCRIPTION
Add support for vncmanager mode to Remote. fate#319319

Remote module can now set up 3 VNC modes: disabled, xinetd, vncmanager
* disabled
  * vncmanager systemd service is disabled
  * vnc1 and vnchttpd1 xinetd services are disabled
* xinetd
  * vncmanager systemd service is disabled
  * xinetd systemd service is enabled
  * vnc1 and vnchttpd1 xinetd services are enabled
* vncmanager
  * vncmanager systemd service is enabled
  * xinetd systemd service is enabled
  * vnchttpd1 xinetd service is enabled but vnc1 is not

Calls to Remote.Enable and Remote.Disable set xinetd and disabled modes, so
users of the old API can keep using it.
