### PR TITLE
Fix detection of Mellanox ConnectX-3 boards with bad subclass (bsc#10…

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 22 08:24:17 UTC 2017 - nmoreychaisemartin@suse.com
+
+- bsc#1044982
+  - handle bad pci class/subclass ids used by Mellanox ConnectX-3
+- 3.2.29
+
+-------------------------------------------------------------------
 Thu May 25 09:27:09 UTC 2017 - mfilka@suse.com
 
 - bnc#1039532

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.2.28
+Version:        3.2.29
 Release:        0
 BuildArch:      noarch
 

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -363,6 +363,16 @@ module Yast
         when 145
           return "usb" # #22739
         when 128
+          # Mellanox ConnectX-3 series badly uses the 128 sub class
+          # Check for the specific known boards with bad subclass.
+          #
+          # Concerned devices are:
+          # 15b3:1003	MT27500 Family [ConnectX-3]
+          # 15b3:1004	MT27500/MT27520 Family [ConnectX-3/ConnectX-3 Pro Virtual Function]
+          # 15b3:1007	MT27520 Family [ConnectX-3 Pro]
+          if hwdevice["vendor_id"] == 71_091
+            return "ib" if [69_635, 69_636, 69_639].include?(hwdevice["device_id"])
+          end
           # Nothing was found
           Builtins.y2error("Unknown network controller type: %1", hwdevice)
           Builtins.y2error(


### PR DESCRIPTION
…44982)

ConnectX-3 boards badly use the subclass 128 which causes them to be ignored by wicked.
This patch adds a check for the 3 specific boards known to have this issue.

Older boards uses the obsolete 0c06 class
Newer uses the proper 0208.

Signed-off-by: Nicolas Morey-Chaisemartin <NMoreyChaisemartin@suse.com>