### PR TITLE
Fix typo in edit_nic_name dialog (bsc#1031120)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 30 13:52:36 WEST 2017 - knut.anderssen@suse.com
+
+- Fix typo in edit_nic_name dialog using bus_id instead of busid
+  (bsc#1031120)
+- 3.1.140.11
+
+-------------------------------------------------------------------
 Tue Dec 20 07:14:38 UTC 2016 - kanderssen@suse.com
 
 - Improved parsing of vlan ids that are longer than one character.

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.140.10
+Version:        3.1.140.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/network/edit_nic_name.rb
+++ b/src/lib/network/edit_nic_name.rb
@@ -103,7 +103,7 @@ module Yast
                 ),
                 Left(
                   RadioButton(
-                    Id(:busid),
+                    Id(:bus_id),
                     _("BusID: %s") % @bus_id
                   )
                 )
@@ -122,7 +122,7 @@ module Yast
       when MAC_UDEV_ATTR
         UI.ChangeWidget(Id(:udev_type), :CurrentButton, :mac)
       when BUSID_UDEV_ATTR
-        UI.ChangeWidget(Id(:udev_type), :CurrentButton, :busid)
+        UI.ChangeWidget(Id(:udev_type), :CurrentButton, :bus_id)
       else
         Builtins.y2error("Unknown udev rule.")
       end


### PR DESCRIPTION
it is a typo reported for SP2 but affects since SP1 so I created it against SP1 and will merge then in SP2, CaaSP & SP3.

- https://bugzilla.suse.com/show_bug.cgi?id=1031120

