### PR TITLE
Smart bonding with npar and sriov interfaces (fate#315995)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,17 @@
 -------------------------------------------------------------------
+Fri May 13 10:19:39 UTC 2016 - knut.anderssen@suse.com
+
+- fate#315995
+  - Added physical port id to device overview and bond slaves item
+    description if supported.
+  - Warn the user when two or more bonded interfaces share the
+    same physical port.
+  - Available interfaces for bonding in bond slaves tab are now
+    sorted and moving them up or down maintain the interface
+    selected.
+- 3.1.150
+
+-------------------------------------------------------------------
 Mon May  2 11:35:45 UTC 2016 - mfilka@suse.com
 
 - bnc#977953

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.149
+Version:        3.1.150
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -755,8 +755,8 @@ module Yast
 
       Popup.YesNoHeadline(
         Label.WarningMsg,
-        _("The interfaces selected for bonding map to same physical port and " \
-          "bonding them \nmay not have the desire result.\n\n%s\n" \
+        _("The interfaces selected share the same physical port and bonding " \
+          "them \nmay not have the desired effect of redundancy.\n\n%s\n" \
           "Really continue?\n") % message
       )
     end

--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -255,7 +255,7 @@ module Yast
             "boolean (string, map)"
           ),
           "store"             => fun_ref(method(:StoreSlave), "void (string, map)"),
-          "help"              => Ops.get_string(@help, "bondslave", "")
+          "help"              => @help["bondslave"].to_s
         },
         "BONDOPTION"   => {
           "widget" => :combobox,

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -746,15 +746,23 @@ module Yast
       ).to_i != 0
     end
 
-    def has_physical_port_id?(dev_name)
-      !physical_port_id(dev_name).empty?
-    end
-
+    # With NPAR and SR-IOV capabilities, one device could divide a ethernet
+    # port in various. If the driver module support it, we can check the phys
+    # port id via sysfs reading the /sys/class/net/$dev_name/phys_port_id
+    #
+    # @param [String] device name to check
+    # @return [String] physical port id if supported or a empty string if not
     def physical_port_id(dev_name)
       SCR.Read(
         path(".target.string"),
         "/sys/class/net/#{dev_name}/phys_port_id"
       ).to_s.strip
+    end
+
+    # @return [boolean] true if the physical port id is not empty
+    # @see #physical_port_id
+    def physical_port_id?(dev_name)
+      !physical_port_id(dev_name).empty?
     end
 
     # Checks if device is physically connected to a network

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -746,6 +746,17 @@ module Yast
       ).to_i != 0
     end
 
+    def has_physical_port_id?(dev_name)
+      !physical_port_id(dev_name).empty?
+    end
+
+    def physical_port_id(dev_name)
+      SCR.Read(
+        path(".target.string"),
+        "/sys/class/net/#{dev_name}/phys_port_id"
+      ).to_s.strip
+    end
+
     # Checks if device is physically connected to a network
     #
     # It does neccessary steps which might be needed for proper initialization

--- a/src/include/network/widgets.rb
+++ b/src/include/network/widgets.rb
@@ -574,6 +574,8 @@ module Yast
         selected = false
         selected = enslavedIfaces.include?(dev_name) if enslavedIfaces
 
+        description << " (Port ID: #{physical_port_id(dev_name)})" if has_physical_port_id?(dev_name)
+
         items << Item(
           Id(dev_name),
           "#{dev_name} - #{description}",

--- a/src/include/network/widgets.rb
+++ b/src/include/network/widgets.rb
@@ -574,7 +574,7 @@ module Yast
         selected = false
         selected = enslavedIfaces.include?(dev_name) if enslavedIfaces
 
-        description << " (Port ID: #{physical_port_id(dev_name)})" if has_physical_port_id?(dev_name)
+        description << " (Port ID: #{physical_port_id(dev_name)})" if physical_port_id?(dev_name)
 
         items << Item(
           Id(dev_name),

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -813,7 +813,7 @@ module Yast
 
       result = []
 
-      @Items.each do |itemId, _attribs|
+      LanItems.Items.each do |itemId, _attribs|
         if @current != itemId && validator.call(master, itemId)
           result = Builtins.add(result, itemId)
         else
@@ -1407,11 +1407,11 @@ module Yast
 
         mac_dev = HTML.Bold("MAC : ") + item_hwinfo["mac"].to_s + "<br>"
         bus_id  = HTML.Bold("BusID : ") + item_hwinfo["busid"].to_s + "<br>"
-        physical_port_id = HTML.Bold("PhysicalPortID : ") + physical_port_id(ifcfg_name).to_s + "<br>"
+        physical_port_id = HTML.Bold("PhysicalPortID : ") + physical_port_id(ifcfg_name) + "<br>"
 
         rich << " " << conn << "<br>" << mac_dev if IsNotEmpty(item_hwinfo["mac"])
         rich << bus_id if IsNotEmpty(item_hwinfo["busid"])
-        rich << physical_port_id if has_physical_port_id?(ifcfg_name)
+        rich << physical_port_id if physical_port_id?(ifcfg_name)
         # display it only if we need it, don't duplicate "ifcfg_name" above
         if IsNotEmpty(item_hwinfo["dev_name"]) && ifcfg_name.empty?
           dev_name = _("Device Name: %s") %  item_hwinfo["dev_name"]

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -813,7 +813,7 @@ module Yast
 
       result = []
 
-      Builtins.foreach(@Items) do |itemId, _attribs|
+      @Items.each do |itemId, _attribs|
         if @current != itemId && validator.call(master, itemId)
           result = Builtins.add(result, itemId)
         else
@@ -1407,9 +1407,11 @@ module Yast
 
         mac_dev = HTML.Bold("MAC : ") + item_hwinfo["mac"].to_s + "<br>"
         bus_id  = HTML.Bold("BusID : ") + item_hwinfo["busid"].to_s + "<br>"
+        physical_port_id = HTML.Bold("PhysicalPortID : ") + physical_port_id(ifcfg_name).to_s + "<br>"
 
         rich << " " << conn << "<br>" << mac_dev if IsNotEmpty(item_hwinfo["mac"])
         rich << bus_id if IsNotEmpty(item_hwinfo["busid"])
+        rich << physical_port_id if has_physical_port_id?(ifcfg_name)
         # display it only if we need it, don't duplicate "ifcfg_name" above
         if IsNotEmpty(item_hwinfo["dev_name"]) && ifcfg_name.empty?
           dev_name = _("Device Name: %s") %  item_hwinfo["dev_name"]

--- a/test/address_test.rb
+++ b/test/address_test.rb
@@ -1,0 +1,144 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+require "yast"
+
+Yast.import "UI"
+
+class DummyClass < Yast::Module
+  def initialize
+    Yast.include self, "network/lan/address.rb"
+  end
+end
+
+describe "NetworkLanAddressInclude" do
+  subject { DummyClass.new }
+
+  describe "#justify_dev_name" do
+
+    it "returns given device name justified by 0's at right" do
+      expect(subject.justify_dev_name("em5p1")).to eq("em00005p00001")
+    end
+
+  end
+
+  describe "devices_to_s" do
+    subject(:routines) { DummyClass.new }
+    let(:devices) do
+      [ "eth0", "eth1", "eth2", "eth3", "a_very_long_device_name" ]
+    end
+    let(:more_devices) do
+      [
+        "enp5s0", "enp5s1", "enp5s2", "enp5s3",
+        "enp5s4", "enp5s5", "enp5s6", "enp5s7"
+      ]
+    end
+
+    context "given a list of devices" do
+      it "returns given devices joined by a space" do
+        text = "eth0 eth1 eth2 eth3 a_very_long_device_name"
+
+        expect(routines.devices_to_s(devices)).to eql(text)
+      end
+
+      context "given a line size" do
+        it "returns given devices wrapped by line size" do
+          text = "eth0 eth1 eth2\n"         \
+                 "eth3\n"                   \
+                 "a_very_long_device_name"
+
+          expect(routines.devices_to_s(devices, 15)).to eql(text)
+        end
+      end
+
+      context "given a number of lines and '...' as cut text" do
+        it "returns wrapped text until given line adding '...' as a new line" do
+          text = "eth0 eth1 eth2\n"         \
+                 "eth3\n"                   \
+                 "a_very_long_device_name\n"  \
+                 "..."
+
+          expect(routines.devices_to_s(devices+more_devices, 15,3,"...")).to eql(text)
+        end
+      end
+
+    end
+  end
+
+  describe "#getISlaveIndex" do
+    let(:msbox_items) do
+      [
+        Yast::Term.new(:item, Yast::Term.new(:id, "eth0")),
+        Yast::Term.new(:item, Yast::Term.new(:id, "eth1")),
+        Yast::Term.new(:item, Yast::Term.new(:id, "eth1.5")),
+        Yast::Term.new(:item, Yast::Term.new(:id, "eth2"))
+      ]
+    end
+
+    before do
+      allow(Yast::UI).to receive(:QueryWidget)
+        .with(:msbox_items, :Items) { msbox_items }
+    end
+
+    it "returns the index position of the given slave in the mbox_items table" do
+      expect(subject.getISlaveIndex("eth2")).to eql(3)
+      expect(subject.getISlaveIndex("eth1.5")).to eql(2)
+    end
+
+    it "returns -1 in case the slave is not in the msbox_items table" do
+      expect(subject.getISlaveIndex("eth4")).to eql(-1)
+    end
+  end
+
+  describe "#ValidateBond" do
+    let(:msbox_items) do
+      ["eth0", "eth1", "eth2", "eth3", "eth4", "eth5", "eth6", "eth7",
+       "enp0sp25", "enp0sp26", "enp0sp27", "enp0sp28", "enp0sp29"]
+    end
+
+    before do
+      allow(Yast::UI).to receive(:QueryWidget)
+        .with(:msbox_items, :SelectedItems) { msbox_items }
+
+    end
+
+    context "when there is not more than one physical port id per interface" do
+      let(:msbox_items) do
+        ["eth0", "eth1", "eth2", "eth3"]
+      end
+
+      before do
+        allow(Yast::UI).to receive(:QueryWidget)
+          .with(:msbox_items, :SelectedItems) { msbox_items }
+        allow(subject).to receive(:has_physical_id?).with("eth0") { false }
+        allow(subject).to receive(:has_physical_id?).with("eth1") { false }
+        allow(subject).to receive(:has_physical_id?).with("eth2") { true }
+        allow(subject).to receive(:has_physical_id?).with("eth3") { true }
+        allow(subject).to receive(:has_physical_id).with("eth2") { "00010486fd348" }
+        allow(subject).to receive(:has_physical_id).with("eth3") { "00010486fd34a" }
+      end
+
+      it "returns true" do
+        expect(subject.ValidateBond("key", "Event")).to eql(true)
+      end
+    end
+
+    context "when there is more than one physical port id per interface" do
+      before do
+        ["eth0", "eth1", "eth2", "eth3", "eth4", "eth5", "eth6", "eth7",
+         "enp0sp25", "enp0sp26", "enp0sp27", "enp0sp28", "enp0sp29"].map do |i|
+          allow(subject).to receive(:has_physical_port_id?).with(i) { true }
+          allow(subject).to receive(:physical_port_id).with(i) { "00010486fd348" }
+        end
+      end
+
+      it "warns the user and request confirmation for continue" do
+        expect(Yast::Popup).to receive(:YesNoHeadline) { :request_answer }
+
+        expect(subject.ValidateBond("key", "Event")).to eql(:request_answer)
+      end
+    end
+  end
+
+end

--- a/test/address_test.rb
+++ b/test/address_test.rb
@@ -23,9 +23,7 @@ describe "NetworkLanAddressInclude" do
 
   describe "wrap_text" do
     subject(:routines) { DummyClass.new }
-    let(:devices) do
-      ["eth0", "eth1", "eth2", "eth3", "a_very_long_device_name"]
-    end
+    let(:devices) { ["eth0", "eth1", "eth2", "eth3", "a_very_long_device_name"] }
     let(:more_devices) do
       [
         "enp5s0", "enp5s1", "enp5s2", "enp5s3",
@@ -76,9 +74,7 @@ describe "NetworkLanAddressInclude" do
     end
 
     before do
-      allow(Yast::UI).to receive(:QueryWidget)
-        .with(:msbox_items, :Items)
-        .and_return(msbox_items)
+      allow(Yast::UI).to receive(:QueryWidget).with(:msbox_items, :Items).and_return(msbox_items)
     end
 
     it "returns the index position of the given slave in the mbox_items table" do
@@ -99,9 +95,7 @@ describe "NetworkLanAddressInclude" do
     end
 
     context "when there is not more than one physical port id per interface" do
-      let(:msbox_items) do
-        ["eth0", "eth1", "eth2", "eth3"]
-      end
+      let(:msbox_items) { ["eth0", "eth1", "eth2", "eth3"] }
 
       it "returns true" do
         allow(subject).to receive(:physical_port_id?).with("eth0").and_return(false)

--- a/test/address_test.rb
+++ b/test/address_test.rb
@@ -23,10 +23,10 @@ describe "NetworkLanAddressInclude" do
 
   end
 
-  describe "devices_to_s" do
+  describe "wrap_text" do
     subject(:routines) { DummyClass.new }
     let(:devices) do
-      [ "eth0", "eth1", "eth2", "eth3", "a_very_long_device_name" ]
+      ["eth0", "eth1", "eth2", "eth3", "a_very_long_device_name"]
     end
     let(:more_devices) do
       [
@@ -35,31 +35,32 @@ describe "NetworkLanAddressInclude" do
       ]
     end
 
-    context "given a list of devices" do
-      it "returns given devices joined by a space" do
-        text = "eth0 eth1 eth2 eth3 a_very_long_device_name"
+    context "given a text" do
+      it "returns same text if not exceed wrap size" do
+        text = "eth0, eth1, eth2, eth3, a_very_long_device_name"
 
-        expect(routines.devices_to_s(devices)).to eql(text)
+        expect(routines.wrap_text(devices.join(", "))).to eql(text)
       end
 
       context "given a line size" do
-        it "returns given devices wrapped by line size" do
-          text = "eth0 eth1 eth2\n"         \
-                 "eth3\n"                   \
+        it "returns given text splited in lines by given line size" do
+          text = "eth0, eth1, eth2,\n"         \
+                 "eth3,\n"                   \
                  "a_very_long_device_name"
 
-          expect(routines.devices_to_s(devices, 15)).to eql(text)
+          expect(routines.wrap_text(devices.join(", "), 16)).to eql(text)
         end
       end
 
       context "given a number of lines and '...' as cut text" do
         it "returns wrapped text until given line adding '...' as a new line" do
-          text = "eth0 eth1 eth2\n"         \
-                 "eth3\n"                   \
-                 "a_very_long_device_name\n"  \
+          devices_s = (devices + more_devices).join(", ")
+          text = "eth0, eth1, eth2,\n"         \
+                 "eth3,\n"                    \
+                 "a_very_long_device_name,\n" \
                  "..."
 
-          expect(routines.devices_to_s(devices+more_devices, 15,3,"...")).to eql(text)
+          expect(routines.wrap_text(devices_s, 20, n_lines: 3, cut_text: "...")).to eql(text)
         end
       end
 

--- a/test/routines_test.rb
+++ b/test/routines_test.rb
@@ -147,12 +147,12 @@ describe "physical_port_id" do
   end
 end
 
-describe "#has_physical_port_id?" do
+describe "#physical_port_id?" do
   subject(:routines) { RoutinesTestClass.new }
 
   it "returns true if physical port id is not empty" do
     allow(routines).to receive(:physical_port_id).with("eth0") { "physical_port_id" }
 
-    expect(routines.has_physical_port_id?("eth0")).to eql(true)
+    expect(routines.physical_port_id?("eth0")).to eql(true)
   end
 end

--- a/test/routines_test.rb
+++ b/test/routines_test.rb
@@ -121,3 +121,38 @@ describe "hwlist2items" do
       .to match_array([Item(Id(0), "x", false), Item(Id(1), "y", true)])
   end
 end
+
+describe "physical_port_id" do
+  subject(:routines) { RoutinesTestClass.new }
+  let(:phys_port_id) { "physical_port_id" }
+
+  before do
+    allow(Yast::SCR).to receive(:Read)
+      .with(Yast::Path.new(".target.string"), "/sys/class/net/eth0/phys_port_id")
+      .and_return(phys_port_id)
+  end
+
+  context "when the module driver support it" do
+    it "returns ethernet physical port id" do
+      expect(routines.physical_port_id("eth0")).to eql("physical_port_id")
+    end
+  end
+
+  context "when the module driver doesn't support it" do
+    let(:phys_port_id) { nil }
+
+    it "returns an empty string" do
+      expect(routines.physical_port_id("eth0")).to be_empty
+    end
+  end
+end
+
+describe "#has_physical_port_id?" do
+  subject(:routines) { RoutinesTestClass.new }
+
+  it "returns true if physical port id is not empty" do
+    allow(routines).to receive(:physical_port_id).with("eth0") { "physical_port_id" }
+
+    expect(routines.has_physical_port_id?("eth0")).to eql(true)
+  end
+end


### PR DESCRIPTION
An initial study was documented [here](https://gist.github.com/teclator/c1012f264b96bc39a191a4227320bce4) although it had to be updated and some parts were redacted quickly to discuss with UX Expert.

**[Trello Card](https://trello.com/c/UKTnEvME/534-5-sle-12-sp2-p6-i-feature-315995-include-support-for-smarter-bonding-of-virtual-functions-on-npar-sr-iov-devices)**.

### Final implementation:

`Physical Port Id` has been added to the `Device Overview` and also to the `Bond Slave's description` in the `Bond Slaves` selection table. 

![screenshot from 2016-05-16 09-47-53](https://cloud.githubusercontent.com/assets/7056681/15285498/5af22e28-1b4f-11e6-9306-9ed8362b9761.png)

![screenshot from 2016-05-16 09-46-09](https://cloud.githubusercontent.com/assets/7056681/15285504/60136b92-1b4f-11e6-9c3c-79358b35804f.png)

In case the user selected more than one device sharing the same ```Physical Port ID``` he will be warned about it when pressed ```Next```.

![screenshot from 2016-05-16 09-47-09](https://cloud.githubusercontent.com/assets/7056681/15285501/5d1759da-1b4f-11e6-982e-e266b8f6997a.png)

![screenshot from 2016-05-16 09-49-12](https://cloud.githubusercontent.com/assets/7056681/15285485/4343d8f8-1b4f-11e6-8f0c-4aaf670f59ff.png)

We had some discussions about trying to improve ```Bond Slaves``` interface but at the end only  sorting of available devices for bonding had been improved. In some cases ```available devices``` weren't sorted properly, now they are sorted by device name taking care of numerical parts.

![screenshot from 2016-05-16 09-48-28](https://cloud.githubusercontent.com/assets/7056681/15285496/58c17fe6-1b4f-11e6-8138-2a9bba030e5a.png)