### PR TITLE
Report error when 2nd stage is disabled (bsc#1046198)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul  4 15:06:40 UTC 2017 - lslezak@suse.cz
+
+- Display a warning in AutoYaST installation when importing the DNS
+  configuration with disabled seconds stage (the second stage is
+  currently required for writing the config) (bsc#1046198)
+- 3.2.31
+
+-------------------------------------------------------------------
 Tue Jul  4 12:57:05 UTC 2017 - mfilka@suse.com
 
 - bnc#1046735

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -488,16 +488,16 @@ module Yast
 
       # check for AY unsupported scenarios, the name servers and the search domains
       # are written in the 2nd stage, if is disabled then it cannot work (bsc#1046198)
-      if Stage.initial && Mode.auto && !@error_reported && (!@nameservers.empty? || !@searchlist.empty?)
+      if Stage.initial && Mode.auto && !@error_reported && !empty?
         # lazy loading to avoid the dependency on AutoYaST, this can be imported only
         # in the initial stage otherwise it might fail!
         Yast.import "AutoinstConfig"
 
         if !AutoinstConfig.second_stage
           # TRANSLATORS: Warning message, the AutoYaST XML profile is incorrect
-          Report.Warning(_("DNS configuration error: The name servers or the search domains\n" \
-            "will not be configured when the second installation stage\n" \
-            "(after reboot) is disabled in the installation XML profile."))
+          Report.Warning(_("DNS configuration error: The DNS configuration\n" \
+            "is written in the second installation stage (after reboot)\n" \
+            "but the second stage is disabled in the AutoYaST XML profile."))
           @error_reported = true
         end
       end
@@ -712,6 +712,12 @@ module Yast
       @modified = true if !fqhostname.empty?
 
       fqhostname
+    end
+
+    # empty configuration?
+    # @return [Boolean] true if the configuration is empty (or contains defaults)
+    def empty?
+      @nameservers.empty? && @searchlist.empty? && @hostname.empty? && @domain.empty?
     end
 
     publish variable: :proposal_valid, type: "boolean"

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -86,6 +86,9 @@ module Yast
 
       # True if DNS is already read
       @initialized = false
+
+      # report the profile error only once
+      @error_reported = false
     end
 
     # Use the parameter, coming usually from install.inf, if it is defined.
@@ -485,15 +488,17 @@ module Yast
 
       # check for AY unsupported scenarios, the name servers and the search domains
       # are written in the 2nd stage, if is disabled then it cannot work (bsc#1046198)
-      if Stage.initial && Mode.auto && (!@nameservers.empty? || !@searchlist.empty?)
+      if Stage.initial && Mode.auto && !@error_reported && (!@nameservers.empty? || !@searchlist.empty?)
         # lazy loading to avoid the dependency on AutoYaST, this can be imported only
         # in the initial stage otherwise it might fail!
         Yast.import "AutoinstConfig"
 
         if !AutoinstConfig.second_stage
-          Report.Error(_("DNS configuration error: The name servers or the search domains\n" \
+          # TRANSLATORS: Warning message, the AutoYaST XML profile is incorrect
+          Report.Warning(_("DNS configuration error: The name servers or the search domains\n" \
             "will not be configured when the second installation stage\n" \
             "(after reboot) is disabled in the installation XML profile."))
+          @error_reported = true
         end
       end
 


### PR DESCRIPTION
- Report a warning when the imported AY settings require the seconds stage but it is disabled in the profile
- Fix for https://bugzilla.suse.com/show_bug.cgi?id=1046198
- Tested with the profile attached at in the bug report

![ay_dns_warning](https://user-images.githubusercontent.com/907998/28006922-a91b8408-6551-11e7-99ff-9d5a96a32d1c.png)
