### PR TITLE
Fix udev rules export when more than 1 device is present

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,9 +1,16 @@
 -------------------------------------------------------------------
+Thu Jul 27 13:49:45 UTC 2017 - igonzalezsosa@suse.com
+
+- bnc#1050986
+  - fix udev rules export when more than one device is configured
+- 3.1.180
+
+-------------------------------------------------------------------
 Wed Jul 26 14:55:20 UTC 2017 - igonzalezsosa@suse.com
 
 - bnc#1037727
   - dhclient configuration warning message does not block AutoYaST
-  - 3.1.179
+- 3.1.179
 
 -------------------------------------------------------------------
 Wed Jul 12 05:37:30 UTC 2017 - mfilka@suse.com

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.179
+Version:        3.1.180
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2728,7 +2728,7 @@ module Yast
         end
       else
         configured = Items().select { |i, _| IsItemConfigured(i) }
-        configured.each do |id, _|
+        ay["net-udev"] = configured.keys.each_with_object({}) do |id, udev|
           @current = id # for GetItemUdev
 
           name = GetItemUdev("NAME").to_s
@@ -2736,12 +2736,10 @@ module Yast
 
           next if !rule || name.empty?
 
-          ay["net-udev"] = {
-            name => {
-              "rule"  => rule,
-              "name"  => name,
-              "value" => GetItemUdev(rule)
-            }
+          udev[name] = {
+            "rule"  => rule,
+            "name"  => name,
+            "value" => GetItemUdev(rule)
           }
         end
       end

--- a/test/lan_items_export_test.rb
+++ b/test/lan_items_export_test.rb
@@ -20,26 +20,73 @@ describe "LanItemsClass#export_udevs" do
 
   let(:scr) { Yast::SCR }
 
+  let(:is_s390) { false }
+
+  let(:eth0) do
+    {
+      "hwinfo" => { "dev_name" => "eth0" },
+      "udev"   => {
+        "net" => [
+          "SUBSYSTEM==\"net\"", "ACTION==\"add\"", "DRIVERS==\"?*\"", "ATTR{type}==\"1\"",
+          "ATTR{address}==\"00:50:56:12:34:56\"", "NAME=\"eth0\""
+        ]
+      }
+    }
+  end
+
+  let(:eth1) do
+    {
+      "hwinfo" => { "dev_name" => "eth1" },
+      "udev"   => {
+        "net" => [
+          "SUBSYSTEM==\"net\"", "ACTION==\"add\"", "DRIVERS==\"?*\"",
+          "KERNELS==\"0000:00:1f.6\"", "NAME=\"eth1\""
+        ]
+      }
+    }
+  end
+
+  let(:items) { { 0 => eth0, 1 => eth1 } }
+
   before(:each) do
     # mock SCR to not touch system
     allow(scr).to receive(:Read).and_return("")
     allow(scr).to receive(:Execute).and_return("exit" => -1, "stdout" => "", "stderr" => "")
+    allow(subject).to receive(:IsItemConfigured).and_return(true)
+    allow(subject).to receive(:Items).and_return(items)
   end
 
-  def path(p)
-    Yast::Path.new(p)
+  before(:each) do
+    allow(Yast::Arch).to receive(:s390).and_return(is_s390)
+  end
+
+  it "exports udev rules" do
+    ay = subject.send(:export_udevs, devices)
+    expect(ay["net-udev"]).to eq(
+      "eth0" => { "rule" => "ATTR{address}", "name" => "eth0", "value" => "00:50:56:12:34:56" },
+      "eth1" => { "rule" => "KERNELS", "name" => "eth1", "value" => "0000:00:1f.6" }
+    )
+  end
+
+  context "when an interface is not configured" do
+    before do
+      allow(subject).to receive(:IsItemConfigured).with(1).and_return(false)
+    end
+
+    it "does not include an udev rule for that interface" do
+      ay = subject.send(:export_udevs, devices)
+      expect(ay["net-udev"].keys).to eq(["eth0"])
+    end
   end
 
   context "When running on s390" do
-    before(:each) do
-      allow(Yast::Arch).to receive(:s390).and_return(true)
-    end
+    let(:is_s390) { true }
 
     # kind of smoke test
     it "produces s390 specific content in exported AY profile" do
       allow(scr)
         .to receive(:Execute)
-        .with(path(".target.bash_output"), /^driver=.*/)
+        .with(Yast::Path.new(".target.bash_output"), /^driver=.*/)
         .and_return("exit" => 0, "stdout" => "qeth", "stderr" => "")
 
       ay = subject.send(:export_udevs, devices)


### PR DESCRIPTION
Fix [bsc#1050986](https://bugzilla.suse.com/show_bug.cgi?id=1050986).