### PR TITLE
Stub a test to fix an order-dependent failure.

### DIFF
--- a/test/yapi_network_test.rb
+++ b/test/yapi_network_test.rb
@@ -274,6 +274,7 @@ describe Yast::YaPI::NETWORK do
       end
 
       it "returns the correct hash" do
+        allow(lan_items).to receive(:Items).with(no_args).and_return({})
         expect(subject.Read).to eql(config)
       end
     end


### PR DESCRIPTION
mostly reproducible with rake osc:build[--vm-type=kvm]

we saw this recently in https://build.opensuse.org/package/show/openSUSE:Factory:Staging:H/yast2-network but it has been since rebuilt and the failure disappeared.
A contributing factor is a change in rspec 3.5.0 which  now obeys the exact order of tests as specified on the command line, which would be still sorted if we used a shell glob, but we use Ruby `Dir.glob`. I will fix that in yast-rake.