### PR TITLE
Not use submit_to until yast-rake was updated (#492)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,10 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :casp10
-
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/
+  conf.obs_api = "https://api.suse.de/"
+  conf.obs_target = "CASP_1.0"
+  conf.obs_sr_project = "SUSE:SLE-12-SP2:Update:Products:CASP10"
+  conf.obs_project = "Devel:YaST:CASP:1.0"
 end


### PR DESCRIPTION
The current version of yast-rake hasn't got casp10 target, we must update yast-rake in SLE12 SP2 or at least in CASP.