### PR TITLE
Do not display a warning about disabled second stage

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Nov 22 11:59:22 UTC 2017 - knut.anderssen@suse.com
+
+- AutoYaST: Do not display a warning about second stage being
+  disabled when importing the DNS configuration (added in 3.3.1)
+  once  the network configuration is done during the first stage
+  (since version 3.3.3) (bsc#1069761)
+- 4.0.9
+
+-------------------------------------------------------------------
 Wed Nov 15 19:22:41 UTC 2017 - knut.anderssen@suse.com
 
 - bnc#1066982

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.0.8
+Version:        4.0.9
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -395,8 +395,6 @@ module Yast
       if Builtins.haskey(settings, "hostname")
         @hostname = Ops.get_string(settings, "hostname", "")
         @domain = Ops.get_string(settings, "domain", "") # empty is not a bug, bnc#677471
-        # print a warning in unsupported scenarios
-        warn_unsupported
       else
         # otherwise, check 1) install.inf 2) /etc/HOSTNAME
         ReadHostname()
@@ -597,25 +595,6 @@ module Yast
     end
 
   private
-
-    # check for AY unsupported scenarios, the name servers and the search domains
-    # are written in the 2nd stage, if is disabled then it cannot work (bsc#1046198)
-    def warn_unsupported
-      return if !Stage.initial || !Mode.auto || @error_reported || empty?
-
-      # lazy loading to avoid the dependency on AutoYaST, this can be imported only
-      # in the initial stage otherwise it might fail!
-      Yast.import "AutoinstConfig"
-
-      # the 2nd stage is enabled or the network is configured before the proposal
-      return if AutoinstConfig.second_stage || AutoinstConfig.network_before_proposal
-
-      # TRANSLATORS: Warning message, the AutoYaST XML profile is incorrect
-      Report.Warning(_("DNS configuration error: The DNS configuration\n" \
-        "is written in the second installation stage (after reboot)\n" \
-        "but the second stage is disabled in the AutoYaST XML profile."))
-      @error_reported = true
-    end
 
     def read_hostname_from_install_inf
       install_inf_hostname = SCR.Read(path(".etc.install_inf.Hostname")) || ""

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -617,12 +617,6 @@ module Yast
       fqhostname
     end
 
-    # empty configuration?
-    # @return [Boolean] true if the configuration is empty (or contains defaults)
-    def empty?
-      @nameservers.empty? && @searchlist.empty? && @hostname.empty? && @domain.empty?
-    end
-
     # Updates /etc/sysconfig/network/dhcp
     def update_sysconfig_dhcp
       if dhclient_set_hostname != @dhcp_hostname || get_write_hostname_to_hosts != @write_hostname

--- a/test/dns_test.rb
+++ b/test/dns_test.rb
@@ -105,59 +105,6 @@ module Yast
           expect(DNS.dhcp_hostname).to eql(false)
         end
       end
-
-      context "The AutoYaST first stage installation" do
-        let(:settings) { { "hostname" => "host", "searchlist" => ["example.com"] } }
-        let(:second_stage) { false }
-        let(:network_before_proposal) { false }
-        let(:autoinst_mock) do
-          double(second_stage: second_stage, network_before_proposal: network_before_proposal)
-        end
-
-        before do
-          allow(Yast::Stage).to receive(:initial).and_return(true)
-          allow(Yast::Mode).to receive(:auto).and_return(true)
-          allow(Yast).to receive(:import).with("AutoinstConfig")
-          # reset the internal counter
-          DNS.instance_variable_set(:@error_reported, false)
-          stub_const("Yast::AutoinstConfig", autoinst_mock)
-        end
-
-        context "with 2nd stage enabled" do
-          let(:second_stage) { true }
-
-          it "does not print a warning for writing the search list" do
-            expect(Yast::Report).to_not receive(:Warning)
-            DNS.hostname = "test"
-            DNS.Import({})
-          end
-        end
-
-        context "with 2nd stage disabled" do
-          it "does not print a warning if the network is configured before the proposal" do
-            stub_const("Yast::AutoinstConfig",
-              double(second_stage: false, network_before_proposal: true))
-            expect(Yast::Report).to_not receive(:Warning)
-            DNS.Import(settings)
-          end
-
-          it "does not print a warning when the hostname is set out of the profile" do
-            expect(Yast::Report).to_not receive(:Warning)
-            DNS.hostname = "test"
-            DNS.Import({})
-          end
-          it "prints a warning for writing the search list" do
-            expect(Yast::Report).to receive(:Warning)
-            DNS.Import(settings)
-          end
-
-          it "prints the warning only once on multiple calls" do
-            expect(Yast::Report).to receive(:Warning).once
-            DNS.Import(settings)
-            DNS.Import(settings)
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
- https://trello.com/c/9aMgl3vG/1197-autoyast-leanos-check-if-dns-warn-is-still-usefull

Once yast-network configures already the DNS when no second stage is available the warn does not make sense anymore.

Here is also the aytest that confirm it is working:

https://github.com/yast/aytests-tests/blob/master/aytests/first_stage_dns.rb