### PR TITLE
Backport dhcp hostname fixes #477 and added network_proposal #491 (bnc#1013605)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     # disable rvm, use system Ruby
     - rvm reset
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-storage yast2-proxy yast2-country yast2-packager" -g "rspec:3.3.0 yast-rake gettext rubocop:0.41.2 simplecov:0.10.0 coveralls"
+    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-storage yast2-proxy yast2-country yast2-packager" -g "rspec:3.3.0 yast-rake gettext rubocop:0.41.2 simplecov:0.10.0 coveralls cheetah"
 script:
     - rubocop
     - rake check:syntax

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Jan 19 15:22:03 UTC 2017 - kanderssen@suse.com
+
+- Backported
+  - Added network proposal using the new summary api and the new
+    proposal_client flag 'label_proposal' for CASP special formmating
+    (fate#322328).
+- 3.1.174
+
+-------------------------------------------------------------------
 Wed Jan 18 07:54:01 UTC 2017 - kanderssen@suse.com
 
 - Added summaries for the configured interfaces, particulary an one

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.173
+Version:        3.1.174
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/network_proposal.rb
+++ b/src/clients/network_proposal.rb
@@ -1,0 +1,2 @@
+require "network/clients/network_proposal"
+Yast::NetworkProposal.run

--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -45,6 +45,7 @@ module Yast
       Yast.import "LanItems"
       Yast.import "Popup"
       Yast.import "Map"
+      Yast.import "NetworkService"
 
       Yast.include include_target, "network/routines.rb"
       Yast.include include_target, "network/widgets.rb"
@@ -420,7 +421,7 @@ module Yast
 
     # Init handler for DHCP_HOSTNAME
     def InitDhcpHostname(_key)
-      UI.ChangeWidget(Id("DHCP_HOSTNAME"), :Enabled, has_dhcp?)
+      UI.ChangeWidget(Id("DHCP_HOSTNAME"), :Enabled, has_dhcp? && NetworkService.is_wicked)
 
       hostname_ifaces = LanItems.find_set_hostname_ifaces
       selected = DNS.dhcp_hostname ? ANY_LABEL : NONE_LABEL
@@ -430,7 +431,7 @@ module Yast
         fix_dhclient_warning(LanItems.invalid_dhcp_cfgs)
 
         selected = NO_CHANGE_LABEL
-        items << [Item(Id(NO_CHANGE_LABEL), _("keep current settings"), true)]
+        items << Item(Id(NO_CHANGE_LABEL), _("keep current settings"), true)
       elsif hostname_ifaces.size == 1
         selected = hostname_ifaces.first
       end

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -14,8 +14,6 @@ module Yast
       textdomain "installation"
     end
 
-  protected
-
     def description
       {
         "rich_text_title" => _("Network Configuration"),

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -1,0 +1,49 @@
+require "installation/proposal_client"
+
+module Yast
+  # Proposal client for Network configuration
+  class NetworkProposal < ::Installation::ProposalClient
+    include Yast::I18n
+    include Yast::Logger
+
+    def initialize
+      Yast.import "UI"
+      Yast.import "Lan"
+      Yast.import "LanItems"
+
+      textdomain "installation"
+    end
+
+  protected
+
+    def description
+      {
+        "rich_text_title" => _("Network Configuration"),
+        "menu_title"      => _("Network Configuration"),
+        "id"              => "network"
+      }
+    end
+
+    def make_proposal(_)
+      {
+        "preformatted_proposal" => Yast::Lan.Summary("summary"),
+        "label_proposal"        => [Yast::LanItems.summary("one_line")]
+      }
+    end
+
+    def ask_user(args)
+      log.info "Launching network configuration"
+      begin
+        Yast::Wizard.OpenAcceptDialog
+
+        result = Yast::WFM.CallFunction("inst_lan", [args.merge("skip_detection" => true)])
+
+        log.info "Returning from the network configuration with: #{result}"
+      ensure
+        Yast::Wizard.CloseDialog
+      end
+
+      { "workflow_sequence" => result }
+    end
+  end
+end

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2499,8 +2499,12 @@ module Yast
 
     # Removes DHCLIENT_SET_HOSTNAME from all ifcfgs
     #
-    # @return [void]
+    # @return [Array<String>] list of names of cleared devices
     def clear_set_hostname
+      log.info("Clearing DHCLIENT_SET_HOSTNAME flag from device configs")
+
+      ret = []
+
       GetNetcardInterfaces().each do |item_id|
         dev_map = GetDeviceMap(item_id)
         next if dev_map.nil? || dev_map.empty?
@@ -2510,7 +2514,13 @@ module Yast
 
         SetDeviceMap(item_id, dev_map)
         SetModified()
+
+        ret << GetDeviceName(item_id)
       end
+
+      log.info("#{ret.inspect} use default DHCLIENT_SET_HOSTNAME")
+
+      ret
     end
 
     # This helper allows YARD to extract DSL-defined attributes.

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -286,6 +286,10 @@ describe "DHCLIENT_SET_HOSTNAME helpers" do
         .to receive(:GetDeviceMap)
         .with(index)
         .and_return(dev_maps[item_map["ifcfg"]])
+      allow(Yast::LanItems)
+        .to receive(:GetDeviceName)
+        .with(index)
+        .and_return(item_map["ifcfg"])
     end
   end
 
@@ -360,9 +364,13 @@ describe "DHCLIENT_SET_HOSTNAME helpers" do
         "eth1" => { "DHCLIENT_SET_HOSTNAME" => "no" }
       }.freeze
     end
+    let(:no_dhclient_maps) do
+      { "eth6" => { "BOOT" => "dhcp" } }.freeze
+    end
 
     it "clears all DHCLIENT_SET_HOSTNAME options" do
-      mock_items(dhcp_yes_maps.merge(dhcp_no_maps))
+      dhclient_maps = dhcp_yes_maps.merge(dhcp_no_maps)
+      mock_items(dhclient_maps.merge(no_dhclient_maps))
 
       expect(Yast::LanItems)
         .to receive(:SetDeviceMap)
@@ -372,7 +380,9 @@ describe "DHCLIENT_SET_HOSTNAME helpers" do
         .to receive(:SetModified)
         .at_least(:once)
 
-      Yast::LanItems.clear_set_hostname
+      ret = Yast::LanItems.clear_set_hostname
+
+      expect(ret).to eql dhclient_maps.keys
     end
   end
 

--- a/test/network_proposal_test.rb
+++ b/test/network_proposal_test.rb
@@ -1,0 +1,64 @@
+require_relative "test_helper"
+
+require "network/clients/network_proposal"
+
+class DummyLanItems
+  def summary(params)
+    params == "one_line" ? "one line summary" : "rich_text_summary"
+  end
+end
+
+class DummyLan
+  def Summary(_)
+    ["rich_text_summary"]
+  end
+end
+
+describe Yast::NetworkProposal do
+  subject { Yast::NetworkProposal.new }
+
+  let(:lan_items_mock) { DummyLanItems.new }
+  let(:lan_mock) { DummyLan.new }
+
+  before do
+    stub_const("Yast::LanItems", lan_items_mock)
+    stub_const("Yast::Lan", lan_mock)
+  end
+
+  describe "#description" do
+    it "returns a map with id, menu_title and rich_text_title " do
+      expect(subject.description).to include("id", "menu_title", "rich_text_title")
+    end
+  end
+
+  describe "#make_proposal" do
+    it "returns a map with 'label_proposal' as an array with one line summary'" do
+      expect(subject.make_proposal({})["label_proposal"]).to eql(["one line summary"])
+    end
+
+    it "returns a map with 'preformatted_proposal' as an array with the network summary'" do
+      expect(subject.make_proposal({})["preformatted_proposal"]).to eql(["rich_text_summary"])
+    end
+  end
+
+  describe "#ask_user" do
+    Yast.import "Wizard"
+
+    before do
+      allow(Yast::Wizard)
+    end
+
+    it "launchs the inst_lan client forcing the manual configuration" do
+      expect(Yast::WFM).to receive(:CallFunction).with("inst_lan", [{ "skip_detection" => true }])
+      subject.ask_user({})
+    end
+
+    it "returns a map with 'workflow_sequence' as the result of the client output" do
+      allow(Yast::WFM).to receive(:CallFunction)
+        .with("inst_lan", [{ "skip_detection" => true }])
+        .and_return("result")
+
+      expect(subject.ask_user({})).to eql("workflow_sequence" => "result")
+    end
+  end
+end


### PR DESCRIPTION
If you want to know more, you can check #495, so basically the dhcp hostname fixes added in #477 were backported to CASP and the network proposal added was added to CASP in #491.

Both PRs can also be backported to SP2 which means that we could not diverge yet.