### PR TITLE
Avoid creating duplicit udev rules in AutoYaST installation

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 12 05:37:30 UTC 2017 - mfilka@suse.com
+
+- bnc#1038717
+  - avoid creating duplicit udev rules in AutoYaST installation
+- 3.1.178
+
+-------------------------------------------------------------------
 Thu May 18 10:11:01 UTC 2017 - gsouza@suse.com
 
 - bsc#1036440 and bsc#994471

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,7 +2,7 @@
 Wed Jul 12 05:37:30 UTC 2017 - mfilka@suse.com
 
 - bnc#1038717
-  - avoid creating duplicit udev rules in AutoYaST installation
+  - avoid creating duplicate udev rules in AutoYaST installation
 - 3.1.178
 
 -------------------------------------------------------------------

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.177
+Version:        3.1.178
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -227,6 +227,24 @@ module Yast
       true
     end
 
+    def rename_lan_item(item, name_to, attr=nil, key=nil)
+      # selecting according device name is unreliable (selects only in between configured devices)
+      LanItems.current = item
+
+      if !attr.nil? && !key.nil?
+        # find out what attribude is currently used for setting device name and
+        # change it if needed. Currently mac is used by default. So, we check is it is
+        # the other one (busid). If no we defaults to mac.
+        bus_attr = LanItems.GetItemUdev("KERNELS")
+        current_attr = bus_attr.empty? ? "ATTR{address}" : "KERNELS"
+
+        # make sure that we base renaming on defined attribute with value given in AY profile
+        LanItems.ReplaceItemUdev(current_attr, attr, key)
+      end
+
+      LanItems.rename(name_to)
+    end
+
     # Takes a list of udev rules and assignes them to corresponding devices.
     #
     # If a device has an udev rule defined already, it is overwritten by new one.
@@ -242,27 +260,25 @@ module Yast
         next if !valid_rename_udev_rule?(rule)
         key.downcase!
 
+        # find item which matches to the given rule definition
         item, matching_item = LanItems.Items.find do |_, i|
           i["hwinfo"]["busid"].downcase == key || i["hwinfo"]["mac"].downcase == key
         end
         next if !matching_item
 
-        # for logging only
         name_from = matching_item["ifcfg"] || matching_item["dev_name"]
         log.info("Matching device found - renaming <#{name_from}> -> <#{name_to}>")
 
-        # selecting according device name is unreliable (selects only in between configured devices)
-        LanItems.current = item
+        # find rule in collision
+        colliding_item, item_map = LanItems.Items.find do |i, _|
+          LanItems.GetDeviceName(i) == name_to
+        end
 
-        # find out what attribude is currently used for setting device name and
-        # change it if needed. Currently mac is used by default. So, we check is it is
-        # the other one (busid). If no we defaults to mac.
-        bus_attr = LanItems.GetItemUdev("KERNELS")
-        current_attr = bus_attr.empty? ? "ATTR{address}" : "KERNELS"
+        # rename item in collision
+        rename_lan_item(colliding_item, name_from)
 
-        # make sure that we base renaming on defined attribute with value given in AY profile
-        LanItems.ReplaceItemUdev(current_attr, attr, key)
-        LanItems.rename(name_to)
+        # rename matching item
+        rename_lan_item(item, name_to, attr, key)
       end
     end
   end

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -250,9 +250,13 @@ module Yast
 
         # make sure that we base renaming on defined attribute with value given in AY profile
         LanItems.ReplaceItemUdev(current_attr, attr, key)
+      elsif attr.nil? ^ key.nil? # xor
+        raise ArgumentError, "Not enough data for udev rule definition"
       end
 
       LanItems.rename(name_to)
+
+      nil
     end
 
     # Takes a list of udev rules and assignes them to corresponding devices.

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -227,7 +227,7 @@ module Yast
       true
     end
 
-    def rename_lan_item(item, name_to, attr=nil, key=nil)
+    def rename_lan_item(item, name_to, attr = nil, key = nil)
       return if item.nil? || item.empty? || item < 0 || item >= LanItems.Items.size
       return if name_to.nil? || name_to.empty?
 
@@ -273,7 +273,7 @@ module Yast
         log.info("Matching device found - renaming <#{name_from}> -> <#{name_to}>")
 
         # find rule in collision
-        colliding_item, item_map = LanItems.Items.find do |i, _|
+        colliding_item, _item_map = LanItems.Items.find do |i, _|
           LanItems.GetDeviceName(i) == name_to
         end
 

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -228,6 +228,9 @@ module Yast
     end
 
     def rename_lan_item(item, name_to, attr=nil, key=nil)
+      return if item.nil? || item.empty? || item < 0 || item >= LanItems.Items.size
+      return if name_to.nil? || name_to.empty?
+
       # selecting according device name is unreliable (selects only in between configured devices)
       LanItems.current = item
 

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -227,8 +227,15 @@ module Yast
       true
     end
 
+    # Renames a network device represented by given item.
+    #
+    # @param [Integer] item is an item id. See LanItems for detail
+    # @param [String] name_to new device name
+    # @param [String] attr an udev attribute usable in NIC's rule. Currently just
+    #  "KERNELS" or "ATTR{address}" makes sense. This parameter is optional
+    # @param [String] value for the given udev attribute. Optional parameter.
     def rename_lan_item(item, name_to, attr = nil, key = nil)
-      return if item.nil? || item.empty? || item < 0 || item >= LanItems.Items.size
+      return if item.nil? || item < 0 || item >= LanItems.Items.size
       return if name_to.nil? || name_to.empty?
 
       # selecting according device name is unreliable (selects only in between configured devices)

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -353,7 +353,7 @@ describe "NetworkAutoYast" do
     before(:each) do
       allow(Yast::LanItems)
         .to receive(:Items)
-        .and_return({ 0 => { "ifcfg" => "eth0" }})
+        .and_return(0 => { "ifcfg" => "eth0" })
     end
 
     context "valid arguments given" do
@@ -397,12 +397,12 @@ describe "NetworkAutoYast" do
       end
 
       it "raise an exception when udev definition is incomplete" do
-        expect {
+        expect do
           network_autoyast.send(:rename_lan_item, 0, "new_name", "KERNELS", nil)
-        }.to raise_error(ArgumentError)
-        expect {
+        end.to raise_error(ArgumentError)
+        expect do
           network_autoyast.send(:rename_lan_item, 0, "new_name", nil, "0000:00:03.0")
-        }.to raise_error(ArgumentError)
+        end.to raise_error(ArgumentError)
       end
     end
   end

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -395,6 +395,15 @@ describe "NetworkAutoYast" do
         network_autoyast.send(:rename_lan_item, -1, "new_name")
         network_autoyast.send(:rename_lan_item, 100, "new_name")
       end
+
+      it "raise an exception when udev definition is incomplete" do
+        expect {
+          network_autoyast.send(:rename_lan_item, 0, "new_name", "KERNELS", nil)
+        }.to raise_error(ArgumentError)
+        expect {
+          network_autoyast.send(:rename_lan_item, 0, "new_name", nil, "0000:00:03.0")
+        }.to raise_error(ArgumentError)
+      end
     end
   end
 end


### PR DESCRIPTION
[bsc#1038717](https://bugzilla.suse.com/show_bug.cgi?id=1038717)

not confirmed to fix reporter's issue, but tested manually by me and requested by Frederic for SP3