### PR TITLE
We cannot just remove the handle of link state (bsc#991694)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Oct  7 15:16:11 UTC 2016 - kanderssen@suse.com
+
+- If an interface is not configured yet then just set the interface
+  link, the backend should handle at least the up event.
+  (bsc#991694)
+- 3.1.170.2
+
+-------------------------------------------------------------------
 Fri Oct  7 15:12:05 UTC 2016 - ancor@suse.com
 
 - Extra space in the remote administration dialog (bsc#988904)
@@ -6,10 +14,10 @@ Fri Oct  7 15:12:05 UTC 2016 - ancor@suse.com
 -------------------------------------------------------------------
 Mon Sep 12 09:40:57 UTC 2016 - kanderssen@suse.com
 
-- Use full interface up / down instead of setting just link 
+- Use full interface up / down instead of setting just link
   up / down to allow proper update of interface's configuration.
   (bsc#991694)
-- 3.1.171
+- 3.1.170.1
 
 -------------------------------------------------------------------
 Wed Sep  7 11:23:16 UTC 2016 - mfilka@suse.com

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.170
+Version:        3.1.170.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_netprobe.rb
+++ b/src/clients/inst_netprobe.rb
@@ -52,7 +52,7 @@ module Yast
 
       if NetHwDetection.running
         # Start interfaces iff running installation. See bnc#395014, bnc#782283 and bnc#792985
-        SetAllIfacesUp()
+        SetAllLinksUp()
       end
 
       Builtins.y2milestone(

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -727,20 +727,20 @@ module Yast
       Run("ip link set #{dev_name} down")
     end
 
-    # Calls wicked ifdown with the given interface
-    #
-    # @param [String] name of interface to put down
-    def SetIfaceDown(dev_name)
-      log.info("Setting interface #{dev_name} down")
-      Run("ifdown #{dev_name}")
-    end
-
     # Calls wicked ifup with the given interface
     #
     # @param [String] name of interface to put down
     def SetIfaceUp(dev_name)
       log.info("Setting interface #{dev_name} up")
       Run("ifup #{dev_name}")
+    end
+
+    # Calls wicked ifdown with the given interface
+    #
+    # @param [String] name of interface to put down
+    def SetIfaceDown(dev_name)
+      log.info("Setting interface #{dev_name} down")
+      Run("ifdown #{dev_name}")
     end
 
     # Tries to set all interfaces up

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -711,22 +711,36 @@ module Yast
       end
     end
 
-    # Calls wicked ifup if it is the currenct backend, set the link up
-    # otherwise
+    # Wrapper to call 'ip link set up' with the given interface
     #
-    # @param [String] name of interface to put down
-    def SetIfaceUp(dev_name)
-      log.info("Setting interface #{dev_name} up")
-      Run("ifup #{dev_name} up")
+    # @param [String] name of interface to 'set link up'
+    def SetLinkUp(dev_name)
+      log.info("Setting link up for interface #{dev_name}")
+      Run("ip link set #{dev_name} up")
     end
 
-    # Calls wicked ifdown if it is the current backend, set the link down
-    # otherwise
+    # Wrapper to call 'ip link set down' with the given interface
+    #
+    # @param [String] name of interface to 'set link down'
+    def SetLinkDown(dev_name)
+      log.info("Setting link down for interface #{dev_name}")
+      Run("ip link set #{dev_name} down")
+    end
+
+    # Calls wicked ifdown with the given interface
     #
     # @param [String] name of interface to put down
     def SetIfaceDown(dev_name)
       log.info("Setting interface #{dev_name} down")
       Run("ifdown #{dev_name}")
+    end
+
+    # Calls wicked ifup with the given interface
+    #
+    # @param [String] name of interface to put down
+    def SetIfaceUp(dev_name)
+      log.info("Setting interface #{dev_name} up")
+      Run("ifup #{dev_name}")
     end
 
     # Tries to set all interfaces up
@@ -749,6 +763,28 @@ module Yast
       return false if interfaces.empty?
 
       interfaces.all? { |i| SetIfaceDown(i) }
+    end
+
+    # Tries to set up the link of all available interfaces
+    #
+    # @return [boolean] false if some of interfaces cannot be set up
+    def SetAllLinksUp
+      interfaces = GetAllInterfaces()
+
+      return false if interfaces.empty?
+
+      interfaces.all? { |i| SetLinkUp(i) }
+    end
+
+    # Tries to set the link down of all available interfaces
+    #
+    # @return [boolean] false if some of interfaces cannot be set down
+    def SetAllLinksDown
+      interfaces = GetAllInterfaces()
+
+      return false if interfaces.empty?
+
+      interfaces.all? { |i| SetLinkDown(i) }
     end
 
     # Checks if given device has carrier
@@ -789,8 +825,8 @@ module Yast
     def phy_connected?(dev_name)
       return true if has_carrier?(dev_name)
 
-      # SetIfaceUp ensures that driver is loaded
-      SetIfaceUp(dev_name)
+      # SetLinkUp ensures that driver is loaded
+      SetLinkUp(dev_name)
 
       # Wait for driver initialization if needed. bnc#876848
       # 5 secs is minimum proposed by sysconfig guys for intel drivers.

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -745,46 +745,62 @@ module Yast
 
     # Tries to set all interfaces up
     #
-    # @return [boolean] false if some of interfaces cannot be set up
+    # @return [boolean] false if interfaces are empty or some
+    # interface cannot be bring up
     def SetAllIfacesUp
+      all_up = true
       interfaces = GetAllInterfaces()
 
       return false if interfaces.empty?
 
-      interfaces.all? { |i| SetIfaceUp(i) }
+      interfaces.each { |i| all_up = false if !SetIfaceUp(i) }
+
+      all_up
     end
 
     # Tries to set all interfaces down
     #
-    # @return [boolean] false if some of interfaces cannot be set down
+    # @return [boolean] false if interfaces are empty or some
+    # interface cannot be bring down
     def SetAllIfacesDown
+      all_down = true
       interfaces = GetAllInterfaces()
 
       return false if interfaces.empty?
 
-      interfaces.all? { |i| SetIfaceDown(i) }
+      interfaces.each { |i| all_down = false if !SetIfaceDown(i) }
+
+      all_down
     end
 
     # Tries to set up the link of all available interfaces
     #
-    # @return [boolean] false if some of interfaces cannot be set up
+    # @return [boolean] false if interfaces are empty or some
+    # interface cannot be set up
     def SetAllLinksUp
+      all_up = true
       interfaces = GetAllInterfaces()
 
       return false if interfaces.empty?
 
-      interfaces.all? { |i| SetLinkUp(i) }
+      interfaces.each { |i| all_up = false if !SetLinkUp(i) }
+
+      all_up
     end
 
     # Tries to set the link down of all available interfaces
     #
-    # @return [boolean] false if some of interfaces cannot be set down
+    # @return [boolean] false if interfaces are empty or some
+    # interface cannot be set down
     def SetAllLinksDown
+      all_down = true
       interfaces = GetAllInterfaces()
 
       return false if interfaces.empty?
 
-      interfaces.all? { |i| SetLinkDown(i) }
+      interfaces.each { |i| all_down = false if !SetLinkDown(i) }
+
+      all_down
     end
 
     # Checks if given device has carrier


### PR DESCRIPTION
If an interface is not configured yet then if we try to bring it up with wicked and maybe with NetworkManager will complain. We have to set the link up and them will handle the event.