### PR TITLE
[WIP] Create udev rule when not exist a previous one. (#996879)

### DIFF
--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -485,6 +485,9 @@ module Yast
     # @param new_val     [string] value for new key
     # @return updated rule when replace_key is found, current rule otherwise
     def ReplaceItemUdev(replace_key, new_key, new_val)
+      Items()[@current]["udev"] = { "net" => {} } if !Items()[@current]["udev"]
+      new = Items()[@current]["udev"]["net"].to_a.empty?
+
       # =    for assignment
       # ==   for equality checks
       operator = new_key == "NAME" ? "=" : "=="
@@ -498,12 +501,15 @@ module Yast
       new_rule = AddToUdevRule(rule, "#{new_key}#{operator}\"#{new_val}\"")
       new_rule.push(name_tuple)
 
-      log.info("ReplaceItemUdev: new udev rule = #{new_rule}")
-
-      if current_rule.sort != new_rule.sort
+      if new || current_rule.sort != new_rule.sort
         SetModified()
 
-        Items()[@current]["udev"] = { "net" => {} } if !Items()[@current]["udev"]
+        if new
+          log.info("Creating a new udev rule for #{LanItems.GetCurrentName}: #{rule}")
+        else
+          log.info("ReplaceItemUdev: new udev rule = #{new_rule}")
+        end
+
         Items()[@current]["udev"]["net"] = new_rule
       end
 


### PR DESCRIPTION
Tested an installation with the current fix successfully (the 70-persistent-net.rules file is created with the imported rules)