### PR TITLE
Udev Rule: Use also the dev_port when bus_id match is in use (bsc#1007172)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Fri Nov 09 09:20:48 UTC 2016 - kanderssen@suse.com
+
+- When an interface is enslaved in a bond the udev rule is modified
+  using the bus_id instead of the mac address but some multiport
+  cards could use the same bus_id. In such cases also the dev_port
+  is needed. Taking this in account the dev_port will be added
+  always when a udev rule based on bus_id is written. (bsc#1007172)
+- 3.1.170.4
+
+-------------------------------------------------------------------
 Mon Oct 10 11:56:38 UTC 2016 - kanderssen@suse.com
 
 - Bridge handling has been improved (bsc#962824).

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.170.3
+Version:        3.1.170.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -47,6 +47,8 @@ Requires:       yast2-storage >= 2.21.11
 # Packages::vnc_packages
 BuildRequires:  yast2-packager >= 3.1.47
 Requires:       yast2-packager >= 3.1.47
+# BusID of all the cards with the same one (bsc#1007172)
+Requires:       hwinfo         >= 21.35
 
 # testsuite
 BuildRequires:  rubygem(rspec)

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -285,25 +285,6 @@ module Yast
       nil
     end
 
-    # Updates the udev rule of the current Lan Item, adding the dev_port and
-    # using the bus_id instead ot the mac address.
-    def use_udev_rule_for_bonding!
-      # Update or insert the dev_port if the sysfs dev_port attribute is present
-      LanItems.ReplaceItemUdev(
-        "ATTR{dev_port}",
-        "ATTR{dev_port}",
-        LanItems.dev_port(LanItems.GetCurrentName)
-      ) if LanItems.dev_port?(LanItems.GetCurrentName)
-
-      # Iff particular bond slave uses mac based persistency,
-      # overwrite to bus id based one. Don't touch otherwise.
-      LanItems.ReplaceItemUdev(
-        "ATTR{address}",
-        "KERNELS",
-        LanItems.getCurrentItem.fetch("hwinfo", {}).fetch("busid", "")
-      )
-    end
-
     # Automatically configures slaves when user enslaves them into a bond or bridge device
     def UpdateSlaves
       current = LanItems.current
@@ -328,7 +309,8 @@ module Yast
         case LanItems.GetDeviceType(current)
         when "bond"
           LanItems.startmode = "hotplug"
-          use_udev_rule_for_bonding!
+
+          LanItems.update_item_udev_rule!(:bus_id)
         when "br"
           LanItems.ipaddr = ""
         end
@@ -352,7 +334,7 @@ module Yast
     # into bond device and persistence based on bus id is required, then some configuration changes
     # are required in ifcfg and udev. It used to be needed to do it by hand before.
     def AutoUpdateOverview
-      # TODO: allow disabling. E.g. iff bus id based persistency is not requested.
+      # TODO: allow disabling. E.g. if bus id based persistency is not requested.
       UpdateSlaves()
 
       nil

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -832,6 +832,25 @@ module Yast
       !physical_port_id(dev_name).empty?
     end
 
+    # Dev port of of the given interface from /sys/class/net/$dev_name/dev_port
+    #
+    # @param [String] device name to check
+    # @return [String] dev port or an empty string if not
+    def dev_port(dev_name)
+      SCR.Read(
+        path(".target.string"),
+        "/sys/class/net/#{dev_name}/dev_port"
+      ).to_s.strip
+    end
+
+    # Checks if the given interface exports its dev port via sysfs
+    #
+    # @return [boolean] true if the dev port is not empty
+    # @see #physical_port_id
+    def dev_port?(dev_name)
+      !dev_port(dev_name).empty?
+    end
+
     # Checks if device is physically connected to a network
     #
     # It does neccessary steps which might be needed for proper initialization

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -832,7 +832,7 @@ module Yast
       !physical_port_id(dev_name).empty?
     end
 
-    # Dev port of of the given interface from /sys/class/net/$dev_name/dev_port
+    # Dev port of the given interface from /sys/class/net/$dev_name/dev_port
     #
     # @param [String] device name to check
     # @return [String] dev port or an empty string if not

--- a/src/lib/network/edit_nic_name.rb
+++ b/src/lib/network/edit_nic_name.rb
@@ -63,22 +63,11 @@ module Yast
           next
         end
 
-        current_rule = LanItems.GetItemUdevRule(LanItems.current)
+        udev_type = UI.QueryWidget(:udev_type, :CurrentButton)
 
-        if UI.QueryWidget(:udev_type, :CurrentButton) == :mac
-          rule_key = MAC_UDEV_ATTR
-          rule_value = @mac
-          LanItems.RemoveKeyFromUdevRule(current_rule, "ATTR{dev_port}")
-        else
-          rule_key = BUSID_UDEV_ATTR
-          rule_value = @bus_id
-          LanItems.ReplaceItemUdev("ATTR{dev_port}", "ATTR{dev_port}", dev_port(@old_name))
-        end
-
-        # update udev rules and other config
         # FIXME: it changes udev key used for device identification
         #  and / or its value only, name is changed elsewhere
-        LanItems.ReplaceItemUdev(@old_key, rule_key, rule_value)
+        LanItems.update_item_udev_rule!(udev_type)
       end
 
       close

--- a/src/lib/network/edit_nic_name.rb
+++ b/src/lib/network/edit_nic_name.rb
@@ -63,12 +63,16 @@ module Yast
           next
         end
 
+        current_rule = LanItems.GetItemUdevRule(LanItems.current)
+
         if UI.QueryWidget(:udev_type, :CurrentButton) == :mac
           rule_key = MAC_UDEV_ATTR
           rule_value = @mac
+          LanItems.RemoveKeyFromUdevRule(current_rule, "ATTR{dev_port}")
         else
           rule_key = BUSID_UDEV_ATTR
           rule_value = @bus_id
+          LanItems.ReplaceItemUdev("ATTR{dev_port}", "ATTR{dev_port}", dev_port(@old_name))
         end
 
         # update udev rules and other config

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -436,7 +436,7 @@ module Yast
     # same function to all the ports) (bsc#1007172)
     #
     # @param based_on [Symbol] principal key to be matched, `:mac` or `:bus_id`
-    # @return [Boolean] true if updated, false otherwise
+    # @return [void]
     def update_item_udev_rule!(based_on = :mac)
       case based_on
       when :mac
@@ -466,11 +466,8 @@ module Yast
           LanItems.getCurrentItem.fetch("hwinfo", {}).fetch("busid", "")
         )
       else
-        log.error("The key given for udev rule #{based_on} is not mac or bus_id.")
-        return false
+        raise ArgumentError, "The key given for udev rule #{based_on} is not supported"
       end
-
-      true
     end
 
     # It replaces a tuple identified by replace_key in current item's udev rule

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -413,6 +413,66 @@ module Yast
       udev_key_value(getUdevFallback, key)
     end
 
+    # It deletes the given key from the udev rule of the current item.
+    #
+    # @param key [string] udev key which identifies the tuple to be removed
+    # @return [Object, nil] the current item's udev rule without the given key; nil if
+    # there is not udev rules for the current item
+    def RemoveItemUdev(key)
+      current_rule = LanItems.GetItemUdevRule(LanItems.current)
+
+      return nil if current_rule.empty?
+
+      log.info("Removing #{key} from #{current_rule}")
+      Items()[@current]["udev"]["net"] =
+        LanItems.RemoveKeyFromUdevRule(current_rule, key)
+    end
+
+    # Updates the udev rule of the current Lan Item based on the key given
+    # which currently could be mac or bus_id.
+    #
+    # In case of bus_id the dev_port will be always added to avoid cases where
+    # the interfaces shared the same bus_id (i.e. Multiport cards using the
+    # same function to all the ports) (bsc#1007172)
+    #
+    # @param based_on [Symbol] principal key to be matched, `:mac` or `:bus_id`
+    # @return [Boolean] true if updated, false otherwise
+    def update_item_udev_rule!(based_on = :mac)
+      case based_on
+      when :mac
+        LanItems.RemoveItemUdev("ATTR{dev_port}")
+
+        # FIXME: While the user is able to modify the udev rule using the
+        # mac address instead of bus_id when bonding, could be that the
+        # mac in use was not the permanent one. We could read it with
+        # ethtool -P dev_name}
+        LanItems.ReplaceItemUdev(
+          "KERNELS",
+          "ATTR{address}",
+          LanItems.getCurrentItem.fetch("hwinfo", {}).fetch("mac", "")
+        )
+      when :bus_id
+        # Update or insert the dev_port if the sysfs dev_port attribute is present
+        LanItems.ReplaceItemUdev(
+          "ATTR{dev_port}",
+          "ATTR{dev_port}",
+          LanItems.dev_port(LanItems.GetCurrentName)
+        ) if LanItems.dev_port?(LanItems.GetCurrentName)
+
+        # If the current rule is mac based, overwrite to bus id. Don't touch otherwise.
+        LanItems.ReplaceItemUdev(
+          "ATTR{address}",
+          "KERNELS",
+          LanItems.getCurrentItem.fetch("hwinfo", {}).fetch("busid", "")
+        )
+      else
+        log.error("The key given for udev rule #{based_on} is not mac or bus_id.")
+        return false
+      end
+
+      true
+    end
+
     # It replaces a tuple identified by replace_key in current item's udev rule
     #
     # Note that the tuple is identified by key only. However modification flag is

--- a/test/complex_test.rb
+++ b/test/complex_test.rb
@@ -104,40 +104,4 @@ describe "NetworkLanComplexInclude" do
       expect(subject.DeviceProtocol(dhcp)).to eql("DHCP")
     end
   end
-
-  describe "#use_udev_rule_for_bonding!" do
-    before do
-      Yast::LanItems.current = 0
-      Yast::LanItems.Items = {
-        0 => {
-          "hwinfo" => {
-            "dev_name" => "test0",
-            "busid"    => "00:08:00"
-          },
-          "udev"   => {
-            "net" => ["ATTR{address}==\"01:02:03:04:05\"", "KERNEL==\"eth*\"", "NAME=\"test0\""]
-          }
-        }
-      }
-      allow(Yast::LanItems).to receive(:dev_port).and_return("0")
-    end
-
-    it "uses KERNELS attribute with busid match instead of mac address" do
-      allow(Yast::LanItems).to receive(:dev_port?).and_return(false)
-      expect(Yast::LanItems.Items[0]["udev"]["net"])
-        .to eql(["ATTR{address}==\"01:02:03:04:05\"", "KERNEL==\"eth*\"", "NAME=\"test0\""])
-      subject.use_udev_rule_for_bonding!
-      expect(Yast::LanItems.Items[0]["udev"]["net"])
-        .to eql(["KERNEL==\"eth*\"", "KERNELS==\"00:08:00\"", "NAME=\"test0\""])
-    end
-
-    it "adds the dev_port to the current rule if present in sysfs" do
-      allow(Yast::LanItems).to receive(:dev_port?).and_return(true)
-      expect(Yast::LanItems.Items[0]["udev"]["net"])
-        .to eql(["ATTR{address}==\"01:02:03:04:05\"", "KERNEL==\"eth*\"", "NAME=\"test0\""])
-      subject.use_udev_rule_for_bonding!
-      expect(Yast::LanItems.Items[0]["udev"]["net"])
-        .to eql(["KERNEL==\"eth*\"", "ATTR{dev_port}==\"0\"", "KERNELS==\"00:08:00\"", "NAME=\"test0\""])
-    end
-  end
 end

--- a/test/complex_test.rb
+++ b/test/complex_test.rb
@@ -104,4 +104,40 @@ describe "NetworkLanComplexInclude" do
       expect(subject.DeviceProtocol(dhcp)).to eql("DHCP")
     end
   end
+
+  describe "#use_udev_rule_for_bonding!" do
+    before do
+      Yast::LanItems.current = 0
+      Yast::LanItems.Items = {
+        0 => {
+          "hwinfo" => {
+            "dev_name" => "test0",
+            "busid"    => "00:08:00"
+          },
+          "udev"   => {
+            "net" => ["ATTR{address}==\"01:02:03:04:05\"", "KERNEL==\"eth*\"", "NAME=\"test0\""]
+          }
+        }
+      }
+      allow(Yast::LanItems).to receive(:dev_port).and_return("0")
+    end
+
+    it "uses KERNELS attribute with busid match instead of mac address" do
+      allow(Yast::LanItems).to receive(:dev_port?).and_return(false)
+      expect(Yast::LanItems.Items[0]["udev"]["net"])
+        .to eql(["ATTR{address}==\"01:02:03:04:05\"", "KERNEL==\"eth*\"", "NAME=\"test0\""])
+      subject.use_udev_rule_for_bonding!
+      expect(Yast::LanItems.Items[0]["udev"]["net"])
+        .to eql(["KERNEL==\"eth*\"", "KERNELS==\"00:08:00\"", "NAME=\"test0\""])
+    end
+
+    it "adds the dev_port to the current rule if present in sysfs" do
+      allow(Yast::LanItems).to receive(:dev_port?).and_return(true)
+      expect(Yast::LanItems.Items[0]["udev"]["net"])
+        .to eql(["ATTR{address}==\"01:02:03:04:05\"", "KERNEL==\"eth*\"", "NAME=\"test0\""])
+      subject.use_udev_rule_for_bonding!
+      expect(Yast::LanItems.Items[0]["udev"]["net"])
+        .to eql(["KERNEL==\"eth*\"", "ATTR{dev_port}==\"0\"", "KERNELS==\"00:08:00\"", "NAME=\"test0\""])
+    end
+  end
 end

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -199,8 +199,8 @@ describe "LanItems#RemoveItemUdev" do
 end
 
 describe "#update_item_udev_rule!" do
-  let(:hwinfo) { { "dev_name" => "test0", "busid" => "00:08:00", "mac" => "01:02:03:04:05" } }
-  let(:udev_net) { ["ATTR{address}==\"01:02:03:04:05\"", "KERNEL==\"eth*\"", "NAME=\"test0\""] }
+  let(:hwinfo) { { "dev_name" => "test0", "busid" => "0000:08:00.0", "mac" => "24:be:05:ce:1e:91" } }
+  let(:udev_net) { ["ATTR{address}==\"24:be:05:ce:1e:91\"", "KERNEL==\"eth*\"", "NAME=\"test0\""] }
   let(:rule) { { 0 => { "hwinfo" => hwinfo, "udev" => { "net" => udev_net } } } }
 
   before do
@@ -215,7 +215,7 @@ describe "#update_item_udev_rule!" do
       expect(Yast::LanItems.Items[0]["udev"]["net"]).to eql(udev_net)
       Yast::LanItems.update_item_udev_rule!(:bus_id)
       expect(Yast::LanItems.Items[0]["udev"]["net"])
-        .to eql(["KERNEL==\"eth*\"", "KERNELS==\"00:08:00\"", "NAME=\"test0\""])
+        .to eql(["KERNEL==\"eth*\"", "KERNELS==\"0000:08:00.0\"", "NAME=\"test0\""])
     end
 
     context "and the dev_port is available via sysfs" do
@@ -224,29 +224,29 @@ describe "#update_item_udev_rule!" do
         expect(Yast::LanItems.Items[0]["udev"]["net"]).to eql(udev_net)
         Yast::LanItems.update_item_udev_rule!(:bus_id)
         expect(Yast::LanItems.Items[0]["udev"]["net"])
-          .to eql(["KERNEL==\"eth*\"", "ATTR{dev_port}==\"0\"", "KERNELS==\"00:08:00\"", "NAME=\"test0\""])
+          .to eql(["KERNEL==\"eth*\"", "ATTR{dev_port}==\"0\"", "KERNELS==\"0000:08:00.0\"", "NAME=\"test0\""])
       end
     end
   end
 
   context "when the given rule key is :mac" do
-    let(:udev_net) { ["KERNEL==\"eth*\"", "KERNELS==\"00:08:00\"", "NAME=\"test0\""] }
+    let(:udev_net) { ["KERNEL==\"eth*\"", "KERNELS==\"0000:08:00.0\"", "NAME=\"test0\""] }
 
     it "uses mac attribute" do
       expect(Yast::LanItems.Items[0]["udev"]["net"]).to eql(udev_net)
       Yast::LanItems.update_item_udev_rule!(:mac)
       expect(Yast::LanItems.Items[0]["udev"]["net"])
-        .to eql(["KERNEL==\"eth*\"", "ATTR{address}==\"01:02:03:04:05\"", "NAME=\"test0\""])
+        .to eql(["KERNEL==\"eth*\"", "ATTR{address}==\"24:be:05:ce:1e:91\"", "NAME=\"test0\""])
     end
 
     context "and the current item has got a dev port" do
-      let(:udev_net) { ["KERNEL==\"eth*\"", "ATTR{dev_port}==\"0\"", "KERNELS==\"00:08:00\"", "NAME=\"test0\""] }
+      let(:udev_net) { ["KERNEL==\"eth*\"", "ATTR{dev_port}==\"0\"", "KERNELS==\"0000:08:00.0\"", "NAME=\"test0\""] }
 
       it "removes the dev_port from current rule if present" do
         expect(Yast::LanItems.Items[0]["udev"]["net"]).to eql(udev_net)
         Yast::LanItems.update_item_udev_rule!(:mac)
         expect(Yast::LanItems.Items[0]["udev"]["net"])
-          .to eql(["KERNEL==\"eth*\"", "ATTR{address}==\"01:02:03:04:05\"", "NAME=\"test0\""])
+          .to eql(["KERNEL==\"eth*\"", "ATTR{address}==\"24:be:05:ce:1e:91\"", "NAME=\"test0\""])
       end
     end
   end


### PR DESCRIPTION
When a interface is enslaved in a bond, then specially for easier card replacement the udev rule is modified using the bus_id instead of the mac address, but the bus_id could be not unique (multiport cards with one network function). In that cases also the dev_port should be used if it is exported via sysfs.

Here is the current systemd code which takes care of predictable network device names https://github.com/systemd/systemd/blob/master/src/udev/udev-builtin-net_id.c#L21 if you want to know more.

And also this blog post https://major.io/2015/08/21/understanding-systemds-predictable-network-device-names/ could be interesting to clarify the current situation as well as how systemd choose the current name: https://github.com/systemd/systemd/blob/master/src/udev/net/link-config.c#L413

**Note:** There was also a bug in hwinfo obtaining the bus_id only for the first interface using the same pci path, it has been fixed in this PR: https://github.com/openSUSE/hwinfo/pull/36. We now require at least `hwinfo-21.35`
