### PR TITLE
routing/firewall: no longer depend on SuSEfirewall2 for IPv4 forwarding

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Oct 25 12:51:56 UTC 2017 - knut.anderssen@suse.com
+
+- Do not depend on SuSEfirewall2 anymore for writing IPv4
+  forwarding as Firewalld will be the default FW in SLE15.
+  (fate#323460, bsc#572202)
+- 4.0.4
+
+-------------------------------------------------------------------
 Wed Oct  5 10:26:53 CEST 2017 - schubi@suse.de
 
 - Remote settings: Only reading firewall settings if we are really

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.0.3
+Version:        4.0.4
 Release:        0
 BuildArch:      noarch
 

--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -1292,11 +1292,11 @@ module Yast
       fwzone = SuSEFirewall4Network.GetZoneOfInterface(LanItems.GetCurrentName)
 
       # If firewall is active and interface in no zone, nothing
-      # gets through (#62309) so add it to the external zone
+      # gets through (#62309) so add it to the default zone
       if fwzone == "" && LanItems.operation == :add && SuSEFirewall4Network.IsOn &&
           SuSEFirewall4Network.UnconfiguredIsBlocked
-        fwzone = "EXT"
-        Builtins.y2milestone("Defaulting to EXT")
+        fwzone = "public"
+        Builtins.y2milestone("Defaulting to public")
       end
 
       @fwzone_initial = fwzone

--- a/src/modules/Remote.rb
+++ b/src/modules/Remote.rb
@@ -183,7 +183,7 @@ module Yast
     # @return true on success
     def Write
       if Mode.normal # running in an installed system
-        # Package containing SuSEfirewall2 services has to be installed before
+        # Package containing SuSEfirewall services has to be installed before
         # reading SuSEFirewall, otherwise exception is thrown by firewall
         if Package.Install(PKG_CONTAINING_FW_SERVICES)
           current_progress = Progress.set(false)

--- a/src/modules/Routing.rb
+++ b/src/modules/Routing.rb
@@ -165,12 +165,7 @@ module Yast
 
     # Reads current status for both IPv4 and IPv6 forwarding
     def ReadIPForwarding
-      @Forward_v4 = if SuSEFirewall.IsEnabled
-        SuSEFirewall.GetSupportRoute
-      else
-        SCR.Read(path(SYSCTL_IPV4_PATH)) == "1"
-      end
-
+      @Forward_v4 = SCR.Read(path(SYSCTL_IPV4_PATH)) == "1"
       @Forward_v6 = SCR.Read(path(SYSCTL_IPV6_PATH)) == "1"
 
       log.info("Forward_v4=#{@Forward_v4}")
@@ -185,15 +180,11 @@ module Yast
     def write_ipv4_forwarding(forward_ipv4)
       sysctl_val = forward_ipv4 ? "1" : "0"
 
-      if SuSEFirewall.IsEnabled
-        SuSEFirewall.SetSupportRoute(forward_ipv4)
-      else
-        SCR.Write(
-          path(SYSCTL_IPV4_PATH),
-          sysctl_val
-        )
-        SCR.Write(path(SYSCTL_AGENT_PATH), nil)
-      end
+      SCR.Write(
+        path(SYSCTL_IPV4_PATH),
+        sysctl_val
+      )
+      SCR.Write(path(SYSCTL_AGENT_PATH), nil)
 
       SCR.Execute(path(".target.bash"), "sysctl -w #{IPV4_SYSCTL}=#{sysctl_val}")
 
@@ -206,8 +197,6 @@ module Yast
     def write_ipv6_forwarding(forward_ipv6)
       sysctl_val = forward_ipv6 ? "1" : "0"
 
-      # SuSEfirewall2 has no direct support for IPv6 (aka FW_FORWARD).
-      # Sysctl has to be configured manualy. bnc#916013
       SCR.Write(
         path(SYSCTL_IPV6_PATH),
         sysctl_val

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -23,39 +23,17 @@ describe Yast::Routing do
       allow(Yast::SCR).to receive(:Execute) { nil }
     end
 
-    context "when Firewall is enabled" do
-      before(:each) do
-        allow(Yast::SuSEFirewall).to receive(:IsEnabled) { true }
-      end
+    describe "#WriteIPForwarding" do
+      it "Updates IPv4 and IPv6 forwarding in sysctl.conf" do
+        allow(Yast::SCR).to receive(:Write) { nil }
+        expect(Yast::SCR)
+          .to receive(:Write)
+          .with(SYSCTL_IPV4_PATH, @value4)
+        expect(Yast::SCR)
+          .to receive(:Write)
+          .with(SYSCTL_IPV6_PATH, @value6)
 
-      describe "#WriteIPForwarding" do
-        it "Delegates setup to SuSEFirewall2" do
-          expect(Yast::SuSEFirewall)
-            .to receive(:SetSupportRoute)
-            .with(forward_v4)
-
-          expect(Yast::Routing.WriteIPForwarding).to be_equal nil
-        end
-      end
-    end
-
-    context "when Firewall is disabled" do
-      before(:each) do
-        allow(Yast::SuSEFirewall).to receive(:IsEnabled) { false }
-      end
-
-      describe "#WriteIPForwarding" do
-        it "Updates IPv4 and IPv6 forwarding in sysctl.conf" do
-          allow(Yast::SCR).to receive(:Write) { nil }
-          expect(Yast::SCR)
-            .to receive(:Write)
-            .with(SYSCTL_IPV4_PATH, @value4)
-          expect(Yast::SCR)
-            .to receive(:Write)
-            .with(SYSCTL_IPV6_PATH, @value6)
-
-          expect(Yast::Routing.WriteIPForwarding).to be_equal nil
-        end
+        expect(Yast::Routing.WriteIPForwarding).to be_equal nil
       end
     end
   end


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/oGANpKhQ/1190-5-research-poc-replace-susefirewall2-with-firewalld)
- https://fate.suse.com/323460

It replaces #503 
