### PR TITLE
Create udev rule when not exist a previous one. (#996879)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 11 00:56:09 UTC 2017 - kanderssen@suse.com
+
+- Fixed the assignment of udev rules to Lan Items when a previous
+  one does not exist (bsc#996879).
+- 3.1.172
+
+-------------------------------------------------------------------
 Tue Nov 29 12:41:40 UTC 2016 - mfilka@suse.com
 
 - bnc#1012581

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.171
+Version:        3.1.172
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -485,6 +485,9 @@ module Yast
     # @param new_val     [string] value for new key
     # @return updated rule when replace_key is found, current rule otherwise
     def ReplaceItemUdev(replace_key, new_key, new_val)
+      Items()[@current]["udev"] = { "net" => {} } if !Items()[@current]["udev"]
+      new = Items()[@current]["udev"]["net"].to_a.empty?
+
       # =    for assignment
       # ==   for equality checks
       operator = new_key == "NAME" ? "=" : "=="
@@ -498,12 +501,15 @@ module Yast
       new_rule = AddToUdevRule(rule, "#{new_key}#{operator}\"#{new_val}\"")
       new_rule.push(name_tuple)
 
-      log.info("ReplaceItemUdev: new udev rule = #{new_rule}")
-
-      if current_rule.sort != new_rule.sort
+      if new || current_rule.sort != new_rule.sort
         SetModified()
 
-        Items()[@current]["udev"] = { "net" => {} } if !Items()[@current]["udev"]
+        if new
+          log.info("Creating a new udev rule for #{LanItems.GetCurrentName}: #{rule}")
+        else
+          log.info("ReplaceItemUdev: new udev rule = #{new_rule}")
+        end
+
         Items()[@current]["udev"]["net"] = new_rule
       end
 

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -485,13 +485,10 @@ module Yast
     # @param new_val     [string] value for new key
     # @return updated rule when replace_key is found, current rule otherwise
     def ReplaceItemUdev(replace_key, new_key, new_val)
-      Items()[@current]["udev"] = { "net" => [] } if !Items()[@current]["udev"]
-      new = Items()[@current]["udev"]["net"].to_a.empty?
-
       # =    for assignment
       # ==   for equality checks
       operator = new_key == "NAME" ? "=" : "=="
-      current_rule = getUdevFallback
+      current_rule = GetItemUdevRule(@current)
       rule = RemoveKeyFromUdevRule(getUdevFallback, replace_key)
 
       # NAME="devname" has to be last in the rule.
@@ -501,15 +498,12 @@ module Yast
       new_rule = AddToUdevRule(rule, "#{new_key}#{operator}\"#{new_val}\"")
       new_rule.push(name_tuple)
 
-      if new || current_rule.sort != new_rule.sort
+      if current_rule.sort != new_rule.sort
         SetModified()
 
-        if new
-          log.info("Creating a new udev rule for #{LanItems.GetCurrentName}: #{rule}")
-        else
-          log.info("ReplaceItemUdev: new udev rule = #{new_rule}")
-        end
+        log.info("ReplaceItemUdev: new udev rule = #{new_rule}")
 
+        Items()[@current]["udev"] = { "net" => [] } if !Items()[@current]["udev"]
         Items()[@current]["udev"]["net"] = new_rule
       end
 

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -485,7 +485,7 @@ module Yast
     # @param new_val     [string] value for new key
     # @return updated rule when replace_key is found, current rule otherwise
     def ReplaceItemUdev(replace_key, new_key, new_val)
-      Items()[@current]["udev"] = { "net" => {} } if !Items()[@current]["udev"]
+      Items()[@current]["udev"] = { "net" => [] } if !Items()[@current]["udev"]
       new = Items()[@current]["udev"]["net"].to_a.empty?
 
       # =    for assignment

--- a/test/udev_test.rb
+++ b/test/udev_test.rb
@@ -163,7 +163,7 @@ describe "LanItems#ReplaceItemUdev" do
       expect(Yast::LanItems.getCurrentItem["udev"]["net"]).to include "ATTR{address}==\"xx:01:02:03:04:05\""
     end
 
-    it "do not set modification flag in case of no change" do
+    it "does not set modification flag in case of no change" do
       allow(Yast::LanItems)
         .to receive(:getUdevFallback)
         .and_return(


### PR DESCRIPTION
During an installation some interfaces are ignored by the udev rules generator like KVM, VMWare and Hyper-V virtual interfaces as you can see here:

 http://git.kernel.org/cgit/linux/hotplug/udev.git/tree/src/rule_generator/75-persistent-net-generator.rules#n35

In that cases the current code does not assign correctly new udev rules for that interfaces and this PR solves that.

I tested an autoinstallation with VMWare mac addresses with and without renaming interfaces successfully.

