### PR TITLE
Backport dhcp hostnames fixes from #477 (bnc#1013605)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,8 @@
 require "yast/rake"
 
+Yast::Tasks.submit_to :casp10
+
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/
-  conf.obs_api = "https://api.suse.de/"
-  conf.obs_target = "CASP_1.0"
-  conf.obs_sr_project = "SUSE:SLE-12-SP2:Update:Products:CASP10"
-  conf.obs_project = "Devel:YaST:CASP:1.0"
 end

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jan 24 15:38:14 UTC 2017 - kanderssen@suse.com
+
+- Backport fix for bnc#1013605
+  - Enable DHCP_HOSTNAME listbox only when wicked service is used.
+  - Fixed displaying the "keep current settings" option.
+- 3.1.173.2
+
+-------------------------------------------------------------------
 Thu Jan 19 15:22:03 UTC 2017 - kanderssen@suse.com
 
 - Added network proposal using the new summary api and the new

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.173.1
+Version:        3.1.173.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -45,6 +45,7 @@ module Yast
       Yast.import "LanItems"
       Yast.import "Popup"
       Yast.import "Map"
+      Yast.import "NetworkService"
 
       Yast.include include_target, "network/routines.rb"
       Yast.include include_target, "network/widgets.rb"
@@ -420,7 +421,7 @@ module Yast
 
     # Init handler for DHCP_HOSTNAME
     def InitDhcpHostname(_key)
-      UI.ChangeWidget(Id("DHCP_HOSTNAME"), :Enabled, has_dhcp?)
+      UI.ChangeWidget(Id("DHCP_HOSTNAME"), :Enabled, has_dhcp? && NetworkService.is_wicked)
 
       hostname_ifaces = LanItems.find_set_hostname_ifaces
       selected = DNS.dhcp_hostname ? ANY_LABEL : NONE_LABEL
@@ -430,7 +431,7 @@ module Yast
         fix_dhclient_warning(LanItems.invalid_dhcp_cfgs)
 
         selected = NO_CHANGE_LABEL
-        items << [Item(Id(NO_CHANGE_LABEL), _("keep current settings"), true)]
+        items << Item(Id(NO_CHANGE_LABEL), _("keep current settings"), true)
       elsif hostname_ifaces.size == 1
         selected = hostname_ifaces.first
       end

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2499,8 +2499,12 @@ module Yast
 
     # Removes DHCLIENT_SET_HOSTNAME from all ifcfgs
     #
-    # @return [void]
+    # @return [Array<String>] list of names of cleared devices
     def clear_set_hostname
+      log.info("Clearing DHCLIENT_SET_HOSTNAME flag from device configs")
+
+      ret = []
+
       GetNetcardInterfaces().each do |item_id|
         dev_map = GetDeviceMap(item_id)
         next if dev_map.nil? || dev_map.empty?
@@ -2510,7 +2514,13 @@ module Yast
 
         SetDeviceMap(item_id, dev_map)
         SetModified()
+
+        ret << GetDeviceName(item_id)
       end
+
+      log.info("#{ret.inspect} use default DHCLIENT_SET_HOSTNAME")
+
+      ret
     end
 
     # This helper allows YARD to extract DSL-defined attributes.

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -286,6 +286,10 @@ describe "DHCLIENT_SET_HOSTNAME helpers" do
         .to receive(:GetDeviceMap)
         .with(index)
         .and_return(dev_maps[item_map["ifcfg"]])
+      allow(Yast::LanItems)
+        .to receive(:GetDeviceName)
+        .with(index)
+        .and_return(item_map["ifcfg"])
     end
   end
 
@@ -360,9 +364,13 @@ describe "DHCLIENT_SET_HOSTNAME helpers" do
         "eth1" => { "DHCLIENT_SET_HOSTNAME" => "no" }
       }.freeze
     end
+    let(:no_dhclient_maps) do
+      { "eth6" => { "BOOT" => "dhcp" } }.freeze
+    end
 
     it "clears all DHCLIENT_SET_HOSTNAME options" do
-      mock_items(dhcp_yes_maps.merge(dhcp_no_maps))
+      dhclient_maps = dhcp_yes_maps.merge(dhcp_no_maps)
+      mock_items(dhclient_maps.merge(no_dhclient_maps))
 
       expect(Yast::LanItems)
         .to receive(:SetDeviceMap)
@@ -372,7 +380,9 @@ describe "DHCLIENT_SET_HOSTNAME helpers" do
         .to receive(:SetModified)
         .at_least(:once)
 
-      Yast::LanItems.clear_set_hostname
+      ret = Yast::LanItems.clear_set_hostname
+
+      expect(ret).to eql dhclient_maps.keys
     end
   end
 


### PR DESCRIPTION
Some fixes regarding to setting the hostname by dhcp were adding in yast/yast-network#461, and later also some fixes concerning linurxc but only in master yast/yast-network#477. This is the related trello card https://trello.com/c/pN6f3kzr.

So this PR will backport that fixes into CASP because linuxrc has been already updated with the changes of this PR: openSUSE/linuxrc#131.

That changes are not yet in SLE-12-SP2 so should wait until then.