### PR TITLE
Added network proposal for CASP (Fate#322328)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan 19 15:22:03 UTC 2017 - kanderssen@suse.com
+
+- Added network proposal using the new summary api and the new
+  proposal_client flag 'label_proposal' for CASP special formmating
+  (fate#322328).
+- 3.1.173.1
+
+-------------------------------------------------------------------
 Wed Jan 18 07:54:01 UTC 2017 - kanderssen@suse.com
 
 - Added summaries for the configured interfaces, particulary an one

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.173
+Version:        3.1.174
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/network_proposal.rb
+++ b/src/clients/network_proposal.rb
@@ -1,0 +1,2 @@
+require "network/clients/network_proposal"
+Yast::NetworkProposal.run

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -14,8 +14,6 @@ module Yast
       textdomain "installation"
     end
 
-  protected
-
     def description
       {
         "rich_text_title" => _("Network Configuration"),

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -1,0 +1,49 @@
+require "installation/proposal_client"
+
+module Yast
+  # Proposal client for Network configuration
+  class NetworkProposal < ::Installation::ProposalClient
+    include Yast::I18n
+    include Yast::Logger
+
+    def initialize
+      Yast.import "UI"
+      Yast.import "Lan"
+      Yast.import "LanItems"
+
+      textdomain "installation"
+    end
+
+  protected
+
+    def description
+      {
+        "rich_text_title" => _("Network Configuration"),
+        "menu_title"      => _("Network Configuration"),
+        "id"              => "network"
+      }
+    end
+
+    def make_proposal(_)
+      {
+        "preformatted_proposal" => Yast::Lan.Summary("summary"),
+        "label_proposal"        => [Yast::LanItems.summary("one_line")]
+      }
+    end
+
+    def ask_user(args)
+      log.info "Launching network configuration"
+      begin
+        Yast::Wizard.OpenAcceptDialog
+
+        result = Yast::WFM.CallFunction("inst_lan", [args.merge("skip_detection" => true)])
+
+        log.info "Returning from the network configuration with: #{result}"
+      ensure
+        Yast::Wizard.CloseDialog
+      end
+
+      { "workflow_sequence" => result }
+    end
+  end
+end

--- a/test/network_proposal_test.rb
+++ b/test/network_proposal_test.rb
@@ -1,0 +1,64 @@
+require_relative "test_helper"
+
+require "network/clients/network_proposal"
+
+class DummyLanItems
+  def summary(params)
+    params == "one_line" ? "one line summary" : "rich_text_summary"
+  end
+end
+
+class DummyLan
+  def Summary(_)
+    ["rich_text_summary"]
+  end
+end
+
+describe Yast::NetworkProposal do
+  subject { Yast::NetworkProposal.new }
+
+  let(:lan_items_mock) { DummyLanItems.new }
+  let(:lan_mock) { DummyLan.new }
+
+  before do
+    stub_const("Yast::LanItems", lan_items_mock)
+    stub_const("Yast::Lan", lan_mock)
+  end
+
+  describe "#description" do
+    it "returns a map with id, menu_title and rich_text_title " do
+      expect(subject.description).to include("id", "menu_title", "rich_text_title")
+    end
+  end
+
+  describe "#make_proposal" do
+    it "returns a map with 'label_proposal' as an array with one line summary'" do
+      expect(subject.make_proposal({})["label_proposal"]).to eql(["one line summary"])
+    end
+
+    it "returns a map with 'preformatted_proposal' as an array with the network summary'" do
+      expect(subject.make_proposal({})["preformatted_proposal"]).to eql(["rich_text_summary"])
+    end
+  end
+
+  describe "#ask_user" do
+    Yast.import "Wizard"
+
+    before do
+      allow(Yast::Wizard)
+    end
+
+    it "launchs the inst_lan client forcing the manual configuration" do
+      expect(Yast::WFM).to receive(:CallFunction).with("inst_lan", [{ "skip_detection" => true }])
+      subject.ask_user({})
+    end
+
+    it "returns a map with 'workflow_sequence' as the result of the client output" do
+      allow(Yast::WFM).to receive(:CallFunction)
+        .with("inst_lan", [{ "skip_detection" => true }])
+        .and_return("result")
+
+      expect(subject.ask_user({})).to eql("workflow_sequence" => "result")
+    end
+  end
+end


### PR DESCRIPTION
- https://trello.com/c/XDgl2dj7/816-13-casp-new-all-in-one-dialog
- Main PR: https://github.com/yast/yast-installation/pull/487

Uses the new summary API added in #489 and uses the new proposal_client flag ["label_proposal"] introduced in yast-yast2#530