### PR TITLE
Sets DHCLIENT_SET_HOSTNAME based on linuxrc or from the control file (bsc#1054933)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Tue Sep 26 12:44:47 UTC 2017 - knut.anderssen@suse.com
 
-- Preloads the global DHCLIENT_SET_HOSTNAME option based on linuxrc
+- Preload the global DHCLIENT_SET_HOSTNAME option based on linuxrc
   sethostname option if given or based in control file default if
   not. (bsc#1054933)
 - Do not override the configuration with the default defined in

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Sep 26 12:44:47 UTC 2017 - knut.anderssen@suse.com
+
+- Preloads the global DHCLIENT_SET_HOSTNAME option based on linuxrc
+  sethostname option if given or based in control file default if
+  not. (bsc#1054933)
+- Do not override the configuration with the default defined in
+  the control file at the end of the first stage (bsc#1056633)
+- 3.2.40
+
+-------------------------------------------------------------------
 Mon Aug 21 07:02:32 UTC 2017 - lslezak@suse.cz
 
 - AutoYaST: Do not display a warning about disabled second stage

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.2.39
+Version:        3.2.40
 Release:        0
 BuildArch:      noarch
 

--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -118,11 +118,7 @@ module Yast
           "custom_widget" => HBox(
             Label(_("Set Hostname via DHCP")),
             HSpacing(2),
-            ComboBox(
-              Id("DHCP_HOSTNAME"),
-              "",
-              []
-            ),
+            ReplacePoint(Id("dhcp_hostname_method"), Empty()),
             ReplacePoint(Id("dh_host_text"), Empty())
           ),
           "init"          => fun_ref(method(:InitDhcpHostname), "void (string)"),
@@ -445,7 +441,14 @@ module Yast
         Item(Id(iface), format(_("yes: %s"), iface), iface == selected)
       end
 
-      UI.ChangeWidget(Id("DHCP_HOSTNAME"), :Items, items)
+      UI.ReplaceWidget(
+        Id("dhcp_hostname_method"),
+        ComboBox(
+          Id("DHCP_HOSTNAME"),
+          "",
+          items
+        )
+      )
 
       log.info("InitDhcpHostname: preselected item = #{selected}")
 

--- a/src/lib/network/clients/inst_setup_dhcp.rb
+++ b/src/lib/network/clients/inst_setup_dhcp.rb
@@ -5,8 +5,15 @@ module Yast
     include Singleton
     include Logger
 
+    def initialize
+      Yast.import "Linuxrc"
+      Yast.import "DNS"
+    end
+
     def main
-      nac = Yast::NetworkAutoconfiguration.instance
+      nac = NetworkAutoconfiguration.instance
+      set_dhcp_hostname! if set_dhcp_hostname? && Stage.initial
+
       if !nac.any_iface_active?
         nac.configure_dhcp
       else
@@ -16,6 +23,25 @@ module Yast
       # if this is not wrapped in a def, ruby -cw says
       # warning: possibly useless use of a literal in void context
       :next
+    end
+
+    def set_dhcp_hostname?
+      set_hostname = Linuxrc.InstallInf("SetHostname")
+      log.info("SetHostname: #{set_hostname}")
+      set_hostname != 0
+    end
+
+    def set_dhcp_hostname!
+      DNS.dhcp_hostname = DNS.default_dhcp_hostname
+      log.info("Write dhcp hostname default: #{DNS.dhcp_hostname}")
+      SCR.Write(
+        Yast::Path.new(".sysconfig.network.dhcp.DHCLIENT_SET_HOSTNAME"),
+        DNS.dhcp_hostname ? "yes" : "no"
+      )
+      SCR.Write(
+        Yast::Path.new(".sysconfig.network.dhcp"),
+        nil
+      )
     end
   end
 end

--- a/src/lib/network/clients/inst_setup_dhcp.rb
+++ b/src/lib/network/clients/inst_setup_dhcp.rb
@@ -12,7 +12,7 @@ module Yast
 
     def main
       nac = NetworkAutoconfiguration.instance
-      set_dhcp_hostname! if set_dhcp_hostname? && Stage.initial
+      set_dhcp_hostname! if Stage.initial
 
       if !nac.any_iface_active?
         nac.configure_dhcp
@@ -25,23 +25,38 @@ module Yast
       :next
     end
 
+    # Check if set of DHCLIENT_SET_HOSTNAME in /etc/sysconfig/network/dhcp has
+    # been disable by linuxrc cmdline
     def set_dhcp_hostname?
       set_hostname = Linuxrc.InstallInf("SetHostname")
       log.info("SetHostname: #{set_hostname}")
-      set_hostname != 0
+      set_hostname != "0"
     end
 
+    # Write the DHCLIENT_SET_HOSTNAME in /etc/sysconfig/network/dhcp based on
+    # linuxrc sethostname cmdline option if provided or the default value
+    # defined in the control file if not.
     def set_dhcp_hostname!
-      DNS.dhcp_hostname = DNS.default_dhcp_hostname
+      DNS.dhcp_hostname =
+        set_hostname_used? ? set_dhcp_hostname? : DNS.default_dhcp_hostname
+
       log.info("Write dhcp hostname default: #{DNS.dhcp_hostname}")
       SCR.Write(
         Yast::Path.new(".sysconfig.network.dhcp.DHCLIENT_SET_HOSTNAME"),
         DNS.dhcp_hostname ? "yes" : "no"
       )
+      # Flush cache
       SCR.Write(
         Yast::Path.new(".sysconfig.network.dhcp"),
         nil
       )
+    end
+
+    # Check whether the linuxrc sethostname option has been used or not
+    #
+    # @return [Boolean] true if sethosname linuxrc cmdline option was given
+    def set_hostname_used?
+      Linuxrc.InstallInf("SetHostnameUsed") == "1"
     end
   end
 end

--- a/src/lib/network/clients/inst_setup_dhcp.rb
+++ b/src/lib/network/clients/inst_setup_dhcp.rb
@@ -1,14 +1,12 @@
 require "network/network_autoconfiguration"
 
+Yast.import "Linuxrc"
+Yast.import "DNS"
+
 module Yast
   class SetupDhcp
     include Singleton
     include Logger
-
-    def initialize
-      Yast.import "Linuxrc"
-      Yast.import "DNS"
-    end
 
     def main
       nac = NetworkAutoconfiguration.instance
@@ -27,6 +25,8 @@ module Yast
 
     # Check if set of DHCLIENT_SET_HOSTNAME in /etc/sysconfig/network/dhcp has
     # been disable by linuxrc cmdline
+    #
+    # @return [Boolean] false if sethostname=0; true otherwise
     def set_dhcp_hostname?
       set_hostname = Linuxrc.InstallInf("SetHostname")
       log.info("SetHostname: #{set_hostname}")

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -88,11 +88,6 @@ module Yast
       DNS.Read # handles NetworkConfig too
       DNS.ProposeHostname # generate random hostname, if none known so far
 
-      # FIXME: after SLE12: DNS.default_dhcp_hostname should be private (setting
-      # default values is not something for an API), but that would need some
-      # refactoring of this part.
-      DNS.dhcp_hostname = DNS.default_dhcp_hostname
-
       # get default value, from control.xml
       DNS.write_hostname = DNS.DefaultWriteHostname
 

--- a/test/inst_setup_dhcp_test.rb
+++ b/test/inst_setup_dhcp_test.rb
@@ -5,7 +5,7 @@ require_relative "test_helper"
 require "network/clients/inst_setup_dhcp"
 
 describe Yast::SetupDhcp do
-  let(:subject) { Yast::SetupDhcp.instance }
+  subject { Yast::SetupDhcp.instance }
 
   describe "#main" do
 
@@ -93,13 +93,14 @@ describe Yast::SetupDhcp do
   end
 
   describe "set_dhcp_hostname?" do
-    let(:set_hostname) { "1" }
-
     before do
       allow(Yast::Linuxrc).to receive(:InstallInf)
         .with("SetHostname").and_return(set_hostname)
     end
+
     context "when dhcp hostname has not been disabled by linuxrc" do
+      let(:set_hostname) { "1" }
+
       it "returns true" do
         expect(subject.set_dhcp_hostname?).to eql(true)
       end

--- a/test/inst_setup_dhcp_test.rb
+++ b/test/inst_setup_dhcp_test.rb
@@ -5,9 +5,7 @@ require_relative "test_helper"
 require "network/clients/inst_setup_dhcp"
 
 describe Yast::SetupDhcp do
-  before do
-    allow(Yast::NetworkInterfaces).to receive(:adapt_old_config!)
-  end
+  let(:subject) { Yast::SetupDhcp.instance }
 
   describe "#main" do
 
@@ -16,7 +14,7 @@ describe Yast::SetupDhcp do
         .to receive(:any_iface_active?)
         .and_return(true)
 
-      expect(Yast::SetupDhcp.instance.main).to eql :next
+      expect(subject.main).to eql :next
     end
 
     it "returns :next when autoconfiguration is not performed" do
@@ -24,7 +22,95 @@ describe Yast::SetupDhcp do
         .to receive(:any_iface_active?)
         .and_return(false)
 
-      expect(Yast::SetupDhcp.instance.main).to eql :next
+      expect(subject.main).to eql :next
+    end
+
+    it "runs network dhcp autoconfiguration if no active interfaces" do
+      allow(Yast::NetworkAutoconfiguration)
+        .to receive(:any_iface_active?)
+        .and_return(false)
+      expect(Yast::NetworkAutoconfiguration.instance)
+        .to receive(:configure_dhcp)
+
+      subject.main
+    end
+
+    context "in the initial Stage" do
+      it "writes DHCLIENT_SET_HOSTNAME in /etc/sysconfig/network/dhcp" do
+        expect(Yast::Stage).to receive(:initial).and_return(true)
+        expect(subject).to receive(:set_dhcp_hostname!)
+
+        subject.main
+      end
+    end
+  end
+
+  describe "#set_dhcp_hostname!" do
+    let(:dhclient_set_hostname_path) do
+      Yast::Path.new(".sysconfig.network.dhcp.DHCLIENT_SET_HOSTNAME")
+    end
+
+    before do
+      allow(Yast::SCR).to receive(:Write)
+    end
+
+    context "when the linurc sethostname option has been used" do
+      before do
+        allow(subject).to receive(:set_hostname_used?).and_return(true)
+      end
+
+      it "sets DNS.dhcp_hostname according to the linuxrc sethosname value" do
+        expect(subject).to receive(:set_dhcp_hostname?).and_return(false)
+        expect(Yast::DNS).to receive(:dhcp_hostname=).with(false)
+
+        subject.set_dhcp_hostname!
+      end
+    end
+
+    context "when the linurc sethostname option has not been used" do
+      before do
+        allow(subject).to receive(:set_hostname_used?).and_return(false)
+      end
+
+      it "sets DNS.dhcp_hostname according to DNS.default_dhcp_hostname" do
+        expect(subject).to_not receive(:set_dhcp_hostname?)
+        expect(Yast::DNS).to receive(:default_dhcp_hostname).and_return(true)
+        expect(Yast::DNS).to receive(:dhcp_hostname=).with(true)
+
+        subject.set_dhcp_hostname!
+      end
+    end
+
+    context "once initialized DNS.dhcp_hostname" do
+      it "writes global DHCLIENT_SET_HOSTNAME in /etc/sysconfig/network/dhcp with it" do
+        allow(Yast::DNS).to receive(:dhcp_hostname=)
+        allow(Yast::DNS).to receive(:dhcp_hostname).and_return(false)
+        expect(Yast::SCR).to receive(:Write).with(dhclient_set_hostname_path, "no")
+
+        subject.set_dhcp_hostname!
+      end
+    end
+  end
+
+  describe "set_dhcp_hostname?" do
+    let(:set_hostname) { "1" }
+
+    before do
+      allow(Yast::Linuxrc).to receive(:InstallInf)
+        .with("SetHostname").and_return(set_hostname)
+    end
+    context "when dhcp hostname has not been disabled by linuxrc" do
+      it "returns true" do
+        expect(subject.set_dhcp_hostname?).to eql(true)
+      end
+    end
+
+    context "when dhcp hostname has been disabled by linuxrc" do
+      let(:set_hostname) { "0" }
+
+      it "returns false" do
+        expect(subject.set_dhcp_hostname?).to eql(false)
+      end
     end
   end
 end


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/Vj69gtYP/1168-5-caasp-20-hostname-via-dhcp-work-according-to-control-file)
- This PR depends on openSUSE/linuxrc#146 and openSUSE/linuxrc#147

Basically, it sets the DHCLIENT_SET_HOSTNAME in /etc/sysconfig/network/dhcp based on linuxrc cmdline sethostname option if provided  or obtains the default from the control file if not.

https://github.com/yast/skelcd-control-SLES/blob/master/control/control.SLES.xml#L21

## Screenshot after inst_setup_dhcp client (just after wellcome screen)
![screenshot_testing_2017-09-25_11 08 43](https://user-images.githubusercontent.com/7056681/30803573-024fba5e-a1e2-11e7-800c-ff73f1390bfa.png)

## Screenshot after manual installation without special linuxrc cmdline options
![screenshot_testing_2017-09-25_11 39 50](https://user-images.githubusercontent.com/7056681/30804698-48fbc340-a1e6-11e7-94d1-884228ab3624.png)


## CaaSP 2.0 Manual Network config

![manualconfig](https://user-images.githubusercontent.com/7056681/30806159-815c4d1c-a1ec-11e7-862b-b5bef3144079.png)

![screenshot](https://user-images.githubusercontent.com/7056681/30806121-5c9f832c-a1ec-11e7-9cd1-b2243827eb9f.png)

## Notes and tricks

The libvirt network config used for the host:
```
      <host mac='dc:e4:cc:27:94:c2' name='teclator.suse.com' ip='192.168.122.60'/>
```

The tests have been done with a modified CaaSP iso with last linuxrc modification and also modified with a DUD containing this code.

```
mksusecd --initrd initrd --create /home/knut/isos/SUSE-CaaS-Platform-2.0-DVD-x86_64-Linuxrc.iso /home/knut/isos/SUSE-CaaS-Platform-2.0-DVD-x86_64-Build0071-Media1.iso
mksusecd --initrd network.dud --create /home/knut/isos/SUSE-CaaS-Platform-2.0-DVD-x86_64-dud.iso /home/knut/isos/SUSE-CaaS-Platform-2.0-DVD-x86_64-Linuxrc.iso
```

## Replace widget instead of just the Items to show the complete interface name
![fit_selector](https://user-images.githubusercontent.com/7056681/30909491-331b1938-a379-11e7-8bdd-ae329880d821.png)

