### PR TITLE
Removed unnecesary SuSEFirewall.Write (bnc#1066982)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Wed Nov 15 19:22:41 UTC 2017 - knut.anderssen@suse.com
 
-- bnc#106682
+- bnc#1066982
   - Removed an unnecesary SuSEFirewall.Write call when storing the
     Firewall remote client configuration.
 - 3.1.184

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Nov 15 19:22:41 UTC 2017 - knut.anderssen@suse.com
+
+- bnc#106682
+  - Removed an unnecesary SuSEFirewall.Write call when storing the
+    Firewall remote client configuration.
+- 3.1.184
+
+-------------------------------------------------------------------
 Tue Nov 14 17:05:47 UTC 2017 - jreidinger@suse.com
 
 - bnc#1066982

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.183
+Version:        3.1.184
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/network/remote/dialogs.rb
+++ b/src/include/network/remote/dialogs.rb
@@ -159,8 +159,6 @@ module Yast
       end
       if ret == :next
         CWMFirewallInterfaces.OpenFirewallStore(firewall_widget, "", event)
-        # OpenFirewallStore just sets variables, but we need real firewall write
-        SuSEFirewall.Write
 
         allow_with_vncmanager = UI.QueryWidget(Id(:allow_with_vncmanager), :Value)
         allow_without_vncmanager = UI.QueryWidget(Id(:allow_without_vncmanager), :Value)


### PR DESCRIPTION
The problem is that as the progress is not disabled the values of the Remote allowing widgets are not read correctly and are written as disabled.

BTW the call is not needed as Remote.Write already writes the SuSEFirewall configuration.

https://github.com/yast/yast-network/blob/master/src/modules/Remote.rb#L219

This PR fix the issue.

Also for record, the origin of the problem was that the SuSEFirewall.Read was moved from Remote.Read method to the Write part in this PR:

 https://github.com/yast/yast-network/pull/513
