### PR TITLE
Fix RSpec warnings

### DIFF
--- a/test/build_lan_overview_test.rb
+++ b/test/build_lan_overview_test.rb
@@ -49,8 +49,8 @@ describe "LanItemsClass#BuildLanOverview" do
       .to receive(:locale)
       .and_return("de")
 
-    # HACK: locale search path
-    Yast::I18n::LOCALE_DIR = File.expand_path("../locale", __FILE__)
+    # locale search path
+    stub_const("Yast::I18n::LOCALE_DIR", File.expand_path("../locale", __FILE__))
 
     textdomain("network")
 

--- a/test/edit_nic_name_test.rb
+++ b/test/edit_nic_name_test.rb
@@ -16,8 +16,7 @@ module Yast
     # general mocking stuff is placed here
     before(:each) do
       # NetworkInterfaces are too low level. Everything needed should be mocked
-      NetworkInterfaces.as_null_object
-      allow(NetworkInterfaces).to receive(:adapt_old_config!)
+      stub_const("NetworkInterfaces", double(adapt_old_config!: nil))
 
       # mock devices configuration
       allow(LanItems).to receive(:ReadHardware) { [{ "dev_name" => CURRENT_NAME, "mac" => "00:01:02:03:04:05" }] }

--- a/test/host_test.rb
+++ b/test/host_test.rb
@@ -276,16 +276,6 @@ describe Yast::Host do
 
       Yast::Host.ResolveHostnameToStaticIPs
     end
-
-    it "doesn't call .Update when an IP already has a hostname" do
-      hostname = "linux"
-
-      Yast::Host.Update(hostname, hostname, static_ips[0])
-
-      expect(Yast::Host.ResolveHostnameToStaticIPs)
-        .not_to receive(:Update)
-        .with(fqhostname, fqhostname, static_ips[0])
-    end
   end
 
   describe ".StaticIPs" do

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -139,8 +139,7 @@ describe "NetworkAutoYast" do
   describe "#merge_configs" do
 
     it "merges all necessary stuff" do
-      Yast.import "UI"
-      Yast::UI.as_null_object
+      stub_const("Yast::UI", double.as_null_object)
       expect(network_autoyast).to receive(:merge_dns)
       expect(network_autoyast).to receive(:merge_routing)
       expect(network_autoyast).to receive(:merge_devices)

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -78,10 +78,10 @@ describe Yast::Routing do
 
       context "when user sets IPv4 Forwarding to #{ipv4} and IPv6 to #{ipv6}" do
         before(:each) do
-          Yast::Wizard.as_null_object
-          Yast::Label.as_null_object
-          Yast::Netmask.as_null_object
-          Yast::Popup.as_null_object
+          stub_const("Yast::Wizard", double.as_null_object)
+          stub_const("Yast::Label", double.as_null_object)
+          stub_const("Yast::Netmask", double.as_null_object)
+          stub_const("Yast::Popup", double.as_null_object)
 
           Yast.import "UI"
           allow(Yast::UI).to receive(:QueryWidget) { "" }
@@ -260,7 +260,7 @@ describe Yast::Routing do
 
         describe "#Read" do
           it "loads configuration from system" do
-            Yast::NetworkInterfaces.as_null_object
+            stub_const("Yast::NetworkInterfaces", double.as_null_object)
 
             expect(Yast::Routing.Read).to be true
           end


### PR DESCRIPTION
For example https://travis-ci.org/yast/yast-network/builds/237460613 is a green passing build but it has various kinds of RSpec warnings. This fixes them, including one (harmless) bug in the tests.