### PR TITLE
Ensure Host entries are read before write (bsc#1058396)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep 21 13:26:16 UTC 2017 - knut.anderssen@suse.com
+
+- Do not blank out /etc/hosts when no <host> section is defined
+  (bsc#1058396)
+- 3.2.41
+
+-------------------------------------------------------------------
 Tue Sep 26 12:44:47 UTC 2017 - knut.anderssen@suse.com
 
 - Preload the global DHCLIENT_SET_HOSTNAME option based on linuxrc

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Thu Sep 21 13:26:16 UTC 2017 - knut.anderssen@suse.com
+Fri Sep 29 13:26:16 UTC 2017 - knut.anderssen@suse.com
 
 - Do not blank out /etc/hosts when no <host> section is defined
   (bsc#1058396)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.2.40
+Version:        3.2.41
 Release:        0
 BuildArch:      noarch
 

--- a/src/desktop/lan.desktop
+++ b/src/desktop/lan.desktop
@@ -15,6 +15,7 @@ X-SuSE-YaST-SortKey=
 X-SuSE-YaST-AutoInstResource=networking
 X-SuSE-YaST-AutoInstClonable=true
 X-SuSE-YaST-AutoInstSchema=networking.rnc
+X-SuSE-YaST-AutoInstRequires=host
 
 Icon=yast-lan
 Exec=xdg-su -c "/sbin/yast2 lan"

--- a/src/modules/Host.rb
+++ b/src/modules/Host.rb
@@ -95,13 +95,14 @@ module Yast
 
         fqhostname = Hostname.MergeFQ(DNS.hostname, DNS.domain)
         set_names(local_ip, ["#{fqhostname} #{DNS.hostname}"])
+        @modified = true
       elsif @hosts.include_ip?(local_ip)
         # Do not add it if product default says no
         # and remove 127.0.02 entry if it exists
 
         @hosts.delete_by_ip(local_ip)
+        @modified = true
       end
-      @modified = true
 
       nil
     end

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -558,6 +558,9 @@ module Yast
       # reload/restart network before this to put correct resolv.conf from dhcp-backup
       orig = Progress.set(false)
       DNS.Write
+      # Ensure that the /etc/hosts has been read to no blank out it (bsc#1058396)
+      # The method just returns true in case of initialized.
+      Host.Read
       Host.EnsureHostnameResolvable
       Host.Write
       Progress.set(orig)

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -558,9 +558,6 @@ module Yast
       # reload/restart network before this to put correct resolv.conf from dhcp-backup
       orig = Progress.set(false)
       DNS.Write
-      # Ensure that the /etc/hosts has been read to no blank out it (bsc#1058396)
-      # The method just returns true in case of initialized.
-      Host.Read
       Host.EnsureHostnameResolvable
       Host.Write
       Progress.set(orig)
@@ -661,6 +658,10 @@ module Yast
       NetworkConfig.Import(settings["config"] || {})
       DNS.Import(settings["dns"] || {})
       Routing.Import(settings["routing"] || {})
+
+      # Ensure that the /etc/hosts has been read to no blank out it in case of
+      # not defined <host> section (bsc#1058396)
+      Host.Read
 
       @ipv6 = settings.fetch("ipv6", true)
 


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/I0zqz1UB/1179-3-sles12-sp3-1058396-l3-etc-hosts-blanked-out-after-autoyast-installation)
- [bugzilla](https://bugzilla.suse.com/show_bug.cgi?id=1058396)

## Description of the problem (already in Trello)

- When there is no `<host>` section defined then the host_auto client is not called and the Host configuration is not read or imported, then if there is a `<networking>` section the lan_auto client write down the **Host** configuration without be initialized or read previously, which means that it blank out the /etc/hosts file.

- There was a similar bug in a common installation when virtual proposal was used https://github.com/yast/yast-network/pull/557, in this case, as only **LanItems** configuration was needed the call to write the **Lan** was simply replaced.

## Solution

- As it is AutoYaST specific, we ensure that /etc/hosts is read when importing.
