### PR TITLE
Improved adding routes

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Apr  3 08:27:26 UTC 2017 - mfilka@suse.com
+
+- bnc#927629
+  - improved adding routes. Accepts netmask or prefix length.
+  - fixed column name in add route dialog from Genmask to more
+    common Netmask
+- 3.2.23
+
+-------------------------------------------------------------------
 Thu Mar 30 13:52:36 WEST 2017 - knut.anderssen@suse.com
 
 - Fix typo in edit_nic_name dialog using bus_id instead of busid

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.2.22
+Version:        3.2.23
 Release:        0
 BuildArch:      noarch
 

--- a/src/include/network/lan/help.rb
+++ b/src/include/network/lan/help.rb
@@ -98,8 +98,12 @@ module Yast
                                ) +
                                  _(
                                    "<p>For each route, enter destination network IP address, gateway address,\n" \
-                                     "and netmask. To omit any of these values, use a dash sign \"-\". Select\n" \
-                                     "the device through which the traffic to the defined network will be routed.\"-\" is an alias for any interface.</p>\n"
+                                     "and netmask. You can use either IPv4 netmask or prefix length when defining\n" \
+                                     "network part of route. Prefix length has to be prefixed using '/'.\n" \
+                                     "To omit any of these values, use a dash sign \"-\". Select\n" \
+                                     "the device through which the traffic to the defined network will be routed.\"-\" is an alias for any interface.\n" \
+                                     "Please note that in case of IPv6 networks only prefix length is accepted\n" \
+                                     "for netmask definition.</p>\n"
                                  ) +
                                  # Routing dialog help 2/2
                                  _(

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -144,7 +144,7 @@ module Yast
       return true if Netmask.Check(netmask)
       return true if netmask.start_with?("/") && netmask[1..-1] =~ /\A\d+\z/
 
-      return false
+      false
     end
 
     # Route edit dialog

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -151,8 +151,9 @@ module Yast
       return false if netmask.nil? || netmask.empty?
       return true if Netmask.Check4(netmask)
 
-      prefix = netmask[1..-1].to_i
-      return true if netmask.start_with?("/") && prefix.between?(1, 128)
+      if netmask.start_with?("/")
+        return true if netmask[1..-1].to_i.between?(1, 128)
+      end
 
       false
     end
@@ -456,7 +457,7 @@ module Yast
       else
         # if it is netmask then long netmask is not supported for IPv6
         # if it is prefix length (CIDR), then prefix it has to be prefixed by '/'
-        raise ArgumentError, "Invalid netmask or prefix length"
+        raise ArgumentError, "Invalid netmask or prefix length: #{netmask}"
       end
 
       route["destination"] = "#{dest}/#{cidr}"

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -86,7 +86,7 @@ module Yast
                       # Table header 2/4
                       _("Gateway"),
                       # Table header 3/4
-                      _("Genmask"),
+                      _("Netmask"),
                       # Table header 4/4
                       _("Device"),
                       # Table header 5/4
@@ -168,7 +168,7 @@ module Yast
                   InputField(
                     Id(:genmask),
                     Opt(:hstretch),
-                    _("Ge&nmask"),
+                    _("&Netmask"),
                     Ops.get_string(entry, 3, "-")
                   ))
               ),

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -146,7 +146,7 @@ module Yast
     # prefix length. If prefix length is used it has to start with '/'.
     # For IPv6 network, only prefix length is allowed.
     #
-    # param [string] netmask or /<prefix length>
+    # @param [String] netmask or /<prefix length>
     def valid_netmask?(netmask)
       return false if netmask.nil? || netmask.empty?
       return true if Netmask.Check4(netmask)
@@ -438,14 +438,15 @@ module Yast
       false
     end
 
-    # Mangles route definition for storing in routes file
+    # Converts route definition for storing in routes file
     #
     # Basically netmask field is obsolete, so it converts
     # the record to use CIDR notation if netmask is defined.
     #
-    # For details see "man routes".
+    # @param route [Hash] see {RoutingClass#Routes}
+    # @return [Hash] where netmask is "-" (CIDR flavor)
     def convert_route_conf(route)
-      return route if route["netmask"].empty? || route["netmask"] == "-"
+      return route if route["netmask"] == "-"
 
       dest = route["destination"]
       netmask = route["netmask"]

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -140,8 +140,15 @@ module Yast
       }
     end
 
+    # Validates user's input obtained from Netmask field
+    #
+    # It currently allows to use netmask for IPv4 (e.g. 255.0.0.0) or
+    # prefix length. If prefix length is used it has to start with '/'.
+    # For IPv6 network, only prefix length is allowed.
+    #
+    # param [string] netmask or /<prefix length>
     def valid_netmask?(netmask)
-      return true if Netmask.Check(netmask)
+      return true if Netmask.Check4(netmask)
       return true if netmask.start_with?("/") && netmask[1..-1] =~ /\A\d+\z/
 
       false

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -148,8 +148,11 @@ module Yast
     #
     # param [string] netmask or /<prefix length>
     def valid_netmask?(netmask)
+      return false if netmask.nil? || netmask.empty?
       return true if Netmask.Check4(netmask)
-      return true if netmask.start_with?("/") && netmask[1..-1] =~ /\A\d+\z/
+
+      prefix = netmask[1..-1].to_i
+      return true if netmask.start_with?("/") && prefix.between?(1, 128)
 
       false
     end

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -425,13 +425,13 @@ module Yast
     end
 
     def storeRouting(_key, _event)
-      route_conf = Builtins.maplist(@r_items) do |e|
+      route_conf = @r_items.map do |route|
         {
-          "destination" => Ops.get_string(e, 1, ""),
-          "gateway"     => Ops.get_string(e, 2, ""),
-          "netmask"     => Ops.get_string(e, 3, ""),
-          "device"      => Ops.get_string(e, 4, ""),
-          "extrapara"   => Ops.get_string(e, 5, "")
+          "destination" => route[1].to_s,
+          "gateway"     => route[2].to_s,
+          "netmask"     => route[3].to_s,
+          "device"      => route[4].to_s,
+          "extrapara"   => route[5].to_s
         }
       end
 

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -140,6 +140,13 @@ module Yast
       }
     end
 
+    def valid_netmask?(netmask)
+      return true if Netmask.Check(netmask)
+      return true if netmask.start_with?("/") && netmask[1..-1] =~ /\A\d+\z/
+
+      return false
+    end
+
     # Route edit dialog
     # @param [Fixnum] id id of the edited route
     # @param [Yast::Term] entry edited entry
@@ -254,7 +261,7 @@ module Yast
         end
         route = Builtins.add(route, val)
         val = Convert.to_string(UI.QueryWidget(Id(:genmask), :Value))
-        if val != "-" && val != "0.0.0.0" && !Netmask.Check(val[1..-1])
+        if val != "-" && val != "0.0.0.0" && !valid_netmask?(val)
           # Popup::Error text
           Popup.Error(_("Subnetmask is invalid."))
           UI.SetFocus(Id(:genmask))

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -218,11 +218,8 @@ module Yast
         Ops.add(Ops.add(IP.ValidChars, "default"), "/-")
       )
       UI.ChangeWidget(Id(:gateway), :ValidChars, Ops.add(IP.ValidChars, "-"))
-      UI.ChangeWidget(
-        Id(:genmask),
-        :ValidChars,
-        Ops.add(Netmask.ValidChars, "-")
-      )
+      # user can enter IPv4 netmask or prefix length (has to start with '/')
+      UI.ChangeWidget(Id(:genmask), :ValidChars, Netmask.ValidChars + "-/")
 
       if entry == term(:empty)
         UI.SetFocus(Id(:destination))
@@ -234,7 +231,6 @@ module Yast
       route = nil
 
       loop do
-        route = nil
         ret = UI.UserInput
         break if ret != :ok
 
@@ -258,7 +254,7 @@ module Yast
         end
         route = Builtins.add(route, val)
         val = Convert.to_string(UI.QueryWidget(Id(:genmask), :Value))
-        if val != "-" && val != "0.0.0.0" && !Netmask.Check(val)
+        if val != "-" && val != "0.0.0.0" && !Netmask.Check(val[1..-1])
           # Popup::Error text
           Popup.Error(_("Subnetmask is invalid."))
           UI.SetFocus(Id(:genmask))

--- a/src/modules/Routing.rb
+++ b/src/modules/Routing.rb
@@ -220,7 +220,7 @@ module Yast
     def normalize_routes(routes)
       return routes if routes.nil? || routes.empty?
 
-      routes.map do |route|
+      deep_copy(routes).map do |route|
         subnet, prefix = route["destination"].split("/")
 
         if !prefix.nil?
@@ -230,8 +230,6 @@ module Yast
 
         route
       end
-
-      routes
     end
 
     # Read routing settings

--- a/src/modules/Routing.rb
+++ b/src/modules/Routing.rb
@@ -225,7 +225,7 @@ module Yast
 
         if !prefix.nil?
           route["destination"] = subnet
-          route["netmask"] = "/#{netmask}"
+          route["netmask"] = "/#{prefix}"
         end
 
         route

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -29,6 +29,7 @@ TESTS = \
   remote_test.rb \
   routines_test.rb \
   routing_test.rb \
+  routing_helpers_test.rb \
   s390_helpers_test.rb \
   suse_firewall_4_network_test.rb \
   udev_test.rb \

--- a/test/routing_helpers_test.rb
+++ b/test/routing_helpers_test.rb
@@ -16,9 +16,9 @@ describe "RoutingHelpers" do
   describe "#convert_route_conf" do
     let(:common_route_conf_part) do
       {
-        "gateway"     => "1.1.1.1",
-        "device"      => "-",
-        "extrapara"   => ""
+        "gateway"   => "1.1.1.1",
+        "device"    => "-",
+        "extrapara" => ""
       }
     end
     let(:correct_route_conf) do

--- a/test/routing_helpers_test.rb
+++ b/test/routing_helpers_test.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+require "yast"
+
+class RoutingHelpers
+  def initialize
+    Yast.include self, "network/services/routing.rb"
+  end
+end
+
+describe "RoutingHelpers" do
+  subject(:routing) { RoutingHelpers.new }
+
+  describe "#convert_route_conf" do
+    let(:common_route_conf_part) do
+      {
+        "gateway"     => "1.1.1.1",
+        "device"      => "-",
+        "extrapara"   => ""
+      }
+    end
+    let(:correct_route_conf) do
+      {
+        "destination" => "1.1.1.0/24",
+        "netmask"     => "-"
+      }.merge(common_route_conf_part)
+    end
+    let(:obsolete_route_conf) do
+      {
+        "destination" => "1.1.1.0",
+        "netmask"     => "255.255.255.0"
+      }.merge(common_route_conf_part)
+    end
+
+    it "does nothing when route conf uses CIDR notation" do
+      expect(routing.convert_route_conf(correct_route_conf)).to eql correct_route_conf
+    end
+
+    it "converts obsolete route conf to use CIDR notation" do
+      expect(routing.convert_route_conf(obsolete_route_conf)).to eql correct_route_conf
+    end
+  end
+end

--- a/test/routing_helpers_test.rb
+++ b/test/routing_helpers_test.rb
@@ -42,4 +42,40 @@ describe "RoutingHelpers" do
       expect(routing.convert_route_conf(obsolete_route_conf)).to eql correct_route_conf
     end
   end
+
+  describe "#valid_netmask?" do
+    it "accepts IPv4 netmask" do
+      expect(routing.valid_netmask?("255.0.0.0")).to be true
+    end
+
+    it "accepts IPv4 prefix" do
+      expect(routing.valid_netmask?("/24")).to be true
+    end
+
+    it "accepts IPv6 prefix" do
+      expect(routing.valid_netmask?("/128")).to be true
+    end
+
+    it "declines IPv6 netmask" do
+      expect(routing.valid_netmask?("fe00::")).to be false
+    end
+
+    it "declines nil or empty input" do
+      expect(routing.valid_netmask?("")).to be false
+      expect(routing.valid_netmask?(nil)).to be false
+    end
+
+    it "declines malformed prefix" do
+      expect(routing.valid_netmask?("/255/")).to be false
+      expect(routing.valid_netmask?("/255")).to be false
+      expect(routing.valid_netmask?("/-255")).to be false
+      expect(routing.valid_netmask?("/0")).to be false
+    end
+
+    it "declines malformed IPv4 netmask" do
+      expect(routing.valid_netmask?("/255.0.0.0")).to be false
+      expect(routing.valid_netmask?("255.0.255.0")).to be false
+      expect(routing.valid_netmask?("0.0.0.0")).to be false
+    end
+  end
 end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -268,4 +268,30 @@ describe Yast::Routing do
       end
     end
   end
+
+  describe "#normalize_routes" do
+    it "puts prefix length into netmask field when destination is in CIDR format" do
+      input_routes = [
+        {
+          "destination" => "1.1.1.1/24"
+        }
+      ]
+
+      result = Yast::Routing.normalize_routes(input_routes)
+
+      expect(result.first["destination"]).to eql "1.1.1.1"
+      expect(result.first["netmask"]).to eql "/24"
+    end
+
+    it "does nothing when netmask is used" do
+      input_routes = [
+        {
+          "destination" => "1.1.1.1",
+          "netmask"     => "255.0.0.0"
+        }
+      ]
+
+      expect(Yast::Routing.normalize_routes(input_routes)).to eql input_routes
+    end
+  end
 end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -228,7 +228,10 @@ describe Yast::Routing do
       { ip_forward_v4: "1", ip_forward_v6: "0" }
     ].freeze
 
-    MOCKED_ROUTES = [{ "1" => "r1" }, { "2" => "r2" }].freeze
+    MOCKED_ROUTES = [
+      { "destination" => "r1" },
+      { "destination" => "r2" }
+    ].freeze
 
     CONFIGS_OS.each do |config|
       ipv4 = config[:ip_forward_v4]


### PR DESCRIPTION
[bsc#927629](https://bugzilla.suse.com/show_bug.cgi?id=927629)  "yast lan does not allow IPv6 and CIDR subnet masks in static routes"
