### PR TITLE
Support vncmanager 3

### DIFF
--- a/src/include/network/remote/dialogs.rb
+++ b/src/include/network/remote/dialogs.rb
@@ -60,9 +60,17 @@ module Yast
           # RadioButton label
           Left(
             RadioButton(
-              Id(:allow),
-              _("&Allow Remote Administration"),
-              Remote.IsEnabled
+              Id(:allow_with_vncmanager),
+              _("&Allow Remote Administration With Session Management"),
+              Remote.IsEnabled && Remote.UsesVncManager
+            )
+          ),
+          # RadioButton label
+          Left(
+            RadioButton(
+              Id(:allow_without_vncmanager),
+              _("&Allow Remote Administration Without Session Management"),
+              Remote.IsEnabled && !Remote.UsesVncManager
             )
           ),
           # RadioButton label
@@ -142,9 +150,12 @@ module Yast
       if ret == :next
         CWMFirewallInterfaces.OpenFirewallStore(firewall_widget, "", event)
 
-        allowed = Convert.to_boolean(UI.QueryWidget(Id(:allow), :Value))
+        allow_with_vncmanager = UI.QueryWidget(Id(:allow_with_vncmanager), :Value)
+        allow_without_vncmanager = UI.QueryWidget(Id(:allow_without_vncmanager), :Value)
 
-        if allowed
+        if allow_with_vncmanager
+          Remote.EnableUsingVncManager
+        elsif allow_without_vncmanager
           Remote.Enable
         else
           Remote.Disable

--- a/src/modules/Remote.rb
+++ b/src/modules/Remote.rb
@@ -153,19 +153,15 @@ module Yast
         to:   "list <map>"
       )
 
-      xinetd_vnc1_enabled = false
-      xinetd_vnchttp1_enabled = false
-      xinetd_conf.each do |m|
-        xinetd_vnc1_enabled = m["enabled"] if m["service"] == "vnc1"
-        xinetd_vnchttp1_enabled = m["enabled"] if m["service"] == "vnchttpd1"
-      end
+      xinetd_vnc1 = xinetd_conf.find { |m| m["service"] == "vnc1" }
+      xinetd_vnc1_enabled = xinetd_vnc1 ? xinetd_vnc1["enabled"] : false
 
       log.info "#{XDM_SERVICE_NAME}: #{xdm}, DM_R_A: #{dm_ra}"
-      log.info "xinetd: #{xinetd}, VNC1: #{xinetd_vnc1_enabled}, VNCHTTP1: #{xinetd_vnchttp1_enabled}"
+      log.info "xinetd: #{xinetd}, VNC1: #{xinetd_vnc1_enabled}"
 
       vncmanager = Service.Enabled(VNCMANAGER_SERVICE)
 
-      if xdm && dm_ra && xinetd && xinetd_vnchttp1_enabled
+      if xdm && dm_ra && xinetd
         if xinetd_vnc1_enabled && !vncmanager
           Enable()
         elsif !xinetd_vnc1_enabled && vncmanager

--- a/src/modules/Remote.rb
+++ b/src/modules/Remote.rb
@@ -36,8 +36,10 @@ module Yast
 
     XDM_SERVICE_NAME = "display-manager"
     XINETD_SERVICE = "xinetd"
+    VNCMANAGER_SERVICE = "vncmanager"
 
     PKG_CONTAINING_FW_SERVICES = "xorg-x11-Xvnc"
+    PKG_CONTAINING_VNCMANAGER = "vncmanager"
 
     GRAPHICAL_TARGET = "graphical"
 
@@ -59,8 +61,8 @@ module Yast
       # Currently, all attributes (enablement of remote access)
       # are applied on vnc1 even vnchttpd1 configuration
 
-      # Allow remote administration
-      @allow_administration = false
+      # Remote administration mode, :disabled, :xinetd or :vncmanager
+      @mode = :disabled
 
       # Default display manager
       @default_dm = "xdm"
@@ -72,26 +74,37 @@ module Yast
 
     # Checks if remote administration is currently allowed
     def IsEnabled
-      @allow_administration
+      !IsDisabled()
     end
 
     # Checks if remote administration is currently disallowed
     def IsDisabled
-      !IsEnabled()
+      @mode == :disabled
     end
 
-    # Enables remote administration.
+    # Enables remote administration without vnc manager.
     def Enable
-      @allow_administration = true
+      @mode = :xinetd
+
+      nil
+    end
+
+    # Enables remote administration with vnc manager.
+    def EnableUsingVncManager
+      @mode = :vncmanager
 
       nil
     end
 
     # Disables remote administration.
     def Disable
-      @allow_administration = false
+      @mode = :disabled
 
       nil
+    end
+
+    def UsesVncManager
+      @mode == :vncmanager
     end
 
     # Reset all module data.
@@ -99,11 +112,15 @@ module Yast
       @already_proposed = true
 
       # Bugzilla #135605 - enabling Remote Administration when installing using VNC
-      @allow_administration = Linuxrc.vnc
+      if Linuxrc.vnc
+        Enable()
+      else
+        Disable()
+      end
 
       Builtins.y2milestone(
         "Remote Administration was proposed as: %1",
-        @allow_administration ? "enabled" : "disabled"
+        IsEnabled() ? "enabled" : "disabled"
       )
 
       nil
@@ -135,18 +152,30 @@ module Yast
         from: "any",
         to:   "list <map>"
       )
-      vnc_conf = Builtins.filter(xinetd_conf) do |m|
-        s = Ops.get_string(m, "service", "")
-        s == "vnc1" || s == "vnchttpd1"
+
+      xinetd_vnc1_enabled = false
+      xinetd_vnchttp1_enabled = false
+      xinetd_conf.each do |m|
+        xinetd_vnc1_enabled = m["enabled"] if m["service"] == "vnc1"
+        xinetd_vnchttp1_enabled = m["enabled"] if m["service"] == "vnchttpd1"
       end
-      vnc = Builtins.size(vnc_conf) == 2 &&
-        Ops.get_boolean(vnc_conf, [0, "enabled"], false) &&
-        Ops.get_boolean(vnc_conf, [1, "enabled"], false)
 
       log.info "#{XDM_SERVICE_NAME}: #{xdm}, DM_R_A: #{dm_ra}"
-      log.info "xinetd: #{xinetd}, VNC: #{vnc}"
+      log.info "xinetd: #{xinetd}, VNC1: #{xinetd_vnc1_enabled}, VNCHTTP1: #{xinetd_vnchttp1_enabled}"
 
-      @allow_administration = xdm && dm_ra && xinetd && vnc
+      vncmanager = Service.Enabled(VNCMANAGER_SERVICE)
+
+      if xdm && dm_ra && xinetd && xinetd_vnchttp1_enabled
+        if xinetd_vnc1_enabled && !vncmanager
+          Enable()
+        elsif !xinetd_vnc1_enabled && vncmanager
+          EnableUsingVncManager()
+        else
+          Disable()
+        end
+      else
+        Disable()
+      end
 
       # Package containing SuSEfirewall2 services has to be installed before
       # reading SuSEFirewall, otherwise exception is thrown by firewall
@@ -175,12 +204,17 @@ module Yast
         to:   "list <map>"
       )
 
-      xinetd = Builtins.maplist(xinetd) do |m|
-        s = Ops.get_string(m, "service", "")
-        next deep_copy(m) if !(s == "vnc1" || s == "vnchttpd1")
-        Ops.set(m, "changed", true)
-        Ops.set(m, "enabled", @allow_administration)
-        log.info "Updated xinet cfg: #{m}"
+      xinetd = xinetd.map do |m|
+        case m["service"]
+        when "vnc1"
+          m["enabled"] = IsEnabled() && !UsesVncManager()
+          m["changed"] = true
+        when "vnchttpd1"
+          m["enabled"] = IsEnabled()
+          m["changed"] = true
+        end
+
+        log.info "Updated xinet cfg: #{m}" if m["changed"]
         deep_copy(m)
       end
 
@@ -235,25 +269,36 @@ module Yast
     def configure_display_manager
       if IsEnabled()
         # Install required packages
-        if !Package.InstallAll(Packages.vnc_packages)
+        packages = Packages.vnc_packages
+        packages << PKG_CONTAINING_VNCMANAGER if UsesVncManager()
+
+        if !Package.InstallAll(packages)
           log.error "Installing of required packages failed"
           return false
         end
 
-        # Enable xinetd
-        if !Service.Enable(XINETD_SERVICE)
-          Report.Error(
-            _("Enabling service %{service} has failed") % { service: XINETD_SERVICE }
-          )
-          return false
-        end
+        services = [
+          [XINETD_SERVICE, true],
+          [XDM_SERVICE_NAME, true],
+          [VNCMANAGER_SERVICE, UsesVncManager()]
+        ]
 
-        # Enable XDM
-        if !Service.Enable(XDM_SERVICE_NAME)
-          Report.Error(
-            _("Enabling service %{service} has failed") % { service: XDM_SERVICE_NAME }
-          )
-          return false
+        services.each do |service, enable|
+          if enable
+            if !Service.Enable(service)
+              Report.Error(
+                _("Enabling service %{service} has failed") % { service: service }
+              )
+              return false
+            end
+          else
+            if !Service.Disable(service)
+              Report.Error(
+                _("Disabling service %{service} has failed") % { service: service }
+              )
+              return false
+            end
+          end
         end
       end
 
@@ -296,12 +341,18 @@ module Yast
 
         Report.Error(Message.CannotRestartService(XINETD_SERVICE)) unless Service.Restart(XINETD_SERVICE)
 
+        if UsesVncManager()
+          Report.Error(Message.CannotRestartService(VNCMANAGER_SERVICE)) unless Service.Restart(VNCMANAGER_SERVICE)
+        end
+
         restart_display_manager
       else
         # xinetd may be needed for other services so we never turn it
         # off. It will exit anyway if no services are configured.
         # If it is running, restart it.
         Service.Reload(XINETD_SERVICE) if Service.active?(XINETD_SERVICE)
+
+        Service.Stop(VNCMANAGER_SERVICE)
       end
     end
 

--- a/test/remote_test.rb
+++ b/test/remote_test.rb
@@ -11,6 +11,10 @@ module Yast
   import "Packages"
 
   describe Remote do
+    before do
+      allow(Packages).to receive(:vnc_packages).and_return %w(some names)
+    end
+
     describe ".Reset" do
       context "on vnc installation" do
         before do
@@ -35,6 +39,114 @@ module Yast
       end
     end
 
+    describe ".Read" do
+      before do
+        allow(Yast::SCR).to receive(:Read).with(
+          Yast::Path.new(".sysconfig.displaymanager.DISPLAYMANAGER_REMOTE_ACCESS")
+        ).and_return("yes")
+
+        allow(Yast::SCR).to receive(:Read).with(
+          Yast::Path.new(".sysconfig.displaymanager.DISPLAYMANAGER")
+        ).and_return("xdm")
+
+        allow(SuSEFirewall).to receive(:Read).and_return true
+      end
+
+      context "vncmanager mode is on" do
+        before do
+          allow(Service).to receive(:Enabled).with("display-manager").and_return true
+          allow(Service).to receive(:Enabled).with("xinetd").and_return true
+          allow(Service).to receive(:Enabled).with("vncmanager").and_return true
+
+          allow(Yast::SCR).to receive(:Read).with(
+            Yast::Path.new(".etc.xinetd_conf.services")
+          ).and_return(
+            [{ "service" => "vnc1", "enabled" => false }, { "service" => "vnchttpd1", "enabled" => true }]
+          )
+        end
+
+        it "recognizes vncmanager mode" do
+          Remote.Read
+          expect(Remote.IsEnabled).to eql(true)
+          expect(Remote.UsesVncManager).to eql(true)
+        end
+      end
+
+      context "xinetd mode is on" do
+        before do
+          allow(Service).to receive(:Enabled).with("display-manager").and_return true
+          allow(Service).to receive(:Enabled).with("xinetd").and_return true
+          allow(Service).to receive(:Enabled).with("vncmanager").and_return false
+
+          allow(Yast::SCR).to receive(:Read).with(
+            Yast::Path.new(".etc.xinetd_conf.services")
+          ).and_return(
+            [{ "service" => "vnc1", "enabled" => true }, { "service" => "vnchttpd1", "enabled" => true }]
+          )
+        end
+
+        it "recognizes xinetd mode" do
+          Remote.Read
+          expect(Remote.IsEnabled).to eql(true)
+          expect(Remote.UsesVncManager).to eql(false)
+        end
+      end
+
+      context "xinetd service is off" do
+        before do
+          allow(Service).to receive(:Enabled).with("display-manager").and_return true
+          allow(Service).to receive(:Enabled).with("xinetd").and_return false
+          allow(Service).to receive(:Enabled).with("vncmanager").and_return false
+
+          allow(Yast::SCR).to receive(:Read).with(
+            Yast::Path.new(".etc.xinetd_conf.services")
+          ).and_return(
+            [{ "service" => "vnc1", "enabled" => true }, { "service" => "vnchttpd1", "enabled" => true }]
+          )
+        end
+
+        it "recognizes disabled mode" do
+          Remote.Read
+          expect(Remote.IsEnabled).to eql(false)
+        end
+      end
+    end
+
+    describe ".enable_disable_remote_administration" do
+      context "with VNC enabled and with session management" do
+        before do
+          Remote.EnableUsingVncManager
+        end
+
+        it "enables vnc without session management" do
+          expect(Remote.IsEnabled).to eql(true)
+          expect(Remote.UsesVncManager).to eql(true)
+        end
+      end
+
+      context "with VNC enabled and without session management" do
+        before do
+          Remote.Enable
+        end
+
+        it "enables vnc without session management" do
+          expect(Remote.IsEnabled).to eql(true)
+          expect(Remote.UsesVncManager).to eql(false)
+        end
+      end
+
+      context "with VNC disabled" do
+        before do
+          Remote.Disable
+        end
+
+        it "disables vnc" do
+          expect(Remote.IsEnabled).to eql(false)
+        end
+      end
+
+    end
+
     describe ".configure_display_manager" do
       before do
         stub_scr_write
@@ -42,31 +154,31 @@ module Yast
         allow(Package).to receive(:Installed).with("xinetd").and_return true
       end
 
-      context "with VNC enabled" do
+      context "with VNC enabled without session management" do
         before do
           Remote.Enable
         end
 
         it "installs packages provided by Packages.vnc_packages" do
           allow(Service).to receive(:Enable).and_return true
+          allow(Service).to receive(:Disable).and_return true
 
-          expect(Packages).to receive(:vnc_packages).and_return %w(some names)
           expect(Package).to receive(:InstallAll).with(%w(some names)).and_return true
           expect(Remote.configure_display_manager).to eql(true)
         end
 
         it "enables the services" do
-          allow(Packages).to receive(:vnc_packages)
           allow(Package).to receive(:InstallAll).and_return true
 
           expect(Service).to receive(:Enable).with("display-manager").and_return true
           expect(Service).to receive(:Enable).with("xinetd").and_return true
+          expect(Service).to receive(:Disable).with("vncmanager").and_return true
           expect(Remote.configure_display_manager).to eql(true)
         end
 
         it "writes the VNC configuration" do
-          allow(Packages).to receive(:vnc_packages)
           allow(Service).to receive(:Enable).twice.and_return true
+          allow(Service).to receive(:Disable).once.and_return true
           allow(Package).to receive(:InstallAll).and_return true
 
           expect(Remote.configure_display_manager).to eql(true)
@@ -74,10 +186,47 @@ module Yast
           expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_REMOTE_ACCESS")).to eq("yes")
           expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_ROOT_LOGIN_REMOTE")).to eq("yes")
 
-          # vnc1 and vnchttp1 services are enabled
+          # vnc1 and vnchttpd1 services are enabled
           services = written_value_for(".etc.xinetd_conf.services")
-          services = services.select { |s| s["service"] =~ /vnc/ }
-          expect(services.map { |s| s["enabled"] }).to eq([true, true])
+          services = services.select { |s| s["service"] =~ /vnc/ }.map { |s| [s["service"], s["enabled"]] }.to_h
+          expect(services).to eq("vnc1" => true, "vnchttpd1" => true)
+        end
+      end
+
+      context "with VNC enabled with session management" do
+        before do
+          Remote.EnableUsingVncManager
+        end
+
+        it "installs packages provided by Packages.vnc_packages" do
+          allow(Service).to receive(:Enable).and_return true
+
+          expect(Package).to receive(:InstallAll).with(%w(some names vncmanager)).and_return true
+          expect(Remote.configure_display_manager).to eql(true)
+        end
+
+        it "enables the services" do
+          allow(Package).to receive(:InstallAll).and_return true
+
+          expect(Service).to receive(:Enable).with("display-manager").and_return true
+          expect(Service).to receive(:Enable).with("xinetd").and_return true
+          expect(Service).to receive(:Enable).with("vncmanager").and_return true
+          expect(Remote.configure_display_manager).to eql(true)
+        end
+
+        it "writes the VNC configuration" do
+          allow(Service).to receive(:Enable).exactly(3).times.and_return true
+          allow(Package).to receive(:InstallAll).and_return true
+
+          expect(Remote.configure_display_manager).to eql(true)
+
+          expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_REMOTE_ACCESS")).to eq("yes")
+          expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_ROOT_LOGIN_REMOTE")).to eq("yes")
+
+          # vnchttpd1 service is enabled but vnc1 is disabled
+          services = written_value_for(".etc.xinetd_conf.services")
+          services = services.select { |s| s["service"] =~ /vnc/ }.map { |s| [s["service"], s["enabled"]] }.to_h
+          expect(services).to eq("vnc1" => false, "vnchttpd1" => true)
         end
       end
 
@@ -102,10 +251,10 @@ module Yast
           expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_REMOTE_ACCESS")).to eq("no")
           expect(written_value_for(".sysconfig.displaymanager.DISPLAYMANAGER_ROOT_LOGIN_REMOTE")).to eq("no")
 
-          # vnc1 and vnchttp1 services are enabled
+          # vnc1 and vnchttpd1 services are disabled
           services = written_value_for(".etc.xinetd_conf.services")
-          services = services.select { |s| s["service"] =~ /vnc/ }
-          expect(services.map { |s| s["enabled"] }).to eq([false, false])
+          services = services.select { |s| s["service"] =~ /vnc/ }.map { |s| [s["service"], s["enabled"]] }.to_h
+          expect(services).to eq("vnc1" => false, "vnchttpd1" => false)
         end
       end
     end
@@ -113,7 +262,7 @@ module Yast
     describe "#restart_services" do
       context "when remote administration is being enabled" do
         before(:each) do
-          Remote.Enable()
+          Remote.Enable
           allow(Service).to receive(:active?).with("display-manager").and_return(active_display_manager)
         end
 
@@ -154,13 +303,23 @@ module Yast
             expect(Service).to receive(:Reload).with("xinetd").and_return(true)
             Remote.restart_services
           end
+
+          it "disables vncmanager" do
+            expect(Service).to receive(:Stop).with("vncmanager").and_return(true)
+            Remote.restart_services
+          end
         end
 
         context "xinetd is inactive" do
           let(:active_xinetd) { false }
 
-          it "does nothing with services" do
+          it "does nothing with xinetd service" do
             expect(Service).not_to receive(:Reload)
+            Remote.restart_services
+          end
+
+          it "disables vncmanager" do
+            expect(Service).to receive(:Stop).with("vncmanager").and_return(true)
             Remote.restart_services
           end
         end


### PR DESCRIPTION
Add support for vncmanager mode to Remote. fate#319319

Remote module can now set up 3 VNC modes: disabled, xinetd, vncmanager
* disabled
  * vncmanager systemd service is disabled
  * vnc1 and vnchttpd1 xinetd services are disabled
* xinetd
  * vncmanager systemd service is disabled
  * xinetd systemd service is enabled
  * vnc1 and vnchttpd1 xinetd services are enabled
* vncmanager
  * vncmanager systemd service is enabled
  * xinetd systemd service is enabled
  * vnchttpd1 xinetd service is enabled but vnc1 is not

Calls to Remote.Enable and Remote.Disable set xinetd and disabled modes, so
users of the old API can keep using it.