### PR TITLE
Added LanItems summary

### DIFF
--- a/src/lib/network/lan_items_summary.rb
+++ b/src/lib/network/lan_items_summary.rb
@@ -1,0 +1,132 @@
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+
+require "yast"
+
+module Yast
+  # This class creates a summary of the configured lan items supporting
+  # different types of summaries.
+  #
+  # @example
+  #   LanItemsSummary.new.summary
+  #   => "<ul><li><p>eth0<br>DHCP</p></li><li><p>eth1<br>NONE</p></li></ul>"
+  # @example
+  #   LanItemsSummary.new(:type => 'one_line').summary
+  #   => "Multiple Interfaces"
+  class LanItemsSummary
+    attr_accessor :summary_type, :options
+
+    def initialize(options = {})
+      Yast.import "LanItems"
+      Yast.import "Summary"
+
+      @summary_type =
+        case options[:type]
+        when "", nil
+          Default
+        when "one_line"
+          OneLine
+        else
+          raise NotImplementedError,
+            "The LanItems summary #{options[:type]} has not been implemented yet"
+        end
+      @options = options.reject { |k, _| k == :type }
+    end
+
+    # Delegates the summary to the specific class depending on the specific.
+    # Uses Default if no type is given.
+    def summary
+      @summary_type.send(:new, @options).summary
+    end
+
+    class Base
+      include I18n
+
+      attr_accessor :options
+
+      def initialize(options)
+        @options = options
+      end
+    end
+
+    # This class generates a one line text summary.
+    class OneLine < Base
+      def initialize(options = {})
+        @options = options
+      end
+
+      def summary
+        protocols  = []
+        configured = []
+        output     = []
+
+        Yast::LanItems.Items.each do |item, conf|
+          next if !LanItems.IsItemConfigured(item)
+
+          ifcfg = LanItems.GetDeviceMap(item) || {}
+
+          protocol = LanItems.DeviceProtocol(ifcfg)
+
+          protocols <<
+            if protocol =~ /DHCP/
+              "DHCP"
+            elsif IP.Check(protocol)
+              "STATIC"
+            else
+              LanItems.DeviceProtocol(ifcfg)
+            end
+
+          configured << conf["ifcfg"]
+        end
+
+        output << protocols.first if protocols.uniq.size == 1
+
+        case configured.size
+        when 0
+          _("Not configured yet.")
+        when 1
+          output << configured.first
+        else
+          output << "Multiple Interfaces"
+        end
+
+        output.join(" / ")
+      end
+    end
+
+    # This class is the default summary using RichText format
+    class Default < Base
+      def summary
+        items = []
+
+        LanItems.Items.each do |item, conf|
+          next if !Yast::LanItems.IsItemConfigured(item)
+
+          ifcfg = LanItems.GetDeviceMap(item) || {}
+          protocol = LanItems.DeviceProtocol(ifcfg)
+
+          items << Summary.Device(conf["ifcfg"], protocol)
+        end
+
+        Summary.DevicesList(items)
+      end
+    end
+  end
+end

--- a/src/lib/network/lan_items_summary.rb
+++ b/src/lib/network/lan_items_summary.rb
@@ -47,7 +47,6 @@ module Yast
         next if !Yast::LanItems.IsItemConfigured(item)
 
         ifcfg = LanItems.GetDeviceMap(item) || {}
-
         items << Summary.Device(conf["ifcfg"], ifcfg_protocol(ifcfg))
       end
 
@@ -56,7 +55,7 @@ module Yast
       Summary.DevicesList(items)
     end
 
-    # Generates a one line text summary showing the .
+    # Generates a one line text summary for the configured interfaces.
     #
     # @example with one configured interface
     #   LanItemsSummary.new.one_line
@@ -76,7 +75,6 @@ module Yast
         next if !LanItems.IsItemConfigured(item)
 
         ifcfg = LanItems.GetDeviceMap(item) || {}
-
         protocols << ifcfg_protocol(ifcfg)
 
         configured << conf["ifcfg"]
@@ -86,11 +84,12 @@ module Yast
 
       case configured.size
       when 0
-        return _("Not configured")
+        return Summary.NotConfigured
       when 1
         output << configured.join(", ")
       else
-        output << "Multiple Interfaces"
+        # TRANSLATORS: informs that multiple interfaces are configured
+        output << _("Multiple Interfaces")
       end
 
       output.join(" / ")

--- a/src/lib/network/lan_items_summary.rb
+++ b/src/lib/network/lan_items_summary.rb
@@ -1,22 +1,23 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
 #
-# All Rights Reserved.
 #
-# This program is free software; you can redistribute it and/or modify it
-# under the terms of version 2 of the GNU General Public License as published
-# by the Free Software Foundation.
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
 #
 # This program is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-# more details.
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, contact SUSE LLC.
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
 #
-# To contact SUSE LLC about this file by physical or electronic mail, you may
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
 
 require "yast"
 

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -1374,8 +1374,8 @@ module Yast
     # @see LanItemsSummary
     # @param options [Hash] summary options
     # @return [String] summary of the configured items
-    def summary(options = {})
-      LanItemsSummary.new(options).summary
+    def summary(type = "default")
+      LanItemsSummary.new.send(type)
     end
 
     # Creates details for device's overview based on ip configuration type

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -25,6 +25,7 @@ require "yast"
 require "yaml"
 require "network/install_inf_convertor"
 require "network/wicked"
+require "network/lan_items_summary"
 
 module Yast
   # Does way too many things.
@@ -1364,6 +1365,17 @@ module Yast
       startmode_descr = startmode_descrs[ifcfg["STARTMODE"].to_s] || _("Started manually")
 
       [startmode_descr]
+    end
+
+    # Creates a summary of the configured items.
+    #
+    # It supports differents types of summaries depending on the options[:type]
+    #
+    # @see LanItemsSummary
+    # @param options [Hash] summary options
+    # @return [String] summary of the configured items
+    def summary(options = {})
+      LanItemsSummary.new(options).summary
     end
 
     # Creates details for device's overview based on ip configuration type

--- a/test/lan_items_summary_test.rb
+++ b/test/lan_items_summary_test.rb
@@ -1,0 +1,91 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+require "network/lan_items_summary"
+
+Yast.import "LanItems"
+
+describe Yast::LanItemsSummary do
+  let(:dhcp_maps) do
+    [
+      { "BOOTPROTO" => "dhcp" },
+      { "BOOTPROTO" => "none" },
+      { "IPADDR" => "1.2.3.4", "NETMASK" => "255.255.255.0" }
+    ].freeze
+  end
+
+  let(:items) do
+    {
+      0 => { "ifcfg" => "eth0" },
+      1 => { "ifcfg" => "eth1" },
+      2 => { "ifcfg" => "br0" }
+    }
+  end
+  let(:no_interfaces) { _("Not configured") }
+
+  before do
+    allow(Yast::LanItems).to receive(:Items).and_return(items)
+    allow(Yast::LanItems).to receive(:IsItemConfigured).and_return(true)
+    dhcp_maps.each_with_index do |item, index|
+      allow(Yast::LanItems).to receive(:GetDeviceMap).with(index).and_return(item)
+    end
+  end
+
+  describe "#default" do
+    it "retuns a Richtext summary of the configured interfaces" do
+      expect(subject.default)
+        .to eql "<ul>" \
+                "<li><p>eth0<br>DHCP</p></li>" \
+                "<li><p>eth1<br>NONE</p></li>" \
+                "<li><p>br0<br>STATIC</p></li>" \
+                "</ul>"
+    end
+
+    it "returns Summary.NotConfigured in case of not configured interfaces" do
+      allow(Yast::LanItems).to receive(:IsItemConfigured).and_return(false)
+
+      expect(subject.default).to eql Yast::Summary.NotConfigured
+    end
+  end
+
+  describe "#one_line" do
+    it "returns a plain text summary of the configured interfaces in one line" do
+      expect(subject.one_line).to eql "Multiple Interfaces"
+    end
+
+    context "when there are no configured interfaces" do
+      let(:items) { {} }
+      it "returns 'Not configured'" do
+        expect(subject.one_line).to eql(no_interfaces)
+      end
+    end
+
+    context "when there is only one configured interface" do
+      let(:items) { { 0 => { "ifcfg" => "eth0" } } }
+
+      it "returns the interface bootproto and interface name" do
+        expect(subject.one_line).to eql "DHCP / eth0"
+      end
+    end
+
+    context "when there are multiple interfaces" do
+      let(:items) { { 0 => { "ifcfg" => "eth0" }, 1 => { "ifcfg" => "eth1" } } }
+
+      context "sharing the same bootproto" do
+        let(:dhcp_maps) { [{ "BOOTPROTO" => "dhcp" }, { "BOOTPROTO" => "dhcp" }] }
+
+        it "returns the bootproto and 'Multiple Interfaces'" do
+          expect(subject.one_line).to eql "DHCP / Multiple Interfaces"
+        end
+      end
+
+      context "with different bootproto" do
+        let(:dhcp_maps) { [{ "BOOTPROTO" => "DHCP" }, { "IPADDR" => "1.2.3.4" }] }
+
+        it "returns 'Multiple Interfaces'" do
+          expect(subject.one_line).to eql "Multiple Interfaces"
+        end
+      end
+    end
+  end
+end

--- a/test/lan_items_summary_test.rb
+++ b/test/lan_items_summary_test.rb
@@ -6,6 +6,8 @@ require "network/lan_items_summary"
 Yast.import "LanItems"
 
 describe Yast::LanItemsSummary do
+  MULTIPLE_INTERFACES = N_("Multiple Interfaces")
+
   let(:dhcp_maps) do
     [
       { "BOOTPROTO" => "dhcp" },
@@ -19,9 +21,8 @@ describe Yast::LanItemsSummary do
       0 => { "ifcfg" => "eth0" },
       1 => { "ifcfg" => "eth1" },
       2 => { "ifcfg" => "br0" }
-    }
+    }.freeze
   end
-  let(:no_interfaces) { _("Not configured") }
 
   before do
     allow(Yast::LanItems).to receive(:Items).and_return(items)
@@ -32,7 +33,7 @@ describe Yast::LanItemsSummary do
   end
 
   describe "#default" do
-    it "retuns a Richtext summary of the configured interfaces" do
+    it "returns a Richtext summary of the configured interfaces" do
       expect(subject.default)
         .to eql "<ul>" \
                 "<li><p>eth0<br>DHCP</p></li>" \
@@ -50,13 +51,13 @@ describe Yast::LanItemsSummary do
 
   describe "#one_line" do
     it "returns a plain text summary of the configured interfaces in one line" do
-      expect(subject.one_line).to eql "Multiple Interfaces"
+      expect(subject.one_line).to eql(MULTIPLE_INTERFACES)
     end
 
     context "when there are no configured interfaces" do
       let(:items) { {} }
-      it "returns 'Not configured'" do
-        expect(subject.one_line).to eql(no_interfaces)
+      it "returns Summary.NotConfigured" do
+        expect(subject.one_line).to eql(Yast::Summary.NotConfigured)
       end
     end
 
@@ -75,7 +76,7 @@ describe Yast::LanItemsSummary do
         let(:dhcp_maps) { [{ "BOOTPROTO" => "dhcp" }, { "BOOTPROTO" => "dhcp" }] }
 
         it "returns the bootproto and 'Multiple Interfaces'" do
-          expect(subject.one_line).to eql "DHCP / Multiple Interfaces"
+          expect(subject.one_line).to eql("DHCP / #{MULTIPLE_INTERFACES}")
         end
       end
 
@@ -83,7 +84,7 @@ describe Yast::LanItemsSummary do
         let(:dhcp_maps) { [{ "BOOTPROTO" => "DHCP" }, { "IPADDR" => "1.2.3.4" }] }
 
         it "returns 'Multiple Interfaces'" do
-          expect(subject.one_line).to eql "Multiple Interfaces"
+          expect(subject.one_line).to eql(MULTIPLE_INTERFACES)
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,9 +5,14 @@ ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
 require "yast"
 require "yast/rspec"
 
+# Ensure the tests runs with english locales
+ENV["LC_ALL"] = "en_US.UTF-8"
+
 require_relative "SCRStub"
 
 RSpec.configure do |c|
+  c.extend Yast::I18n # available in context/describe
+  c.include Yast::I18n
   c.include SCRStub
 end
 


### PR DESCRIPTION
This is just the firs request for comments, I could make it simpler if needed or if we consider it as over-engineering.

I decided to use the LanItems.summary but permitting to used different types of summaries being the Default based on Summary class as it is in others networks modules like:

https://github.com/yast/yast-network/blob/master/src/modules/Host.rb#L263
https://github.com/yast/yast-network/blob/master/src/modules/DNS.rb#L532
https://github.com/yast/yast-network/blob/master/src/modules/DNS.rb#L532

So for CASP one click dialog we could use:


 `Yast::LanItems.summary("one_line")`
or
`Yast::LanItemsSummary.new.one_line`

> === OLD ===
> 
>  `Yast::LanItems.summary(:type => "one_line")`
> or
> `Yast::LanItemsSummary.new(:type => "one_line").summary`
> or
>   `Yast::LanItemsSummary::OneLine.new.summary`
> 

And in case of a proposal in the future just `Yast::LanItems.summary`

Here screenshots with the current CASP one dialog overview: yast/yast-installation#487

### With one interface configured 
![networkoneinterface](https://cloud.githubusercontent.com/assets/7056681/22017336/d5f930ee-dca1-11e6-9b3d-3dfdf6b8de3a.png)

### With multiple interfaces and different bootproto
![networkmultipleinterfaces](https://cloud.githubusercontent.com/assets/7056681/22017100/bd57b0ac-dca0-11e6-8fd6-9ae09dd3ffec.png)
