### PR TITLE
Removed useless code

### DIFF
--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -1019,8 +1019,7 @@ module Yast
     # @param [String] key	the widget being validated
     # @param [Hash] event	the event being handled
     # @return whether valid
-    def ValidateBootproto(_key, event)
-      event = deep_copy(event)
+    def ValidateBootproto(_key, _event)
       if UI.QueryWidget(:bootproto, :CurrentButton) == :static
         ipa = Convert.to_string(UI.QueryWidget(:ipaddr, :Value))
         if ipa != "" && !IP.Check(ipa)

--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -1015,33 +1015,6 @@ module Yast
       true
     end
 
-    # If the traffic would be blocked, ask the user
-    # if he wants to change it
-    # @param [Hash] event	the event being handled
-    # @return change it?
-    def NeedToAssignFwZone(event)
-      event = deep_copy(event)
-      ret = Ops.get(event, "ID")
-      if ret == :next
-        # If firewall is active and interface in no zone, nothing
-        # gets through (#62309) so warn and redirect to details
-        name = Convert.to_string(UI.QueryWidget(Id("IFCFGID"), :Value))
-        if SuSEFirewall4Network.IsOn &&
-            SuSEFirewall4Network.GetZoneOfInterface(name) == "" &&
-            SuSEFirewall4Network.UnconfiguredIsBlocked
-          return Popup.YesNoHeadline(
-            Label.WarningMsg,
-            _(
-              "The firewall is active, but this interface is not\n" \
-                "in any zone. All its traffic would be blocked.\n" \
-                "Assign it to a zone now?"
-            )
-          )
-        end
-      end
-      false
-    end
-
     # Validator for network masks adresses
     # @param [String] key	the widget being validated
     # @param [Hash] event	the event being handled
@@ -1097,10 +1070,7 @@ module Yast
           end
         end
       end
-      if NeedToAssignFwZone(event)
-        UI.FakeUserInput("ID" => "t_general")
-        return false
-      end
+
       true
     end
 

--- a/src/modules/SuSEFirewall4Network.rb
+++ b/src/modules/SuSEFirewall4Network.rb
@@ -259,12 +259,6 @@ module Yast
       true
     end
 
-    # @return Whether the UI should warn about interfaces
-    # that are not in any zone
-    def UnconfiguredIsBlocked
-      !SuSEFirewall.IsAnyNetworkInterfaceSupported
-    end
-
     # Function sets that a firewall proposal was changed by user
     # by editing firewall zone of network interface
     # (applicable during 2nd stage of installation only)
@@ -349,7 +343,6 @@ module Yast
     publish function: :IsProtectedByFirewall, type: "boolean (string)"
     publish function: :GetZoneOfInterface, type: "string (string)"
     publish function: :ProtectByFirewall, type: "boolean (string, string, boolean)"
-    publish function: :UnconfiguredIsBlocked, type: "boolean ()"
     publish function: :ChangedByUser, type: "void (boolean)"
     publish function: :IsInstalled, type: "boolean ()"
     publish function: :SetEnabled1stStage, type: "void (boolean)"


### PR DESCRIPTION
In firewalld each device is always assigned to a zone. Either explicitly
or implicitly to a default one provided by firewalld.