### PR TITLE
routing/firewall: no longer depend on SuSEfirewall2 for IPv4 forwarding

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,3 +1,13 @@
+Tue Apr  4 14:27:03 CEST 2017 - matthias.gerstner@suse.de
+
+- harmonized configuration of IPv4 and IPv6 forwarding. IPv4
+  forwarding was configured implicitly via SuSEfirewall2, if enabled. IPv6 was
+  enabled explicitly via sysctl. Now both cases are configured via sysctl.
+  SuSEfirewall will continue to function if the user configures FW_ROUTE=yes.
+  In the future SuSEfirewall2 will alter ip_forwarding only if it's not been
+  already enabled via yast/sysctl. See bsc#572202.
+- 3.2.23
+
 -------------------------------------------------------------------
 Thu Mar 30 13:52:36 WEST 2017 - knut.anderssen@suse.com
 

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.2.22
+Version:        3.2.23
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/Routing.rb
+++ b/src/modules/Routing.rb
@@ -145,12 +145,7 @@ module Yast
 
     # Reads current status for both IPv4 and IPv6 forwarding
     def ReadIPForwarding
-      @Forward_v4 = if SuSEFirewall.IsEnabled
-        SuSEFirewall.GetSupportRoute
-      else
-        SCR.Read(path(SYSCTL_IPV4_PATH)) == "1"
-      end
-
+      @Forward_v4 = SCR.Read(path(SYSCTL_IPV4_PATH)) == "1"
       @Forward_v6 = SCR.Read(path(SYSCTL_IPV6_PATH)) == "1"
 
       log.info("Forward_v4=#{@Forward_v4}")
@@ -165,15 +160,13 @@ module Yast
     def write_ipv4_forwarding(forward_ipv4)
       sysctl_val = forward_ipv4 ? "1" : "0"
 
-      if SuSEFirewall.IsEnabled
-        SuSEFirewall.SetSupportRoute(forward_ipv4)
-      else
-        SCR.Write(
-          path(SYSCTL_IPV4_PATH),
-          sysctl_val
-        )
-        SCR.Write(path(SYSCTL_AGENT_PATH), nil)
-      end
+      # No longer configure IPv4 forwarding via SuSEfirewall, but do it
+      # directly like with IPv6 (see bnc#572202)
+      SCR.Write(
+        path(SYSCTL_IPV4_PATH),
+        sysctl_val
+      )
+      SCR.Write(path(SYSCTL_AGENT_PATH), nil)
 
       SCR.Execute(path(".target.bash"), "sysctl -w #{IPV4_SYSCTL}=#{sysctl_val}")
 

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -28,7 +28,7 @@ describe Yast::Routing do
     # or not
     fw_enabled = [false, true]
     fw_enabled.each do |enabled|
-      context "when Firewall is %s" % [enabled ? "enabled" : "disabled"] do
+      context format("when Firewall is %s", enabled ? "enabled" : "disabled") do
         before(:each) do
           allow(Yast::SuSEFirewall).to receive(:IsEnabled) { enabled }
         end

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -23,41 +23,33 @@ describe Yast::Routing do
       allow(Yast::SCR).to receive(:Execute) { nil }
     end
 
-    context "when Firewall is enabled" do
-      before(:each) do
-        allow(Yast::SuSEFirewall).to receive(:IsEnabled) { true }
-      end
+    # yast should no longer be coupled to SuSEfirewall2, thus forwarding
+    # should be configured the same way regardless of firewall being enabled
+    # or not
+    fw_enabled = [false, true]
+    fw_enabled.each do |enabled|
+      context "when Firewall is %s" % [enabled ? "enabled" : "disabled"] do
+        before(:each) do
+          allow(Yast::SuSEFirewall).to receive(:IsEnabled) { enabled }
+        end
 
-      describe "#WriteIPForwarding" do
-        it "Delegates setup to SuSEFirewall2" do
-          expect(Yast::SuSEFirewall)
-            .to receive(:SetSupportRoute)
-            .with(forward_v4)
-
-          expect(Yast::Routing.WriteIPForwarding).to be_equal nil
+        describe "#WriteIPForwarding" do
+          it "Updates IPv4 and IPv6 forwarding in sysctl.conf" do
+            allow(Yast::SCR).to receive(:Write) { nil }
+            expect(Yast::SCR)
+              .to receive(:Write)
+              .with(SYSCTL_IPV4_PATH, @value4)
+            expect(Yast::SCR)
+              .to receive(:Write)
+              .with(SYSCTL_IPV6_PATH, @value6)
+            expect(Yast::Routing.WriteIPForwarding).to be_equal nil
+            expect(Yast::SuSEFirewall)
+              .not_to receive(:SetSupportRoute)
+          end
         end
       end
     end
 
-    context "when Firewall is disabled" do
-      before(:each) do
-        allow(Yast::SuSEFirewall).to receive(:IsEnabled) { false }
-      end
-
-      describe "#WriteIPForwarding" do
-        it "Updates IPv4 and IPv6 forwarding in sysctl.conf" do
-          allow(Yast::SCR).to receive(:Write) { nil }
-          expect(Yast::SCR)
-            .to receive(:Write)
-            .with(SYSCTL_IPV4_PATH, @value4)
-          expect(Yast::SCR)
-            .to receive(:Write)
-            .with(SYSCTL_IPV6_PATH, @value6)
-
-          expect(Yast::Routing.WriteIPForwarding).to be_equal nil
-        end
-      end
-    end
   end
 
   # Various contexts which mocks different setup sources follows.


### PR DESCRIPTION
IPv4 and IPv6 forwarding have been handled inconsistently, IPv4
forwarding being configured implicitly via SuSEfirewall2, if enabled.

To straighten out things yast should handle both cases IPV4 and IPv6 the
same, ignoring what SuSEfirewall2 does. SuSEfirewall2 routing will
continue to function if the user configures FW_ROUTE=yes. In the future
SuSEfirewall2 will fiddle with ip_forwarding only if it's not been
already enabled via yast/sysctl.

Also see bnc#572202.