### PR TITLE
Improved device name collision recognition in autoinstallation

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Dec 11 08:26:58 UTC 2017 - mfilka@suse.com
+
+- bnc#1056109
+  - improved device name collision recognition when applying device
+    renaming according to the AY profile
+- 3.1.185
+
+-------------------------------------------------------------------
 Wed Nov 15 19:22:41 UTC 2017 - knut.anderssen@suse.com
 
 - bnc#1066982

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.184
+Version:        3.1.185
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -280,20 +280,34 @@ module Yast
         end
         next if !matching_item
 
-        name_from = LanItems.GetDeviceName(item)
+        name_from = item_name(item)
         log.info("Matching device found - renaming <#{name_from}> -> <#{name_to}>")
 
-        # find rule in collision
-        colliding_item, _item_map = LanItems.Items.find do |i, _|
-          LanItems.GetDeviceName(i) == name_to
-        end
-
         # rename item in collision
-        rename_lan_item(colliding_item, name_from)
+        rename_lan_item(colliding_item(name_to), name_from)
 
         # rename matching item
         rename_lan_item(item, name_to, attr, key)
       end
+    end
+
+    # Returns items id, taking into account that item could be renamed
+    #
+    # @return [String] device name
+    def item_name(item_id)
+      LanItems.renamed?(item_id) ? LanItems.renamed_to(item_id) : LanItems.GetDeviceName(item_id)
+    end
+
+    # Finds a LanItem which name is in collision to the provided name
+    #
+    # @param [String] a device name (eth0, ...)
+    # @return [Integer] item id (see LanItems::Items)
+    def colliding_item(name)
+      colliding_item, _item_map = LanItems.Items.find do |i, _|
+        name == item_name(i)
+      end
+
+      colliding_item
     end
   end
 end

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -240,6 +240,7 @@ module Yast
 
       # selecting according device name is unreliable (selects only in between configured devices)
       LanItems.current = item
+      LanItems.InitItemUdevRule(item)
 
       if !attr.nil? && !key.nil?
         # find out what attribude is currently used for setting device name and

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -350,6 +350,34 @@ module Yast
       Ops.get_list(GetLanItem(itemId), ["udev", "net"], [])
     end
 
+    # Sets udev rule for given item
+    #
+    # @param itemId [Integer] a key for {#Items}
+    # @param rule   [String]  an udev rule
+    def SetItemUdevRule(itemId, rule)
+      GetLanItem(itemId)["udev"]["net"] = rule
+    end
+
+    # Inits item's udev rule to a default one if none is present
+    #
+    # @param itemId [Integer] a key for {#Items}
+    # @return [String] item's udev rule
+    def InitItemUdevRule(item_id)
+      udev = GetItemUdevRule(item_id)
+      return udev if !udev.empty?
+
+      default_mac = GetLanItem(item_id).fetch("hwinfo", {})["mac"]
+      raise ArgumentError, "Cannot propose udev rule - NIC not present" if !default_mac
+
+      default_udev = GetDefaultUdevRule(
+        GetCurrentName(),
+        default_mac
+      )
+      SetItemUdevRule(item_id, default_udev)
+
+      default_udev
+    end
+
     def ReadUdevDriverRules
       Builtins.y2milestone("Reading udev rules ...")
       @udev_net_rules = Convert.convert(

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -370,7 +370,7 @@ module Yast
       raise ArgumentError, "Cannot propose udev rule - NIC not present" if !default_mac
 
       default_udev = GetDefaultUdevRule(
-        GetCurrentName(),
+        GetDeviceName(item_id),
         default_mac
       )
       SetItemUdevRule(item_id, default_udev)

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -594,7 +594,7 @@ module Yast
     #
     # @param item_id [Integer] a key for {#Items}
     def renamed_to(item_id)
-      @Items[item_id]["renamed_to"]
+      Items()[item_id]["renamed_to"]
     end
 
     def current_renamed_to
@@ -605,7 +605,7 @@ module Yast
     #
     # @param item_id [Integer] a key for {#Items}
     def renamed?(item_id)
-      return false if !LanItems.Items[item_id].key?("renamed_to")
+      return false if !renamed_to(item_id)
       renamed_to(item_id) != GetDeviceName(item_id)
     end
 

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -142,8 +142,8 @@ describe "LanItems#InitItemUdev" do
       .to receive(:Items)
       .and_return(
         0 => {
-          "ifcfg"      => "eth0",
-          "udev"       => {
+          "ifcfg" => "eth0",
+          "udev"  => {
             "net" => udev_rule("24:be:05:ce:1e:91", "eth0")
           }
         },
@@ -153,7 +153,7 @@ describe "LanItems#InitItemUdev" do
             "dev_name" => "eth1"
           },
           # always exists
-          "udev" => {
+          "udev"   => {
             "net" => []
           }
         }

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -125,6 +125,50 @@ describe "LanItemsClass#s390_correct_lladdr" do
   end
 end
 
+describe "LanItems#InitItemUdev" do
+  def udev_rule(mac, name)
+    [
+      "SUBSYSTEM==\"net\"",
+      "ACTION==\"add\"",
+      "DRIVERS==\"?*\"",
+      "ATTR{address}==\"#{mac}\"",
+      "ATTR{type}==\"1\"",
+      "NAME=\"#{name}\""
+    ]
+  end
+
+  before(:each) do
+    allow(Yast::LanItems)
+      .to receive(:Items)
+      .and_return(
+        0 => {
+          "ifcfg"      => "eth0",
+          "udev"       => {
+            "net" => udev_rule("24:be:05:ce:1e:91", "eth0")
+          }
+        },
+        1 => {
+          "hwinfo" => {
+            "mac"      => "00:00:00:00:00:01",
+            "dev_name" => "eth1"
+          },
+          # always exists
+          "udev" => {
+            "net" => []
+          }
+        }
+      )
+  end
+
+  it "returns existing udev rule if there is any already" do
+    expect(Yast::LanItems.InitItemUdevRule(0)).to eql udev_rule("24:be:05:ce:1e:91", "eth0")
+  end
+
+  it "creates new udev rule if none is present" do
+    expect(Yast::LanItems.InitItemUdevRule(1)).to eql udev_rule("00:00:00:00:00:01", "eth1")
+  end
+end
+
 describe "LanItems#GetItemUdev" do
   def check_GetItemUdev(key, expected_value)
     expect(Yast::LanItems.GetItemUdev(key)).to eql expected_value

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -406,4 +406,34 @@ describe "NetworkAutoYast" do
       end
     end
   end
+
+  describe "#item_name" do
+    def mock_lan_item(renamed_to: nil)
+      allow(Yast::LanItems)
+        .to receive(:Items)
+        .and_return(0 => {
+          "ifcfg"   => "eth0",
+          "renamed_to" => !renamed_to.nil? ? renamed_to : nil,
+          "udev" => {
+            "net" => [
+              "ATTR{address}==\"24:be:05:ce:1e:91\"",
+              "NAME=\"#{renamed_to}\""
+            ]
+          }
+        })
+    end
+
+    it "returns old name when device has not been renamed" do
+      mock_lan_item
+
+      expect(network_autoyast.send(:item_name, 0)).to eql "eth0"
+    end
+
+    it "returns new name when device has been renamed" do
+      new_name = "new1"
+      mock_lan_item(renamed_to: new_name)
+
+      expect(network_autoyast.send(:item_name, 0)).to eql new_name
+    end
+  end
 end

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -414,7 +414,7 @@ describe "NetworkAutoYast" do
         .and_return(
           0 => {
             "ifcfg"      => "eth0",
-            "renamed_to" => !renamed_to.nil? ? renamed_to : nil,
+            "renamed_to" => renamed_to,
             "udev"       => {
               "net" => [
                 "ATTR{address}==\"24:be:05:ce:1e:91\"",

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -532,6 +532,17 @@ describe "NetworkAutoYast" do
         Yast::LanItems.Read
       end
 
+      # see bnc#1056109
+      # - basically dev_name is renamed_to || ifcfg || hwinfo.devname for purposes
+      # of this test (ifcfg is name distinguished from sysconfig configuration,
+      # hwinfo.devname is name assigned by kernel during device initialization and
+      # renamed_to is new device name assigned by user when asking for device renaming
+      # - updating udev rules)
+      #
+      # - when we have devices <eth0, eth1, eth2> and ruleset defined in AY profile
+      # which renames these devices it could, before the fix, happen that after
+      # applying of the ruleset we could end with new nameset e.g. <eth2, eth0, eth0>
+      # which obviously leads to misconfiguration of the system
       it "applies rules so, that names remain unique" do
         network_autoyast.send(:assign_udevs_to_devs, udev_rules)
 

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -353,7 +353,7 @@ describe "NetworkAutoYast" do
     before(:each) do
       allow(Yast::LanItems)
         .to receive(:Items)
-        .and_return(0 => { "ifcfg" => "eth0" })
+        .and_return(0 => { "ifcfg" => "eth0", "udev" => { "net" => ["ATTR{address}==\"24:be:05:ce:1e:91\"", "KERNEL==\"eth*\"", "NAME=\"eth0\""] } })
     end
 
     context "valid arguments given" do

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -407,7 +407,7 @@ describe "NetworkAutoYast" do
     end
   end
 
-  describe "#item_name" do
+  context "When creating udev rules based on the AY profile" do
     def mock_lan_item(renamed_to: nil)
       allow(Yast::LanItems)
         .to receive(:Items)
@@ -425,17 +425,39 @@ describe "NetworkAutoYast" do
         )
     end
 
-    it "returns old name when device has not been renamed" do
-      mock_lan_item
+    describe "#item_name" do
+      it "returns old name when the device has not been renamed" do
+        mock_lan_item
 
-      expect(network_autoyast.send(:item_name, 0)).to eql "eth0"
+        expect(network_autoyast.send(:item_name, 0)).to eql "eth0"
+      end
+
+      it "returns new name when the device has been renamed" do
+        new_name = "new1"
+        mock_lan_item(renamed_to: new_name)
+
+        expect(network_autoyast.send(:item_name, 0)).to eql new_name
+      end
     end
 
-    it "returns new name when device has been renamed" do
-      new_name = "new1"
-      mock_lan_item(renamed_to: new_name)
+    describe "#colliding_item" do
+      it "returns nothing if no collision was found" do
+        mock_lan_item
 
-      expect(network_autoyast.send(:item_name, 0)).to eql new_name
+        expect(network_autoyast.send(:colliding_item, "enp0s3")).to be nil
+      end
+
+      it "returns device name which is in collision" do
+        mock_lan_item
+
+        expect(network_autoyast.send(:colliding_item, "eth0")).to be 0
+      end
+
+      it "returns device name when the device was already renamed before and we new name is in collision" do
+        mock_lan_item(renamed_to: "enp0s3")
+
+        expect(network_autoyast.send(:colliding_item, "enp0s3")).to be 0
+      end
     end
   end
 end

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -411,16 +411,18 @@ describe "NetworkAutoYast" do
     def mock_lan_item(renamed_to: nil)
       allow(Yast::LanItems)
         .to receive(:Items)
-        .and_return(0 => {
-          "ifcfg"   => "eth0",
-          "renamed_to" => !renamed_to.nil? ? renamed_to : nil,
-          "udev" => {
-            "net" => [
-              "ATTR{address}==\"24:be:05:ce:1e:91\"",
-              "NAME=\"#{renamed_to}\""
-            ]
+        .and_return(
+          0 => {
+            "ifcfg"      => "eth0",
+            "renamed_to" => !renamed_to.nil? ? renamed_to : nil,
+            "udev"       => {
+              "net" => [
+                "ATTR{address}==\"24:be:05:ce:1e:91\"",
+                "NAME=\"#{renamed_to}\""
+              ]
+            }
           }
-        })
+        )
     end
 
     it "returns old name when device has not been renamed" do

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -459,5 +459,90 @@ describe "NetworkAutoYast" do
         expect(network_autoyast.send(:colliding_item, "enp0s3")).to be 0
       end
     end
+
+    describe "#assign_udevs_to_devs" do
+      Yast.import "LanItems"
+
+      let(:udev_rules) do
+        [
+          {
+            "name"  => "eth1",
+            "rule"  => "KERNELS",
+            "value" => "0000:01:00.0"
+          },
+          {
+            "name"  => "eth0",
+            "rule"  => "KERNELS",
+            "value" => "0000:01:00.2"
+          }
+        ]
+      end
+
+      let(:persistent_udevs) do
+        {
+          "eth0" => [
+            "KERNELS==\"0000:01:00.0\"",
+            "NAME=eth0"
+          ],
+          "eth1" => [
+            "KERNELS==\"0000:01:00.1\"",
+            "NAME=eth1"
+          ],
+          "eth2" => [
+            "KERNELS==\"0000:01:00.2\"",
+            "NAME=eth2"
+          ]
+        }
+      end
+
+      let(:hw_netcard) do
+        [
+          {
+            "dev_name" => "eth0",
+            "busid"    => "0000:01:00.0",
+            "mac"      => "00:00:00:00:00:00"
+          },
+          {
+            "dev_name" => "eth1",
+            "busid"    => "0000:01:00.1",
+            "mac"      => "00:00:00:00:00:01"
+          },
+          {
+            "dev_name" => "eth2",
+            "busid"    => "0000:01:00.2",
+            "mac"      => "00:00:00:00:00:02"
+          }
+        ]
+      end
+
+      before(:each) do
+        allow(Yast::LanItems)
+          .to receive(:ReadHardware)
+          .with("netcard")
+          .and_return(hw_netcard)
+        allow(Yast::NetworkInterfaces)
+          .to receive(:Read)
+          .and_return(true)
+        # respective agent is not able to change scr root
+        allow(Yast::SCR)
+          .to receive(:Read)
+          .with(path(".udev_persistent.net"))
+          .and_return(persistent_udevs)
+
+        Yast::LanItems.Read
+      end
+
+      it "applies rules so, that names remain unique" do
+        network_autoyast.send(:assign_udevs_to_devs, udev_rules)
+
+        lan_items = Yast::LanItems
+        names = lan_items.Items.keys.map do |i|
+          lan_items.renamed?(i) ? lan_items.renamed_to(i) : lan_items.GetDeviceName(i)
+        end
+
+        # check if device names are unique
+        expect(names.sort).to eql ["eth0", "eth1", "eth2"]
+      end
+    end
   end
 end


### PR DESCRIPTION
[bsc#1056109](https://bugzilla.suse.com/show_bug.cgi?id=1056109)
https://trello.com/c/A0ujYsUt
Previously on this topic: #533 

This PR solves issues when ay udev rules leads to a collision in device renaming. For example when AY profile defines rule eth0 -> eth1 (-> means "rename to") and eth1 exists in the system. 