### PR TITLE
Backport vlan id parsing improvements (bsc#968692)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 20 07:14:38 UTC 2016 - kanderssen@suse.com
+
+- Improved parsing of vlan ids that are longer than one character.
+  Backport from SP2 (bsc#968692)
+- 3.1.140.10
+
+-------------------------------------------------------------------
 Thu Nov 17 16:00:48 UTC 2016 - kanderssen@suse.com
 
 - When an interface is enslaved in a bond the udev rule is modified

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.140.9
+Version:        3.1.140.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/network/lan/hardware.rb
+++ b/src/include/network/lan/hardware.rb
@@ -810,6 +810,8 @@ module Yast
       true
     end
 
+    VLAN_SIZE = 4 # size of vlanN prefix without number
+
     def storeHW(_key, _event)
       if isNewDevice
         nm = devname_from_hw_dialog
@@ -829,7 +831,7 @@ module Yast
         end
         if LanItems.type == "vlan"
           # for vlan devices named vlanN pre-set vlan_id to N, otherwise default to 0
-          LanItems.vlan_id = "#{nm["vlan".size].to_i}"
+          LanItems.vlan_id = nm[VLAN_SIZE..-1]
         end
       end
 


### PR DESCRIPTION
This changes were already added by @jreidinger and @ancorgs in these PRs:

https://github.com/yast/yast-network/pull/426
https://github.com/yast/yast-network/pull/427