### PR TITLE
Alternative improve bridge handling (bsc#962824)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Mon Oct 10 11:56:38 UTC 2016 - kanderssen@suse.com
+
+- Bridge handling has been improved (bsc#962824).
+  - "NONE" is shown instead of 0.0.0.0 for old bridge configuration
+  - The bridge master is shown in the enslaved interface.
+  - The interfaces overview is updated after a bridge is modified
+  - The interfaces enlsaved are not lost when save in a different
+    tab.
+- 3.1.170.3
+
+-------------------------------------------------------------------
 Fri Oct  7 15:16:11 UTC 2016 - kanderssen@suse.com
 
 - If an interface is not configured yet then just set the interface

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.170.2
+Version:        3.1.170.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -33,8 +33,8 @@ BuildRequires:  rubygem(yast-rake)
 
 # yast2 v3.1.86: Added ServicesProposal library
 BuildRequires:  yast2 >= 3.1.86
-# yast2 v3.1.135: Fixed Hostname API
-Requires:       yast2 >= 3.1.136
+# Network: Adapt old enslaved interface config
+Requires:       yast2 >= 3.1.206.2
 
 #netconfig (FaTE #303618)
 Requires:       sysconfig >= 0.80.0

--- a/src/clients/inst_setup_dhcp.rb
+++ b/src/clients/inst_setup_dhcp.rb
@@ -1,24 +1,3 @@
-require "yast"
-require "network/network_autoconfiguration"
-
-module Yast
-  class SetupDhcp
-    include Singleton
-    include Logger
-
-    def main
-      nac = Yast::NetworkAutoconfiguration.instance
-      if !nac.any_iface_active?
-        nac.configure_dhcp
-      else
-        log.info("Automatic DHCP configuration not started - an interface is already configured")
-      end
-
-      # if this is not wrapped in a def, ruby -cw says
-      # warning: possibly useless use of a literal in void context
-      :next
-    end
-  end
-end
+require "network/clients/inst_setup_dhcp"
 
 Yast::SetupDhcp.instance.main

--- a/src/data/network/sysconfig_defaults.yml
+++ b/src/data/network/sysconfig_defaults.yml
@@ -42,3 +42,4 @@ BONDING_MODULE_OPTS: mode=active-backup miimon=100
 TUNNEL_SET_OWNER: ''
 TUNNEL_SET_GROUP: ''
 IPOIB_MODE: connected
+BRIDGE_PORTS: ''

--- a/src/include/network/complex.rb
+++ b/src/include/network/complex.rb
@@ -401,18 +401,19 @@ module Yast
     # @param [Hash] devmap device map
     # @return textual device protocol
     def DeviceProtocol(devmap)
-      devmap = deep_copy(devmap)
-      if Ops.get_string(devmap, "STARTMODE", "") == "managed"
+      if devmap["STARTMODE"] == "managed"
         # Abbreviation for "The interface is Managed by NetworkManager"
         return _("Managed")
       end
-      ip = Ops.get_string(devmap, "BOOTPROTO", "static")
-      ip = if ip.nil? || ip == "" || ip == "static"
-        Ops.get_string(devmap, "IPADDR", "")
+      bootproto = devmap["BOOTPROTO"] || "static"
+
+      if bootproto.empty? || bootproto == "static"
+        return "NONE" if devmap["IPADDR"] == "0.0.0.0"
+
+        devmap["IPADDR"].to_s
       else
-        Builtins.toupper(ip)
+        bootproto.upcase
       end
-      ip
     end
   end
 end

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -285,40 +285,47 @@ module Yast
       nil
     end
 
-    # Automatically configures bonding slaves when user enslaves them into a master bond device.
-    def UpdateBondingSlaves
+    # Automatically configures slaves when user enslaves them into a bond or bridge device
+    def UpdateSlaves
       current = LanItems.current
 
-      Builtins.foreach(Lan.bond_autoconf_slaves) do |dev|
+      Lan.autoconf_slaves.each do |dev|
         if LanItems.FindAndSelect(dev)
           LanItems.SetItem
         else
           dev_index = LanItems.FindDeviceIndex(dev)
-          if Ops.less_than(dev_index, 0)
-            Builtins.y2error(
-              "initOverview: invalid bond slave device name %1",
-              dev
-            )
+          if dev_index < 0
+            log.error("initOverview: invalid slave device name #{dev}")
             next
           end
           LanItems.current = dev_index
 
           AddInterface()
-
-          # clear defaults, some defaults are invalid for bonding slaves and can cause troubles
-          # in related sysconfig scripts or makes no sence for bonding slaves (e.g. ip configuration).
-          LanItems.netmask = ""
         end
-        LanItems.startmode = "hotplug"
+        # clear defaults, some defaults are invalid for slaves and can cause troubles
+        # in related sysconfig scripts or makes no sence for slaves (e.g. ip configuration).
+        LanItems.netmask = ""
         LanItems.bootproto = "none"
-        # if particular bond slave uses mac based persistency, overwrite to bus id based one. Don't touch otherwise.
-        LanItems.ReplaceItemUdev(
-          "ATTR{address}",
-          "KERNELS",
-          Ops.get_string(LanItems.getCurrentItem, ["hwinfo", "busid"], "")
-        )
+        case LanItems.GetDeviceType(current)
+        when "bond"
+          LanItems.startmode = "hotplug"
+          # if particular bond slave uses mac based persistency, overwrite to bus id based one. Don't touch otherwise.
+          LanItems.ReplaceItemUdev(
+            "ATTR{address}",
+            "KERNELS",
+            Ops.get_string(LanItems.getCurrentItem, ["hwinfo", "busid"], "")
+          )
+        when "br"
+          LanItems.ipaddr = ""
+        end
+
         LanItems.Commit
       end
+
+      # Once the interfaces have been configured we should empty the list to
+      # avoid configure them again in case that some interface is removed from the
+      # master.
+      Lan.autoconf_slaves = []
 
       LanItems.current = current
 
@@ -332,7 +339,7 @@ module Yast
     # are required in ifcfg and udev. It used to be needed to do it by hand before.
     def AutoUpdateOverview
       # TODO: allow disabling. E.g. iff bus id based persistency is not requested.
-      UpdateBondingSlaves()
+      UpdateSlaves()
 
       nil
     end
@@ -342,19 +349,13 @@ module Yast
       AutoUpdateOverview()
 
       # update table with device description
-      term_items = Builtins.maplist(
-        Convert.convert(
-          LanItems.Overview,
-          from: "list",
-          to:   "list <map <string, any>>"
-        )
-      ) do |i|
-        t = Item(Id(Ops.get_integer(i, "id", -1)))
-        Builtins.foreach(Ops.get_list(i, "table_descr", [])) do |l|
-          t = Builtins.add(t, l)
+      term_items =
+        LanItems.Overview.map do |i|
+          t = Item(Id(i["id"]))
+          (i["table_descr"] || []).each { |l| t << l }
+          t
         end
-        deep_copy(t)
-      end
+
       UI.ChangeWidget(Id(:_hw_items), :Items, term_items)
 
       if !@shown
@@ -364,7 +365,7 @@ module Yast
         enableDisableButtons
       end
 
-      Builtins.y2milestone("LanItems %1", LanItems.Items)
+      log.info("LanItems #{LanItems.Items}")
 
       nil
     end

--- a/src/lib/network/clients/inst_setup_dhcp.rb
+++ b/src/lib/network/clients/inst_setup_dhcp.rb
@@ -1,0 +1,21 @@
+require "network/network_autoconfiguration"
+
+module Yast
+  class SetupDhcp
+    include Singleton
+    include Logger
+
+    def main
+      nac = Yast::NetworkAutoconfiguration.instance
+      if !nac.any_iface_active?
+        nac.configure_dhcp
+      else
+        log.info("Automatic DHCP configuration not started - an interface is already configured")
+      end
+
+      # if this is not wrapped in a def, ruby -cw says
+      # warning: possibly useless use of a literal in void context
+      :next
+    end
+  end
+end

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -85,6 +85,9 @@ module Yast
       # list of interface names which were recently assigned as a slave to a bond device
       @bond_autoconf_slaves = []
 
+      # list of interface names which were recently enslaved in a bridge or bond device
+      @autoconf_slaves = []
+
       # Lan::Read (`cache) will do nothing if initialized already.
       @initialized = false
     end
@@ -1039,7 +1042,6 @@ module Yast
         # for wlan require iw instead of wireless-tools (bnc#539669)
         "wlan" => "iw",
         "vlan" => "vlan",
-        "br"   => "bridge-utils",
         "tun"  => "tunctl",
         "tap"  => "tunctl"
       }
@@ -1098,6 +1100,7 @@ module Yast
     publish variable: :ipv6, type: "boolean"
     publish variable: :AbortFunction, type: "block <boolean>"
     publish variable: :bond_autoconf_slaves, type: "list <string>"
+    publish variable: :autoconf_slaves, type: "list <string>"
     publish function: :Modified, type: "boolean ()"
     publish function: :isAnyInterfaceDown, type: "boolean ()"
     publish function: :Read, type: "boolean (symbol)"

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -125,6 +125,11 @@ module Yast
       @wl_default_key = 0
       @wl_nick = ""
 
+      # FIXME: We should unify bridge_ports and bond_slaves variables
+
+      # interfaces attached to bridge (list delimited by ' ')
+      @bridge_ports = ""
+
       # bond options
       @bond_slaves = []
       @bond_option = ""
@@ -133,8 +138,6 @@ module Yast
       @vlan_etherdevice = ""
       @vlan_id = ""
 
-      # interfaces attached to bridge (list delimited by ' ')
-      @bridge_ports = ""
       # wl_wpa_eap aggregates the settings in a map for easier CWM access.
       #
       # **Structure:**
@@ -736,9 +739,7 @@ module Yast
     #
     # @param [String] bridgeMaster  name of master device
     # @param [Fixnum] itemId        index into LanItems::Items
-    # TODO: bridgeMaster is not used yet bcs detection of bridge master
-    # for checked device is missing.
-    def IsBridgeable(_bridgeMaster, itemId)
+    def IsBridgeable(bridgeMaster, itemId)
       ifcfg = GetDeviceMap(itemId)
 
       # no netconfig configuration has been found so nothing
@@ -750,6 +751,11 @@ module Yast
 
       if bonded[devname]
         log.debug("Excluding lan item (#{itemId}: #{devname}) - is bonded")
+        return false
+      end
+
+      if bridge_index[devname] && bridge_index[devname] != bridgeMaster
+        log.debug("Excluding lan item (#{itemId}: #{devname}) - is already in a bridge")
         return false
       end
 
@@ -1005,53 +1011,26 @@ module Yast
 
       ReadHw()
       NetworkInterfaces.Read
+      NetworkInterfaces.adapt_old_config!
       NetworkInterfaces.CleanHotplugSymlink
 
       interfaces = getNetworkInterfaces
       # match configurations to Items list with hwinfo
-      Builtins.foreach(interfaces) do |confname|
-        pos = nil
-        val = {}
-        Builtins.foreach(
-          Convert.convert(
-            @Items,
-            from: "map <integer, any>",
-            to:   "map <integer, map <string, any>>"
-          )
-        ) do |key, value|
-          if Ops.get_string(value, ["hwinfo", "dev_name"], "") == confname
-            pos = key
-            val = deep_copy(value)
-          end
+      interfaces.each do |confname|
+        @Items.each do |key, value|
+          match = value.fetch("hwinfo", {}).fetch("dev_name", "") == confname
+          @Items[key]["ifcfg"] = confname if match
         end
-        if pos.nil?
-          pos = Builtins.size(@Items)
-          Ops.set(@Items, pos, {})
-        end
-        Ops.set(@Items, [pos, "ifcfg"], confname)
       end
 
-      # add to Items also virtual devices (configurations) without hwinfo
-      Builtins.foreach(interfaces) do |confname|
-        already = false
-        Builtins.foreach(
-          Convert.convert(
-            Map.Keys(@Items),
-            from: "list",
-            to:   "list <integer>"
-          )
-        ) do |key|
-          if confname == Ops.get_string(@Items, [key, "ifcfg"], "")
-            already = true
-            raise Break
-          end
-        end
-        if !already
-          AddNew()
-          Ops.set(@Items, @current, "ifcfg" => confname)
-        end
+      interfaces.each do |confname|
+        next if @Items.keys.any? { |key| @Items.fetch(key, {}).fetch("ifcfg", "") == confname }
+
+        AddNew()
+        @Items[@current] = { "ifcfg" => confname }
       end
-      Builtins.y2milestone("Read Configuration LanItems::Items %1", @Items)
+
+      log.info "Read Configuration LanItems::Items #{@Items}"
 
       nil
     end
@@ -1217,21 +1196,42 @@ module Yast
 
     def BuildBondIndex
       index = {}
-      bond_devs = Convert.convert(
-        Ops.get(NetworkInterfaces.FilterDevices("netcard"), "bond", {}),
-        from: "map",
-        to:   "map <string, map>"
-      )
 
-      Builtins.foreach(bond_devs) do |bond_master, _value|
-        Builtins.foreach(GetBondSlaves(bond_master)) do |slave|
-          index = Builtins.add(index, slave, bond_master)
+      bond_devs = NetworkInterfaces.FilterDevices("netcard").fetch("bond", {})
+
+      bond_devs.each do |bond_master, _value|
+        GetBondSlaves(bond_master).each do |slave|
+          index[slave] = bond_master
         end
       end
 
-      Builtins.y2debug("bond slaves index: %1", index)
+      log.debug("bond slaves index: #{index}")
 
-      deep_copy(index)
+      index
+    end
+
+    # Creates a map where the keys are the interfaces enslaved and the values
+    # are the bridges where them are taking part.
+    def bridge_index
+      index = {}
+
+      bridge_devs = NetworkInterfaces.FilterDevices("netcard").fetch("br", {})
+
+      bridge_devs.each do |bridge_master, value|
+        value["BRIDGE_PORTS"].to_s.split.each do |if_name|
+          index[if_name] = bridge_master
+        end
+      end
+
+      index
+    end
+
+    # Returns the interfaces that are enslaved in the given bridge
+    #
+    # @param [String] bridge name
+    # @return [Array<String>] a list of interface names
+    def bridge_slaves(master)
+      bridge_index.select { |_k, v| v == master }.keys
     end
 
     # Creates item's startmode human description
@@ -1307,6 +1307,8 @@ module Yast
       overview = []
       links = []
 
+      bond_index = BuildBondIndex()
+
       LanItems.Items.each_key do |key|
         rich = ""
         ip = _("Not configured")
@@ -1317,25 +1319,21 @@ module Yast
         note = ""
         bullets = []
         ifcfg_name = LanItems.Items[key]["ifcfg"] || ""
+        ifcfg_type = NetworkInterfaces.GetType(ifcfg_name)
 
-        LanItems.type = NetworkInterfaces.GetType(ifcfg_name)
         if !ifcfg_name.empty?
           ifcfg_conf = GetDeviceMap(key)
           ifcfg_desc = ifcfg_conf["NAME"]
           descr = ifcfg_desc if !ifcfg_desc.nil? && !ifcfg_desc.empty?
-          descr = CheckEmptyName(LanItems.type, descr)
+          descr = CheckEmptyName(ifcfg_type, descr)
           ip = DeviceProtocol(ifcfg_conf)
-          status = DeviceStatus(
-            LanItems.type,
-            ifcfg_name,
-            ifcfg_conf
-          )
+          status = DeviceStatus(ifcfg_type, ifcfg_name, ifcfg_conf)
 
           bullets << _("Device Name: %s") % ifcfg_name
           bullets += startmode_overview(key)
           bullets += ip_overview(ip) if ifcfg_conf["STARTMODE"] != "managed"
 
-          if LanItems.type == "wlan" &&
+          if ifcfg_type == "wlan" &&
               ifcfg_conf["WIRELESS_AUTH_MODE"] == "open" &&
               IsEmpty(ifcfg_conf["WIRELESS_KEY_0"])
 
@@ -1349,26 +1347,20 @@ module Yast
             links << href
           end
 
-          if LanItems.type == "bond"
-            bond_slaves_desc = format(
-              "%s: %s",
-              _("Bonding slaves"),
-              GetBondSlaves(ifcfg_name).join(" ")
-            )
-            bullets << bond_slaves_desc
+          if ifcfg_type == "bond" || ifcfg_type == "br"
+            bullets << slaves_desc(ifcfg_type, ifcfg_name)
           end
 
-          bond_index = BuildBondIndex()
-          bond_master = Ops.get(
-            bond_index,
-            ifcfg_name,
-            ""
-          )
-
-          if !bond_master.empty?
-            note = format(_("enslaved in %s"), bond_master)
-            bond_master_desc = format("%s: %s", _("Bonding master"), bond_master)
-            bullets << bond_master_desc
+          if enslaved?(ifcfg_name)
+            if bond_index[ifcfg_name]
+              master = bond_index[ifcfg_name]
+              master_desc = _("Bonding master")
+            else
+              master = bridge_index[ifcfg_name]
+              master_desc = _("Bridge")
+            end
+            note = format(_("enslaved in %s"), master)
+            bullets << format("%s: %s", master_desc, master)
           end
 
           if renamed?(key)
@@ -1377,7 +1369,7 @@ module Yast
 
           overview << Summary.Device(descr, status)
         else
-          descr = CheckEmptyName(LanItems.type, descr)
+          descr = CheckEmptyName(ifcfg_type, descr)
           overview << Summary.Device(descr, Summary.NotConfigured)
         end
         conn = ""
@@ -2031,6 +2023,7 @@ module Yast
 
         # configure bridge ports
         if @bridge_ports
+          log.info "Configuring bridge ports #{@bridge_ports} for: #{ifcfg_name}"
           @bridge_ports.split.each { |bp| configure_as_bridge_port(bp) }
         end
 
@@ -2387,6 +2380,34 @@ module Yast
     end
 
   private
+
+    # Returns a formated string with the interfaces that are part of a bridge
+    # or of a bond interface.
+    #
+    # @param [String] ifcfg_type
+    # @param [String] ifcfg_name
+    # @return [String] formated string with the interface type and the interfaces enslaved
+    def slaves_desc(ifcfg_type, ifcfg_name)
+      if ifcfg_type == "bond"
+        slaves = GetBondSlaves(ifcfg_name)
+        desc = _("Bonding slaves")
+      else
+        slaves = bridge_slaves(ifcfg_name)
+        desc = _("Bridge Ports")
+      end
+
+      format("%s: %s", desc, slaves.join(" "))
+    end
+
+    # Check if the given interface is enslaved in a bond or in a bridge
+    #
+    # @return [Boolean] true if enslaved
+    def enslaved?(ifcfg_name)
+      bond_index = BuildBondIndex()
+      return true if bond_index[ifcfg_name] || bridge_index[ifcfg_name]
+
+      false
+    end
 
     # Checks if given lladdr can be written into ifcfg
     #

--- a/test/bond_test.rb
+++ b/test/bond_test.rb
@@ -6,148 +6,147 @@ require "yast"
 
 Yast.import "LanItems"
 
-module Yast
-  describe LanItems do
-    let(:netconfig_items) do
-      {
-        "eth"  => {
-          "eth1" => { "BOOTPROTO" => "none" },
-          "eth2" => { "BOOTPROTO" => "none" },
-          "eth4" => { "BOOTPROTO" => "none" },
-          "eth5" => { "BOOTPROTO" => "none" },
-          "eth6" => { "BOOTPROTO" => "dhcp" }
+describe Yast::LanItems do
+  let(:netconfig_items) do
+    {
+      "eth"  => {
+        "eth1" => { "BOOTPROTO" => "none" },
+        "eth2" => { "BOOTPROTO" => "none" },
+        "eth4" => { "BOOTPROTO" => "none" },
+        "eth5" => { "BOOTPROTO" => "none" },
+        "eth6" => { "BOOTPROTO" => "dhcp" }
+      },
+      "bond" => {
+        "bond0" => {
+          "BOOTPROTO"      => "static",
+          "BONDING_MASTER" => "yes",
+          "BONDING_SLAVE0" => "eth1",
+          "BONDING_SLAVE1" => "eth2"
         },
-        "bond" => {
-          "bond0" => {
-            "BOOTPROTO"      => "static",
-            "BONDING_MASTER" => "yes",
-            "BONDING_SLAVE0" => "eth1",
-            "BONDING_SLAVE1" => "eth2"
-          },
-          "bond1" => {
-            "BOOTPROTO"      => "static",
-            "BONDING_MASTER" => "yes"
-          }
+        "bond1" => {
+          "BOOTPROTO"      => "static",
+          "BONDING_MASTER" => "yes"
         }
       }
-    end
-    let(:hwinfo_items) do
-      [
-        { "dev_name" => "eth11" },
-        { "dev_name" => "eth12" }
-      ]
-    end
+    }
+  end
+  let(:hwinfo_items) do
+    [
+      { "dev_name" => "eth11" },
+      { "dev_name" => "eth12" }
+    ]
+  end
 
-    before(:each) do
-      allow(NetworkInterfaces).to receive(:FilterDevices).with("netcard") { netconfig_items }
+  before(:each) do
+    allow(Yast::NetworkInterfaces).to receive(:FilterDevices).with("netcard") { netconfig_items }
+    allow(Yast::NetworkInterfaces).to receive(:adapt_old_config!)
 
-      allow(LanItems).to receive(:ReadHardware) { hwinfo_items }
-      LanItems.Read
-    end
+    allow(Yast::LanItems).to receive(:ReadHardware) { hwinfo_items }
+    Yast::LanItems.Read
+  end
 
-    describe "#GetBondableInterfaces" do
-      let(:expected_bondable) { ["eth4", "eth5", "eth11", "eth12"] }
+  describe "#GetBondableInterfaces" do
+    let(:expected_bondable) { ["eth4", "eth5", "eth11", "eth12"] }
 
-      context "on common architectures" do
-        before(:each) do
-          expect(Arch).to receive(:s390).at_least(:once).and_return false
-          # FindAndSelect initializes internal state of LanItems it
-          # is used internally by some helpers
-          LanItems.FindAndSelect("bond1")
-        end
-
-        it "returns list of slave candidates" do
-          expect(
-            LanItems
-              .GetBondableInterfaces(LanItems.GetCurrentName)
-              .map { |i| LanItems.GetDeviceName(i) }
-          ).to match_array expected_bondable
-        end
+    context "on common architectures" do
+      before(:each) do
+        expect(Yast::Arch).to receive(:s390).at_least(:once).and_return false
+        # FindAndSelect initializes internal state of Yast::LanItems it
+        # is used internally by some helpers
+        Yast::LanItems.FindAndSelect("bond1")
       end
 
-      context "on s390" do
-        before(:each) do
-          expect(Arch).to receive(:s390).at_least(:once).and_return true
-        end
-
-        it "returns list of slave candidates" do
-          expect(LanItems).to receive(:s390_ReadQethConfig).with("eth4")
-            .and_return("QETH_LAYER2" => "yes")
-          expect(LanItems).to receive(:s390_ReadQethConfig).with(::String)
-            .at_least(:once).and_return("QETH_LAYER2" => "no")
-
-          expect(
-            LanItems
-              .GetBondableInterfaces(LanItems.GetCurrentName)
-              .map { |i| LanItems.GetDeviceName(i) }
-          ).to match_array ["eth4"]
-        end
+      it "returns list of slave candidates" do
+        expect(
+          Yast::LanItems
+            .GetBondableInterfaces(Yast::LanItems.GetCurrentName)
+            .map { |i| Yast::LanItems.GetDeviceName(i) }
+        ).to match_array expected_bondable
       end
     end
 
-    describe "#GetBondSlaves" do
-      it "returns list of slaves if bond device has some" do
-        expect(LanItems.GetBondSlaves("bond0")).to match_array ["eth1", "eth2"]
+    context "on s390" do
+      before(:each) do
+        expect(Yast::Arch).to receive(:s390).at_least(:once).and_return true
       end
 
-      it "returns empty list if bond device doesn't have slaves assigned" do
-        expect(LanItems.GetBondSlaves("bond1")).to be_empty
+      it "returns list of slave candidates" do
+        expect(Yast::LanItems).to receive(:s390_ReadQethConfig).with("eth4")
+          .and_return("QETH_LAYER2" => "yes")
+        expect(Yast::LanItems).to receive(:s390_ReadQethConfig).with(::String)
+          .at_least(:once).and_return("QETH_LAYER2" => "no")
+
+        expect(
+          Yast::LanItems
+            .GetBondableInterfaces(Yast::LanItems.GetCurrentName)
+            .map { |i| Yast::LanItems.GetDeviceName(i) }
+        ).to match_array ["eth4"]
       end
     end
+  end
 
-    describe "#BuildBondIndex" do
-      let(:expected_mapping) { { "eth1" => "bond0", "eth2" => "bond0" } }
-
-      it "creates mapping of device names to corresponding bond master" do
-        expect(LanItems.BuildBondIndex).to match(expected_mapping)
-      end
+  describe "#GetBondSlaves" do
+    it "returns list of slaves if bond device has some" do
+      expect(Yast::LanItems.GetBondSlaves("bond0")).to match_array ["eth1", "eth2"]
     end
 
-    describe "#setup_bonding" do
-      let(:bonding_map) { { "BONDING_SLAVE0" => "eth0", "BONDING_SLAVE1" => "enp0s3" } }
-      let(:mandatory_opts) { { "BONDING_MASTER" => "yes", "BONDING_MODULE_OPTS" => option } }
-      let(:option) { "bonding_option" }
+    it "returns empty list if bond device doesn't have slaves assigned" do
+      expect(Yast::LanItems.GetBondSlaves("bond1")).to be_empty
+    end
+  end
 
-      it "sets BONDING_MASTER and BONDING_MODULE_OPTS" do
-        expected_map = mandatory_opts
+  describe "#BuildBondIndex" do
+    let(:expected_mapping) { { "eth1" => "bond0", "eth2" => "bond0" } }
 
-        ret = LanItems.setup_bonding({}, [], option)
+    it "creates mapping of device names to corresponding bond master" do
+      expect(Yast::LanItems.BuildBondIndex).to match(expected_mapping)
+    end
+  end
 
-        expect(ret.select { |k, _| k !~ /BONDING_SLAVE/ }).to match(expected_map)
-      end
+  describe "#setup_bonding" do
+    let(:bonding_map) { { "BONDING_SLAVE0" => "eth0", "BONDING_SLAVE1" => "enp0s3" } }
+    let(:mandatory_opts) { { "BONDING_MASTER" => "yes", "BONDING_MODULE_OPTS" => option } }
+    let(:option) { "bonding_option" }
 
-      it "sets BONDING_SLAVEx options according to given list" do
-        expected_map = bonding_map
+    it "sets BONDING_MASTER and BONDING_MODULE_OPTS" do
+      expected_map = mandatory_opts
 
-        ret = LanItems.setup_bonding({}, ["eth0", "enp0s3"], nil)
+      ret = Yast::LanItems.setup_bonding({}, [], option)
 
-        expect(ret.select { |k, v| k =~ /BONDING_SLAVE/ && !v.nil? }).to match expected_map
-      end
+      expect(ret.select { |k, _| k !~ /BONDING_SLAVE/ }).to match(expected_map)
+    end
 
-      it "clears BONDING_SLAVEx which are not needed anymore" do
-        expected_map = { "BONDING_SLAVE0" => "enp0s3" }
+    it "sets BONDING_SLAVEx options according to given list" do
+      expected_map = bonding_map
 
-        ret = LanItems.setup_bonding(bonding_map, ["enp0s3"], nil)
+      ret = Yast::LanItems.setup_bonding({}, ["eth0", "enp0s3"], nil)
 
-        expect(ret.select { |k, v| k =~ /BONDING_SLAVE/ && !v.nil? }).to match expected_map
-        # Following is required to get unneeded BONDING_SLAVEx deleted
-        # during write
-        expect(ret).to have_key("BONDING_SLAVE1")
-        expect(ret["BONDING_SLAVE1"]).to be nil
-      end
+      expect(ret.select { |k, v| k =~ /BONDING_SLAVE/ && !v.nil? }).to match expected_map
+    end
 
-      it "clears all BONDING_SLAVESx and sets BONDING_MASTER, BONDING_OPTIONS when no slaves provided" do
-        ret = LanItems.setup_bonding(bonding_map, nil, option)
-        expected_slaves = { "BONDING_SLAVE0" => nil, "BONDING_SLAVE1" => nil }
-        expected_map = mandatory_opts.merge(expected_slaves)
+    it "clears BONDING_SLAVEx which are not needed anymore" do
+      expected_map = { "BONDING_SLAVE0" => "enp0s3" }
 
-        expect(ret).to match(expected_map)
-      end
+      ret = Yast::LanItems.setup_bonding(bonding_map, ["enp0s3"], nil)
 
-      it "raises an exception in case of nil devmap" do
-        expect { LanItems.setup_bonding(nil, nil, nil) }
-          .to raise_error(ArgumentError, "Device map has to be provided.")
-      end
+      expect(ret.select { |k, v| k =~ /BONDING_SLAVE/ && !v.nil? }).to match expected_map
+      # Following is required to get unneeded BONDING_SLAVEx deleted
+      # during write
+      expect(ret).to have_key("BONDING_SLAVE1")
+      expect(ret["BONDING_SLAVE1"]).to be nil
+    end
+
+    it "clears all BONDING_SLAVESx and sets BONDING_MASTER, BONDING_OPTIONS when no slaves provided" do
+      ret = Yast::LanItems.setup_bonding(bonding_map, nil, option)
+      expected_slaves = { "BONDING_SLAVE0" => nil, "BONDING_SLAVE1" => nil }
+      expected_map = mandatory_opts.merge(expected_slaves)
+
+      expect(ret).to match(expected_map)
+    end
+
+    it "raises an exception in case of nil devmap" do
+      expect { Yast::LanItems.setup_bonding(nil, nil, nil) }
+        .to raise_error(ArgumentError, "Device map has to be provided.")
     end
   end
 end

--- a/test/bridge_test.rb
+++ b/test/bridge_test.rb
@@ -6,87 +6,87 @@ require "yast"
 
 Yast.import "LanItems"
 
-module Yast
-  describe LanItems do
-    let(:netconfig_items) do
-      {
-        "eth"  => {
-          "eth1" => { "BOOTPROTO" => "none" },
-          "eth2" => { "BOOTPROTO" => "none" },
-          "eth4" => {
-            "BOOTPROTO" => "static",
-            "IPADDR"    => "0.0.0.0",
-            "PREFIX"    => "32"
-          },
-          "eth5" => { "BOOTPROTO" => "static", "STARTMODE" => "nfsroot" },
-          "eth6" => { "BOOTPROTO" => "static", "STARTMODE" => "ifplugd" }
+describe Yast::LanItems do
+  let(:netconfig_items) do
+    {
+      "eth"  => {
+        "eth1" => { "BOOTPROTO" => "none" },
+        "eth2" => { "BOOTPROTO" => "none" },
+        "eth4" => {
+          "BOOTPROTO" => "static",
+          "IPADDR"    => "0.0.0.0",
+          "PREFIX"    => "32"
         },
-        "tun"  => {
-          "tun0" => {
-            "BOOTPROTO" => "static",
-            "STARTMODE" => "onboot",
-            "TUNNEL"    => "tun"
-          }
-        },
-        "tap"  => {
-          "tap0" => {
-            "BOOTPROTO" => "static",
-            "STARTMODE" => "onboot",
-            "TUNNEL"    => "tap"
-          }
-        },
-        "br"   => {
-          "br0" => { "BOOTPROTO" => "dhcp" }
-        },
-        "bond" => {
-          "bond0" => {
-            "BOOTPROTO"      => "static",
-            "BONDING_MASTER" => "yes",
-            "BONDING_SLAVE0" => "eth1",
-            "BONDING_SLAVE1" => "eth2"
-          }
+        "eth5" => { "BOOTPROTO" => "static", "STARTMODE" => "nfsroot" },
+        "eth6" => { "BOOTPROTO" => "static", "STARTMODE" => "ifplugd" }
+      },
+      "tun"  => {
+        "tun0" => {
+          "BOOTPROTO" => "static",
+          "STARTMODE" => "onboot",
+          "TUNNEL"    => "tun"
+        }
+      },
+      "tap"  => {
+        "tap0" => {
+          "BOOTPROTO" => "static",
+          "STARTMODE" => "onboot",
+          "TUNNEL"    => "tap"
+        }
+      },
+      "br"   => {
+        "br0" => { "BOOTPROTO" => "dhcp" }
+      },
+      "bond" => {
+        "bond0" => {
+          "BOOTPROTO"      => "static",
+          "BONDING_MASTER" => "yes",
+          "BONDING_SLAVE0" => "eth1",
+          "BONDING_SLAVE1" => "eth2"
         }
       }
-    end
+    }
+  end
 
-    let(:hwinfo_items) do
-      [
-        { "dev_name" => "eth11" },
-        { "dev_name" => "eth12" }
-      ]
-    end
+  let(:hwinfo_items) do
+    [
+      { "dev_name" => "eth11" },
+      { "dev_name" => "eth12" }
+    ]
+  end
 
-    let(:expected_bridgeable) do
-      [
-        "bond0",
-        "eth4",
-        "eth11",
-        "eth12",
-        "tap0"
-      ]
-    end
+  let(:expected_bridgeable) do
+    [
+      "bond0",
+      "eth4",
+      "eth11",
+      "eth12",
+      "tap0"
+    ]
+  end
 
+  before(:each) do
+    allow(Yast::NetworkInterfaces).to receive(:FilterDevices).with("netcard") { netconfig_items }
+    allow(Yast::NetworkInterfaces).to receive(:adapt_old_config!)
+
+    allow(Yast::LanItems).to receive(:ReadHardware) { hwinfo_items }
+
+    Yast::LanItems.Read
+  end
+
+  describe "#GetBridgeableInterfaces" do
     before(:each) do
-      allow(NetworkInterfaces).to receive(:FilterDevices).with("netcard") { netconfig_items }
-
-      allow(LanItems).to receive(:ReadHardware) { hwinfo_items }
-      LanItems.Read
+      # FindAndSelect initializes internal state of LanItems it
+      # is used internally by some helpers
+      Yast::LanItems.FindAndSelect("br0")
     end
 
-    describe "#GetBridgeableInterfaces" do
-      before(:each) do
-        # FindAndSelect initializes internal state of LanItems it
-        # is used internally by some helpers
-        LanItems.FindAndSelect("br0")
-      end
-
-      it "returns list of slave candidates" do
-        expect(
-          LanItems
-            .GetBridgeableInterfaces(LanItems.GetCurrentName)
-            .map { |i| LanItems.GetDeviceName(i) }
-        ).to match_array expected_bridgeable
-      end
+    it "returns list of slave candidates" do
+      expect(
+        Yast::LanItems
+          .GetBridgeableInterfaces(Yast::LanItems.GetCurrentName)
+          .map { |i| Yast::LanItems.GetDeviceName(i) }
+      ).to match_array expected_bridgeable
     end
   end
 end

--- a/test/complex_test.rb
+++ b/test/complex_test.rb
@@ -3,6 +3,7 @@
 require_relative "test_helper"
 
 require "yast"
+include Yast::I18n
 
 Yast.import "LanItems"
 Yast.import "Stage"
@@ -13,56 +14,95 @@ class NetworkLanComplexIncludeClass < Yast::Module
   end
 end
 
-describe "NetworkLanComplexInclude::input_done?" do
+describe "NetworkLanComplexInclude" do
   subject { NetworkLanComplexIncludeClass.new }
 
-  BOOLEAN_PLACEHOLDER = "placeholder (true or false)".freeze
+  describe "#input_done?" do
+    BOOLEAN_PLACEHOLDER = "placeholder (true or false)".freeze
 
-  context "when not running in installer" do
-    before(:each) do
-      allow(Yast::Stage)
-        .to receive(:initial)
-        .and_return(false)
+    context "when not running in installer" do
+      before(:each) do
+        allow(Yast::Stage)
+          .to receive(:initial)
+          .and_return(false)
+      end
+
+      it "returns true for input different than :abort" do
+        expect(subject.input_done?(:no_abort)).to eql true
+      end
+
+      it "returns true for input equal to :abort in case of no user modifications" do
+        allow(Yast::LanItems)
+          .to receive(:GetModified)
+          .and_return(false)
+
+        expect(subject.input_done?(:abort)).to eql true
+      end
+
+      it "asks user for abort confirmation for input equal to :abort and user did modifications" do
+        allow(Yast::LanItems)
+          .to receive(:GetModified)
+          .and_return(true)
+
+        expect(subject)
+          .to receive(:ReallyAbort)
+          .and_return(BOOLEAN_PLACEHOLDER)
+
+        expect(subject.input_done?(:abort)).to eql BOOLEAN_PLACEHOLDER
+      end
     end
 
-    it "returns true for input different than :abort" do
-      expect(subject.input_done?(:no_abort)).to eql true
-    end
+    context "when running in installer" do
+      before(:each) do
+        allow(Yast::Stage)
+          .to receive(:initial)
+          .and_return(true)
+      end
 
-    it "returns true for input equal to :abort in case of no user modifications" do
-      allow(Yast::LanItems)
-        .to receive(:GetModified)
-        .and_return(false)
+      it "asks user for installation abort confirmation for input equal to :abort" do
+        expect(Yast::Popup)
+          .to receive(:ConfirmAbort)
+          .and_return(BOOLEAN_PLACEHOLDER)
 
-      expect(subject.input_done?(:abort)).to eql true
-    end
-
-    it "asks user for abort confirmation for input equal to :abort and user did modifications" do
-      allow(Yast::LanItems)
-        .to receive(:GetModified)
-        .and_return(true)
-
-      expect(subject)
-        .to receive(:ReallyAbort)
-        .and_return(BOOLEAN_PLACEHOLDER)
-
-      expect(subject.input_done?(:abort)).to eql BOOLEAN_PLACEHOLDER
+        expect(subject.input_done?(:abort)).to eql BOOLEAN_PLACEHOLDER
+      end
     end
   end
 
-  context "when running in installer" do
-    before(:each) do
-      allow(Yast::Stage)
-        .to receive(:initial)
-        .and_return(true)
+  describe "#DeviceProtocol" do
+    let(:ipaddr) { "192.168.0.120" }
+    let(:managed) { { "STARTMODE" => "managed" } }
+    let(:static) { { "BOOTPROTO" => "static", "IPADDR" => ipaddr } }
+    let(:empty) { { "BOOTPROTO" => "", "IPADDR" => ipaddr } }
+    let(:no_bootproto) { { "IPADDR" => ipaddr } }
+    # IPADDR are set just to show that returns the protocol instead of the IP
+    let(:dhcp) { { "BOOTPROTO" => "dhcp", "IPADDR" => ipaddr } }
+    let(:none) { { "BOOTPROTO" => "none", "IPADDR" => ipaddr } }
+    let(:zero) { { "BOOTPROTO" => "static", "IPADDR" => ipaddr } }
+
+    it "returns _('Managed') if the interface is managed by NetworkManager" do
+      expect(subject.DeviceProtocol(managed)).to eql(_("Managed"))
     end
 
-    it "asks user for installation abort confirmation for input equal to :abort" do
-      expect(Yast::Popup)
-        .to receive(:ConfirmAbort)
-        .and_return(BOOLEAN_PLACEHOLDER)
+    it "returns the IP address in case that BOOTPROTO is empty" do
+      expect(subject.DeviceProtocol(empty)).to eql(ipaddr)
+    end
 
-      expect(subject.input_done?(:abort)).to eql BOOLEAN_PLACEHOLDER
+    it "returns the IP address in case of no BOOTPROTO" do
+      expect(subject.DeviceProtocol(no_bootproto)).to eql(ipaddr)
+    end
+
+    it "returns 'NONE' in case of static config and IPADDR == '0.0.0.0'" do
+      expect(subject.DeviceProtocol(static.merge("IPADDR" => "0.0.0.0"))).to eql("NONE")
+    end
+
+    it "returns the IP address in case of static config" do
+      expect(subject.DeviceProtocol(static)).to eql(ipaddr)
+    end
+
+    it "returns BOOTPROTO converted to uppercase" do
+      expect(subject.DeviceProtocol(none)).to eql("NONE")
+      expect(subject.DeviceProtocol(dhcp)).to eql("DHCP")
     end
   end
 end

--- a/test/complex_test.rb
+++ b/test/complex_test.rb
@@ -78,7 +78,6 @@ describe "NetworkLanComplexInclude" do
     # IPADDR are set just to show that returns the protocol instead of the IP
     let(:dhcp) { { "BOOTPROTO" => "dhcp", "IPADDR" => ipaddr } }
     let(:none) { { "BOOTPROTO" => "none", "IPADDR" => ipaddr } }
-    let(:zero) { { "BOOTPROTO" => "static", "IPADDR" => ipaddr } }
 
     it "returns _('Managed') if the interface is managed by NetworkManager" do
       expect(subject.DeviceProtocol(managed)).to eql(_("Managed"))

--- a/test/default_route_test.rb
+++ b/test/default_route_test.rb
@@ -2,7 +2,6 @@
 
 require_relative "test_helper"
 
-require "yast"
 require "network/install_inf_convertor"
 
 describe "Yast::LanItemsClass" do
@@ -48,6 +47,8 @@ describe "Yast::LanItemsClass" do
     # stub NetworkInterfaces, apart from the ifcfgs
     allow(Yast::NetworkInterfaces)
       .to receive(:CleanHotplugSymlink)
+    allow(Yast::NetworkInterfaces)
+      .to receive(:adapt_old_config!)
     allow(Yast::NetworkInterfaces)
       .to receive(:GetTypeFromSysfs)
       .with(/eth\d+/)

--- a/test/edit_nic_name_test.rb
+++ b/test/edit_nic_name_test.rb
@@ -17,6 +17,7 @@ module Yast
     before(:each) do
       # NetworkInterfaces are too low level. Everything needed should be mocked
       NetworkInterfaces.as_null_object
+      allow(NetworkInterfaces).to receive(:adapt_old_config!)
 
       # mock devices configuration
       allow(LanItems).to receive(:ReadHardware) { [{ "dev_name" => CURRENT_NAME, "mac" => "00:01:02:03:04:05" }] }

--- a/test/inst_setup_dhcp_test.rb
+++ b/test/inst_setup_dhcp_test.rb
@@ -2,12 +2,15 @@
 
 require_relative "test_helper"
 
-require "yast"
-require "network/network_autoconfiguration"
-require_relative "../src/clients/inst_setup_dhcp"
+require "network/clients/inst_setup_dhcp"
 
 describe Yast::SetupDhcp do
+  before do
+    allow(Yast::NetworkInterfaces).to receive(:adapt_old_config!)
+  end
+
   describe "#main" do
+
     it "returns :next when autoconfiguration is performed" do
       allow(Yast::NetworkAutoconfiguration)
         .to receive(:any_iface_active?)

--- a/test/lan_test.rb
+++ b/test/lan_test.rb
@@ -8,10 +8,9 @@ Yast.import "Lan"
 
 describe "LanClass#Packages" do
   packages = {
-    "iw"           => "wlan",
-    "vlan"         => "vlan",
-    "bridge-utils" => "br",
-    "tunctl"       => "tun"
+    "iw"     => "wlan",
+    "vlan"   => "vlan",
+    "tunctl" => "tun"
   }
 
   packages.each do |pkg, type|

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -87,6 +87,8 @@ describe Yast::NetworkAutoconfiguration do
       allow(Yast::NetworkInterfaces)
         .to receive(:CleanHotplugSymlink)
       allow(Yast::NetworkInterfaces)
+        .to receive(:adapt_old_config!)
+      allow(Yast::NetworkInterfaces)
         .to receive(:GetTypeFromSysfs).  with(/eth\d+/).      and_return "eth"
       allow(Yast::NetworkInterfaces)
         .to receive(:GetType).           with(/eth\d+/).      and_return "eth"
@@ -165,6 +167,8 @@ describe Yast::NetworkAutoconfiguration do
       allow(Yast::LanItems)
         .to receive(:GetNetcardNames)
         .and_return([IFACE, "enp0s3", "br7"])
+      allow(Yast::NetworkInterfaces)
+        .to receive(:adapt_old_config!)
       allow(Yast::NetworkInterfaces)
         .to receive(:Check)
         .with(IFACE)

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -2,11 +2,13 @@
 
 require_relative "test_helper"
 
-require "yast"
 require "network/network_autoyast"
 
 describe "NetworkAutoYast" do
   subject(:network_autoyast) { Yast::NetworkAutoYast.instance }
+  before do
+    allow(Yast::NetworkInterfaces).to receive(:adapt_old_config!)
+  end
 
   describe "#merge_devices" do
     let(:netconfig_linuxrc) do


### PR DESCRIPTION
This in alternative to #441 and which depends on yast/yast-yast2#500. 

The idea is to adapt the configuration internally when the `ifcfg-*` files are read instead of when the bridge or interface enslaved where edited. The files will only be written in case that the user change some configuration but if he edit the enslaved interface or just in the **LanOverview** table he will not see the static configuration.

I have unified the configuration overview with bridges involved with the bonding one as you can see in the screenshots. There have been fixed also some small issue.

## Bond overview
![enslavedbond](https://cloud.githubusercontent.com/assets/7056681/18710258/398a800c-7ffc-11e6-889f-b610fd6a079a.png)

## Bridge overview
![enslavedbridge](https://cloud.githubusercontent.com/assets/7056681/18710260/3b4b556a-7ffc-11e6-808f-ba87199a063a.png)

## Old bridge configuration
![old_bridge](https://cloud.githubusercontent.com/assets/7056681/18710212/db44211a-7ffb-11e6-97ae-8c521094c0e0.gif)

## New bridge configuration
![new_bridge](https://cloud.githubusercontent.com/assets/7056681/18710206/d311fb0c-7ffb-11e6-9ef6-dc71c960c6b7.gif)