### PR TITLE
Do not display an AY warning (bsc#1054400)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 21 07:02:32 UTC 2017 - lslezak@suse.cz
+
+- AutoYaST: Do not display a warning about disabled second stage
+  when the hostname setting is read out of profile (bsc#1054400)
+- 3.2.39
+
+-------------------------------------------------------------------
 Mon Aug 21 06:57:26 UTC 2017 - mfilka@suse.com
 
 - bnc#1039656

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.2.38
+Version:        3.2.39
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -68,6 +68,9 @@ module Yast
       # Domain Name (not including the host part)
       @domain = ""
 
+      # the hostname and the domain has been imported from an AY profile
+      @hostname_from_profile = nil
+
       @nameservers = []
       @searchlist = []
 
@@ -476,11 +479,13 @@ module Yast
       if Builtins.haskey(settings, "hostname")
         @hostname = Ops.get_string(settings, "hostname", "")
         @domain = Ops.get_string(settings, "domain", "") # empty is not a bug, bnc#677471
+        @hostname_from_profile = true
       else
         # otherwise, check 1) install.inf 2) /etc/HOSTNAME
         ReadHostname()
         # if nothing is found, generate a random one
         ProposeHostname()
+        @hostname_from_profile = false
       end
 
       @nameservers = Builtins.eval(Ops.get_list(settings, "nameservers", []))
@@ -488,7 +493,7 @@ module Yast
 
       # check for AY unsupported scenarios, the name servers and the search domains
       # are written in the 2nd stage, if is disabled then it cannot work (bsc#1046198)
-      if Stage.initial && Mode.auto && !@error_reported && !empty?
+      if Stage.initial && Mode.auto && @hostname_from_profile && !@error_reported && !empty?
         # lazy loading to avoid the dependency on AutoYaST, this can be imported only
         # in the initial stage otherwise it might fail!
         Yast.import "AutoinstConfig"

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -68,9 +68,6 @@ module Yast
       # Domain Name (not including the host part)
       @domain = ""
 
-      # the hostname and the domain has been imported from an AY profile
-      @hostname_from_profile = nil
-
       @nameservers = []
       @searchlist = []
 
@@ -89,9 +86,6 @@ module Yast
 
       # True if DNS is already read
       @initialized = false
-
-      # report the profile error only once
-      @error_reported = false
     end
 
     # Use the parameter, coming usually from install.inf, if it is defined.
@@ -479,33 +473,17 @@ module Yast
       if Builtins.haskey(settings, "hostname")
         @hostname = Ops.get_string(settings, "hostname", "")
         @domain = Ops.get_string(settings, "domain", "") # empty is not a bug, bnc#677471
-        @hostname_from_profile = true
+        # print a warning in unsupported scenarios
+        warn_unsupported
       else
         # otherwise, check 1) install.inf 2) /etc/HOSTNAME
         ReadHostname()
         # if nothing is found, generate a random one
         ProposeHostname()
-        @hostname_from_profile = false
       end
 
       @nameservers = Builtins.eval(Ops.get_list(settings, "nameservers", []))
       @searchlist = Builtins.eval(Ops.get_list(settings, "searchlist", []))
-
-      # check for AY unsupported scenarios, the name servers and the search domains
-      # are written in the 2nd stage, if is disabled then it cannot work (bsc#1046198)
-      if Stage.initial && Mode.auto && @hostname_from_profile && !@error_reported && !empty?
-        # lazy loading to avoid the dependency on AutoYaST, this can be imported only
-        # in the initial stage otherwise it might fail!
-        Yast.import "AutoinstConfig"
-
-        if !AutoinstConfig.second_stage
-          # TRANSLATORS: Warning message, the AutoYaST XML profile is incorrect
-          Report.Warning(_("DNS configuration error: The DNS configuration\n" \
-            "is written in the second installation stage (after reboot)\n" \
-            "but the second stage is disabled in the AutoYaST XML profile."))
-          @error_reported = true
-        end
-      end
 
       @modified = true
       # empty settings means that we're probably resetting the config
@@ -697,6 +675,25 @@ module Yast
     end
 
   private
+
+    # check for AY unsupported scenarios, the name servers and the search domains
+    # are written in the 2nd stage, if is disabled then it cannot work (bsc#1046198)
+    def warn_unsupported
+      return if !Stage.initial || !Mode.auto || @error_reported || empty?
+
+      # lazy loading to avoid the dependency on AutoYaST, this can be imported only
+      # in the initial stage otherwise it might fail!
+      Yast.import "AutoinstConfig"
+
+      # the 2nd stage is enabled, OK
+      return if AutoinstConfig.second_stage
+
+      # TRANSLATORS: Warning message, the AutoYaST XML profile is incorrect
+      Report.Warning(_("DNS configuration error: The DNS configuration\n" \
+        "is written in the second installation stage (after reboot)\n" \
+        "but the second stage is disabled in the AutoYaST XML profile."))
+      @error_reported = true
+    end
 
     def read_hostname_from_install_inf
       install_inf_hostname = SCR.Read(path(".etc.install_inf.Hostname")) || ""

--- a/test/dns_test.rb
+++ b/test/dns_test.rb
@@ -135,6 +135,13 @@ module Yast
           expect(Yast::Report).to_not receive(:Warning)
           DNS.Import(settings)
         end
+
+        it "does not print a warning when the hostname is set out of the profile" do
+          stub_const("Yast::AutoinstConfig", double(second_stage: true))
+          expect(Yast::Report).to_not receive(:Warning)
+          DNS.hostname = "test"
+          DNS.Import({})
+        end
       end
     end
   end


### PR DESCRIPTION
...when the hostname setting is read out of profile.

- Fix for https://bugzilla.suse.com/show_bug.cgi?id=1054400
- The hostname can be also read from `install.inf` (passed via boot command line), in that case the warning is wrong as the hostname is not specified in the profile.
- 3.2.38