### PR TITLE
Merge SLE-12-SP2 into 'SLE-12-SP2-CASP'

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -4,7 +4,7 @@ Tue Jan 24 15:38:14 UTC 2017 - kanderssen@suse.com
 - Backport fix for bnc#1013605
   - Enable DHCP_HOSTNAME listbox only when wicked service is used.
   - Fixed displaying the "keep current settings" option.
-- 3.1.173.2
+- 3.1.174
 
 -------------------------------------------------------------------
 Thu Jan 19 15:22:03 UTC 2017 - kanderssen@suse.com

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.173.2
+Version:        3.1.174
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Once network proposal has been also backported, diverge is not needed.