### PR TITLE
Obsolete code seems not to be used anymore.

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Nov 30 12:11:44 UTC 2016 - kanderssen@suse.com
+
+- Linuxrc does not export some variables anymore and handles the
+  configuration of network directly, for that reason, some methods
+  or reponsibilities of InstallInfConvertor class are not needed
+  being removed.
+
+-------------------------------------------------------------------
 Wed Nov 30 09:04:58 UTC 2016 - mfilka@suse.com
 
 - bnc#1012764

--- a/src/lib/network/install_inf_convertor.rb
+++ b/src/lib/network/install_inf_convertor.rb
@@ -36,7 +36,6 @@ module Yast
     end
 
     def write_netconfig
-      write_ifcfg(create_ifcfg)
       write_global_netconfig
     end
 
@@ -47,130 +46,16 @@ module Yast
 
   private
 
-    def create_ifcfg
-      ifcfg = ""
-
-      # set BOOTPROTO=[ static | dhcp ], linuxrc names it "NetConfig"
-      bootproto = InstallInf["NetConfig"]
-      case bootproto
-      when "static"
-        # add broadcast interface #suse49131
-        ifcfg << "BOOTPROTO='static'\n"
-        ifcfg << "IPADDR='#{InstallInf["IP"]}/#{Netmask.ToBits(InstallInf["Netmask"])}'\n"
-        ifcfg << "BROADCAST='#{InstallInf["Broadcast"]}'\n"
-
-        ip6_addr = InstallInf["IP6"]
-        if !ip6_addr.empty?
-          ifcfg << "LABEL_ipv6='ipv6'\n"
-          ifcfg << "IPADDR_ipv6='#{ip6_addr}'\n"
-        end
-
-      when "dhcp"
-        ifcfg << "BOOTPROTO='dhcp4'\n"
-
-      when "dhcp6"
-        ifcfg << "BOOTPROTO='dhcp6'\n"
-
-      when "dhcp,dhcp6"
-        ifcfg << "BOOTPROTO='dhcp'\n"
-      end
-
-      # set DHCP_SET_HOSTNAME=yes  #suse30528
-      if bootproto =~ /dhcp/
-        log.info("set DHCLIENT_SET_HOSTNAME=yes on installed system")
-        SCR.Execute(
-          BASH_PATH,
-          "sed -i s/\"DHCLIENT_SET_HOSTNAME=.*\"/'DHCLIENT_SET_HOSTNAME=\"yes\"'/g /etc/sysconfig/network/dhcp"
-        )
-      end
-
-      ifcfg << "STARTMODE='onboot'\n"
-
-      # wireless devices (bnc#223570)
-      ifcfg << create_wlan_ifcfg
-
-      # if available, write MTU
-      mtu = InstallInf["IP_MTU"]
-      ifcfg << "MTU='#{mtu}'\n" if !mtu.empty?
-
-      # for qeth devices (s390)
-      # bnc#578689 - YaST2 should not write the MAC address into ifcfg file
-      hardware = ReadHardware("netcard")
-      log.info("hardware: #{hardware}")
-
-      ifcfg << create_s390_ifcfg(hardware) if Arch.s390
-
-      # point to point interface
-      remote_ip = InstallInf["Pointopoint"]
-      ifcfg << "REMOTE_IPADDR='#{remote_ip}'\n" if !remote_ip.empty?
-
-      ifcfg << create_device_name_ifcfg(hardware)
-
-      log.info("Network Configuration:\n#{ifcfg}")
-
-      ifcfg
-    end
-
     # create all network files except ifcfg and hwcfg
     # directly to installed system
     def write_global_netconfig
       # create hostname
       write_hostname
 
-      if InstallInf["NetConfig"] == "static"
-        write_gateway
-
-        # write DHCPTimeout linuxrc parameter as /etc/sysconfig/network/config.WAIT_FOR_INTERFACES (bnc#396824)
-        write_dhcp_timeout
-
-        # create resolv.conf only for static configuration
-        write_dns
-      end
-
       # create proxy sysconfig file
       write_proxy
 
-      # create defaultdomain
-      write_nis_domain
-
-      # write wait_for_interfaces if needed
-      write_connect_wait
-
       nil
-    end
-
-    def write_dhcp_timeout
-      dhcp_timeout = InstallInf["DHCPTimeout"].to_s
-
-      return false if dhcp_timeout.empty?
-
-      log.info("Writing WAIT_FOR_INTERFACES=#{dhcp_timeout}")
-      SCR.Write(path(".sysconfig.network.config.WAIT_FOR_INTERFACES"), dhcp_timeout)
-    end
-
-    def write_gateway
-      gateway = InstallInf["Gateway"].to_s
-      ptp = InstallInf["Pointopoint"].to_s
-
-      # create routes file
-      if !gateway.empty?
-        log.info("Writing route : #{gateway}")
-        return SCR.Write(
-          path(".target.string"),
-          "/etc/sysconfig/network/routes",
-          "default #{gateway} - -\n"
-        )
-      elsif !ptp.empty?
-        log.info("Writing Peer-to-Peer route: #{ptp}")
-        return SCR.Write(
-          path(".target.string"),
-          "/etc/sysconfig/network/routes",
-          "default #{ptp} - -\n"
-        )
-      else
-        log.warn("No routing information in install.inf")
-        return false
-      end
     end
 
     def hostname
@@ -186,55 +71,6 @@ module Yast
 
       log.info("Write HOSTNAME: #{hostname}")
       SCR.Write(path(".target.string"), DNSClass::HOSTNAME_PATH, hostname)
-    end
-
-    def write_dns
-      nameserver = InstallInf["Nameserver"].to_s
-
-      return false if nameserver.empty?
-
-      # hostname is supposed to be FQDN (http://en.opensuse.org/Linuxrc)
-      # remember domain, use it as fallback below, if there is no DNS search
-      # domain (#476208)
-      split = Hostname.SplitFQ(hostname) if !hostname.empty? && !IP.Check(hostname)
-      fqdomain = ""
-      fqdomain = split[1].to_s if split
-
-      serverlist = nameserver
-      # write also secondary and third nameserver when available (bnc#446101)
-      nameserver2 = InstallInf["Nameserver2"].to_s
-      serverlist << " " << nameserver2 if !nameserver2.empty?
-
-      nameserver3 = InstallInf["Nameserver3"].to_s
-      serverlist << " " << nameserver3 if !nameserver3.empty?
-
-      # Do not write /etc/resolv.conf directly, feed the data to sysconfig instead,
-      # 'netconfig' will do the job later on network startup (FaTE #303618)
-      SCR.Write(
-        path(".sysconfig.network.config.NETCONFIG_DNS_STATIC_SERVERS"),
-        serverlist
-      )
-      log.info("Writing static nameserver entry: #{nameserver}")
-
-      # Enter search domain data only if present
-      domain = InstallInf["Domain"].to_s
-      if !domain.empty?
-        SCR.Write(
-          path(".sysconfig.network.config.NETCONFIG_DNS_STATIC_SEARCHLIST"),
-          domain
-        )
-        log.info("Writing static searchlist entry: #{domain}")
-      elsif !fqdomain.empty?
-        SCR.Write(
-          path(".sysconfig.network.config.NETCONFIG_DNS_STATIC_SEARCHLIST"),
-          fqdomain
-        )
-        log.info("No DNS search domain defined, using FQ domain name #{fqdomain} as a fallback")
-      end
-
-      # We're done. It is OK not to touch NETCONFIG_DNS_POLICY now as it is set to 'auto' by default
-      # and user did not have a chance to modify it up to now
-      SCR.Write(path(".sysconfig.network.config"), nil)
     end
 
     def write_proxy
@@ -263,139 +99,8 @@ module Yast
       Proxy.Write
     end
 
-    def write_nis_domain
-      nisdomain = InstallInf["NISDomain"].to_s
-
-      return false if nisdomain.empty? || !FileUtils.Exists("/etc/defaultdomain")
-
-      log.info("Write defaultdomain: #{nisdomain}")
-      SCR.Write(path(".target.string"), "/etc/defaultdomain", nisdomain)
-    end
-
-    def write_connect_wait
-      connect_wait = InstallInf["ConnectWait"].to_s
-
-      return false if connect_wait.empty?
-
-      ret = SCR.Execute(
-        BASH_PATH,
-        "sed -i s/^WAIT_FOR_INTERFACES=.*/WAIT_FOR_INTERFACES=#{connect_wait}/g /etc/sysconfig/network/config"
-      )
-
-      ret == 0
-    end
-
-    def dev_name
-      netdevice = InstallInf["Netdevice"].to_s
-
-      log.info("InstInstallInfClient#dev_name:#{netdevice}")
-
-      netdevice
-    end
-
     def stdout_of(command)
       SCR.Execute(path(".target.bash_output"), command)["stdout"].to_s
-    end
-
-    def create_wlan_ifcfg
-      wlan_key = InstallInf["WlanKey"]
-      wlan_essid = InstallInf["WlanESSID"]
-      wlan_key_type = InstallInf["WlanKeyType"]
-      wlan_auth = InstallInf["WlanAuth"]
-      wlan_key_len = InstallInf["WlanKeyLen"]
-
-      return "" if wlan_essid.empty?
-
-      ifcfg = "WIRELESS_ESSID='#{wlan_essid}'\n"
-
-      case wlan_auth
-      when "", "psk"
-        ifcfg << "WIRELESS_WPA_PSK='#{wlan_key}'\n"
-        ifcfg << "WIRELESS_AUTH_MODE='psk'\n"
-
-      when "open"
-        ifcfg << "WIRELESS_AUTH_MODE='no-encryption'\n"
-
-      when "wep_open", "wep_restricted"
-        type = if wlan_key_type == "password"
-          "h:"
-        elsif wlan_key_type == "ascii"
-          "s:"
-        else
-          wlan_key_type[0] + ":"
-        end
-
-        wlan_auth_mode = wlan_auth == "wep-open" ? "open" : "sharedkey"
-
-        ifcfg << "WIRELESS_AUTH_MODE='#{wlan_auth_mode}'\n"
-        ifcfg << "WIRELESS_DEFAULT_KEY='0'\n"
-        ifcfg << "WIRELESS_KEY_0='#{type}#{wlan_key}'\n"
-        ifcfg << "WIRELESS_KEY_LENGTH='#{wlan_key_len}'\n"
-      end
-
-      ifcfg
-    end
-
-    def create_s390_ifcfg(hardware)
-      hwaddr = InstallInf["OSAHWAddr"]
-      return "" if hwaddr.empty?
-
-      netdevice = dev_name
-      return "" if netdevice.empty?
-
-      devtype = NetworkInterfaces.GetType(netdevice)
-
-      log.info("Interface type: #{devtype}")
-
-      # only some card types need a persistent MAC (bnc#658708)
-      sysfs_id = dev_name_to_sysfs_id(netdevice, hardware)
-      return "" if !s390_device_needs_persistent_mac(sysfs_id, hardware)
-
-      # hsi devices do not support setting hwaddr (bnc #479481)
-      return "" if devtype == "hsi"
-
-      # set HW address only for qeth set to Layer 2 (bnc #479481)
-      return "" if devtype == "eth" && InstallInf["Layer2"] != "1"
-
-      "LLADDR='#{hwaddr}'\n"
-    end
-
-    def create_device_name_ifcfg(hardware)
-      device_name = dev_name
-
-      # authoritative sources of device name are:
-      # - hwinfo
-      # - install.inf
-      # nobody else was able to edit device name so far (so ifcfg["NAME"])
-      # is empty
-      hw_name = HardwareName(hardware, device_name)
-      hw_name = InstallInf["NetCardName"] || "" if hw_name.empty?
-
-      return "" if hw_name.empty?
-
-      # protect special characters, #305343
-      "NAME='#{String.Quote(hw_name)}'\n"
-    end
-
-    def write_ifcfg(ifcfg)
-      device_name = dev_name
-
-      return false if device_name.empty?
-
-      if !AllowUdevModify()
-        # bnc#821427: use same options as in /lib/udev/rules.d/71-biosdevname.rules
-        cmd = "biosdevname --policy physical --smbios 2.6 --nopirq -i #{dev_name}"
-        out = String.FirstChunk(stdout_of(cmd), "\n")
-        if !out.empty?
-          device_name = out
-          log.info("biosdevname renames #{dev_name} to #{device_name}")
-        end
-      end
-
-      dev_file = "/etc/sysconfig/network/ifcfg-#{device_name}"
-
-      log.info("ifcfg file: #{dev_file}")
-      SCR.Write(path(".target.string"), dev_file, ifcfg)
     end
   end
 end

--- a/test/install_inf_convertor_test.rb
+++ b/test/install_inf_convertor_test.rb
@@ -17,12 +17,6 @@ describe "InstallInfConvertor" do
           .at_least(:once) { nil }
     end
 
-    describe "#write_dhcp_timeout" do
-      it "returns false" do
-        expect(@install_inf_convertor.send(:write_dhcp_timeout)).to be false
-      end
-    end
-
     describe "#hostname" do
       it "returns empty string" do
         expect(@install_inf_convertor.send(:hostname)).to be_empty
@@ -35,52 +29,12 @@ describe "InstallInfConvertor" do
       end
     end
 
-    describe "#write_dns" do
-      it "returns false" do
-        expect(@install_inf_convertor.send(:write_dns)).to be false
-      end
-    end
-
     describe "#write_proxy" do
       it "returns false" do
         expect(@install_inf_convertor.send(:write_proxy)).to be false
       end
     end
 
-    describe "#write_nis_domain" do
-      it "returns false" do
-        expect(@install_inf_convertor.send(:write_nis_domain)).to be false
-      end
-    end
-
-    describe "#write_connect_wait" do
-      it "returns false" do
-        expect(@install_inf_convertor.send(:write_connect_wait)).to be false
-      end
-    end
-
-    describe "#dev_name" do
-      it "returns empty string" do
-        expect(@install_inf_convertor.send(:dev_name)).to be_empty
-      end
-
-      it "returns empty string even in autoinst mode" do
-        Yast.import "Mode"
-        allow(Yast::Mode).to receive(:autoinst) { true }
-
-        expect(@install_inf_convertor.send(:dev_name)).to be_empty
-      end
-    end
-
-    describe "#write_ifcfg" do
-      it "returns false when attempting to write nil content" do
-        expect(@install_inf_convertor.send(:write_ifcfg, nil)).to eql false
-      end
-
-      it "returns false even when written content is not nil" do
-        expect(@install_inf_convertor.send(:write_ifcfg, "STARTMODE='onboot'\n")).to eql false
-      end
-    end
   end
 
   context "linuxrc provides dhcp configuration" do
@@ -104,29 +58,6 @@ describe "InstallInfConvertor" do
           .with("NetCardName") { @netcardname }
     end
 
-    describe "#dev_name" do
-      it "returns expected device name" do
-        expect(@install_inf_convertor.send(:dev_name)).to eql @device
-      end
-    end
-
-    describe "#write_ifcfg" do
-      it "creates ifcfg file for #{@device}" do
-        expect(Yast::SCR)
-          .to receive(:Write)
-            .with(path(".target.string"), /.*-#{@device}/, "") { true }
-        expect(@install_inf_convertor.send(:write_ifcfg, "")).to eql true
-      end
-    end
-
-    describe "#create_ifcfg" do
-      it "creates a valid ifcfg for netconfig" do
-        expect(ifcfg = @install_inf_convertor.send(:create_ifcfg)).not_to be_empty
-        expect(ifcfg).to include "BOOTPROTO='dhcp4'"
-        expect(ifcfg).to include "STARTMODE='onboot'"
-        expect(ifcfg).to include "NAME='#{@netcardname}'"
-      end
-    end
   end
 
   context "linuxrc provides static configuration" do
@@ -160,38 +91,10 @@ describe "InstallInfConvertor" do
           .with("Nameserver") { @nameserver }
     end
 
-    describe "#create_ifcfg" do
-      it "creates a valid ifcfg for netconfig" do
-        expect(ifcfg = @install_inf_convertor.send(:create_ifcfg)).not_to be_empty
-        expect(ifcfg).to include "BOOTPROTO='static'"
-        expect(ifcfg).to include "IPADDR='#{@ip}\/#{Yast::Netmask.ToBits(@netmask)}'"
-      end
-    end
-
     describe "#write_global_netconfig" do
       it "writes all expected configuration" do
-        expect(@install_inf_convertor)
-          .to receive(:write_dns)
         expect(@install_inf_convertor.send(:write_global_netconfig))
           .to eql nil
-      end
-    end
-
-    describe "#write_dns" do
-      it "updates global netconfig file" do
-        expect(Yast::SCR)
-          .to receive(:Write)
-            .with(
-              path(".sysconfig.network.config"),
-              nil
-            ) { true }
-        expect(Yast::SCR)
-          .to receive(:Write)
-            .with(
-              path(".sysconfig.network.config.NETCONFIG_DNS_STATIC_SERVERS"),
-              @nameserver
-            ).once { true }
-        expect(@install_inf_convertor.send(:write_dns)).to eql true
       end
     end
   end
@@ -255,43 +158,6 @@ describe "InstallInfConvertor" do
       expect(Yast::Proxy).to receive(:Write).never
 
       expect(Yast::InstallInfConvertor.instance.send(:write_proxy)).to be false
-    end
-  end
-
-  context "running in system z/VM" do
-    it "writes hw address into ifcfg for Layer 2 aware qeth devices" do
-      HWADDR = "02:AA:BB:CC:DD:FF".freeze
-
-      allow(Yast::InstallInfConvertor::InstallInf)
-        .to receive(:[])
-        .with("Layer2")
-        .and_return("1")
-      allow(Yast::InstallInfConvertor::InstallInf)
-        .to receive(:[])
-        .with("Netdevice")
-        .and_return("eth1")
-      allow(Yast::InstallInfConvertor.instance)
-        .to receive(:s390_device_needs_persistent_mac)
-        .and_return(true)
-
-      expect(Yast::InstallInfConvertor::InstallInf)
-        .to receive(:[])
-        .with("OSAHWAddr")
-        .and_return(HWADDR)
-      expect(Yast::InstallInfConvertor.instance.send(:create_s390_ifcfg, nil).strip!)
-        .to eql "LLADDR='#{HWADDR}'"
-    end
-  end
-
-  describe "AllowUdevModify" do
-    it "reports if biosdevname was requested" do
-      allow(Yast::InstallInfConvertor::InstallInf)
-        .to receive(:[])
-        .with("Cmdline")
-        .and_return("splash=silent biosdevname=1")
-
-      expect(Yast::InstallInfConvertor.instance.AllowUdevModify)
-        .to be false
     end
   end
 end


### PR DESCRIPTION
During the documentation of installation and autoinstallation I realized that Linuxrc does not export some variables anymore handling the configuration of network directly and was mainly removed in this commit https://github.com/openSUSE/linuxrc/commits/c07386aedd4458c75753aa534242d49c3974c6cb.

This is the up to date documentation about the linuxrc yast interface (install.inf file):

https://github.com/openSUSE/linuxrc/blob/master/linuxrc_yast_interface.txt

where you can see that `Netconfig`, `Netdevice`... are not exported.