### PR TITLE
Handle ifplugd priority as string

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Aug  2 12:40:53 UTC 2016 - mfilka@suse.com
+
+- bnc#991382
+  - Do not crash with internal error when using "On Cable
+    Connection" device activation mode.
+- 3.1.160
+
+-------------------------------------------------------------------
 Tue Jul 12 10:41:58 CEST 2016 - schubi@suse.de
 
 - Added entry "dhclient_set_hostname" to the AutoYaST schema file.

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.159
+Version:        3.1.160
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -1830,7 +1830,7 @@ module Yast
       devmap["MTU"] = @mtu
       devmap["ETHTOOL_OPTIONS"] = @ethtool_options
       devmap["STARTMODE"] = @startmode
-      devmap["IFPLUGD_PRIORITY"] = @ifplugd_priority.to_i if @startmode == "ifplugd"
+      devmap["IFPLUGD_PRIORITY"] = @ifplugd_priority if @startmode == "ifplugd"
       devmap["BOOTPROTO"] = @bootproto
       devmap["_aliases"] = @aliases if @aliases && !@aliases.empty?
 


### PR DESCRIPTION
bnc#991382

Note that default value of ```ifplugd_priority``` is a string. When fetching a value provided by user from dialog the value is converted into string. So, the conversion which is being dropped by this patch was complete nonsense.