### PR TITLE
Propose defaults for SuSEFirewall2 also during an autoinstallation (bsc#1080630)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 26 14:55:08 UTC 2018 - knut.anderssen@suse.com
+
+- SuSEFIrewall2: Allow also (vnc / ssh) access in SuSEFirewall in
+  case of remote auto-installations for the 2st stage (bsc#1080630)
+- 3.2.49
+
+-------------------------------------------------------------------
 Wed Feb 14 10:40:04 UTC 2018 - knut.anderssen@suse.com
 
 - Do not propose network interfaces without link (bsc#1062596)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.2.48
+Version:        3.2.49
 Release:        0
 BuildArch:      noarch
 

--- a/src/clients/firewall_stage1_finish.rb
+++ b/src/clients/firewall_stage1_finish.rb
@@ -143,16 +143,13 @@ module Yast
     def adjust_ay_configuration
       Builtins.y2milestone("Preparing proposal for autoconfiguration.")
       SuSEFirewall4Network.prepare_proposal unless SuSEFirewallProposal.GetChangedByUser
-      enable_fw = SuSEFirewall4Network.Enabled1stStage
-      return unless enable_fw
       enable_sshd = SuSEFirewall4Network.EnabledSshd
       open_ssh = SuSEFirewall4Network.EnabledSsh1stStage
       open_vnc = SuSEFirewall4Network.EnabledVnc1stStage
 
-      log.info "After installation, firewall will be #{enable_fw ? "enabled" : "disabled"}, " \
-        "SSHD will be #{enable_sshd ? "enabled" : "disabled"}, " \
-        "SSH port will be #{open_ssh_port ? "open" : "closed"}, " \
-        "VNC port will be #{open_vnc_port ? "open" : "closed"}"
+      log.info "After installation, SSHD will be #{enable_sshd ? "enabled" : "disabled"}, " \
+        "SSH port will be #{open_ssh ? "open" : "closed"}, " \
+        "VNC port will be #{open_vnc ? "open" : "closed"}"
 
       # Read the configuration from sysconfig
       # bnc#887406: The file is in inst-sys

--- a/src/clients/firewall_stage1_finish.rb
+++ b/src/clients/firewall_stage1_finish.rb
@@ -102,10 +102,13 @@ module Yast
 
     # Convenience method for opening the ssh port during the first stage when
     # enabled
+    #
+    # If the service-file is not part of the current system an exception will
+    # be raised. For that reason, these files have to be part of the inst-sys
+    #
+    # @param open [Boolean] whether the ssh service has to be opened in the
+    # firewall
     def open_ssh_port(open)
-      # Open or close FW ports depending on user decision
-      # This can raise an exception if requested service-files are not part of the current system
-      # For that reason, these files have to be part of the inst-sys
       if known_firewall_services?(SuSEFirewall4NetworkClass::SSH_SERVICES)
         SuSEFirewall.SetServicesForZones(
           SuSEFirewall4NetworkClass::SSH_SERVICES,
@@ -119,6 +122,11 @@ module Yast
 
     # Convenience method for opening the vnc port during the first stage when
     # enabled
+    #
+    # If the service-file is not part of the current system an exception will
+    # be raised. For that reason, these files have to be part of the inst-sys
+    #
+    # @param open [Boolean]
     def open_vnc_port(open)
       if known_firewall_services?(SuSEFirewall4NetworkClass::VNC_SERVICES)
         SuSEFirewall.SetServicesForZones(

--- a/test/firewall_stage1_finish_test.rb
+++ b/test/firewall_stage1_finish_test.rb
@@ -79,7 +79,6 @@ describe Yast::FirewallStage1FinishClient do
       allow(subject).to receive(:open_ssh_port)
       allow(subject).to receive(:open_vnc_port)
       allow(Yast::Linuxrc).to receive(:useiscsi).and_return(false)
-      allow(Yast::SuSEFirewall4Network).to receive(:Enabled1stStage).and_return(true)
     end
 
     context "when the user has not modified the proposal" do
@@ -97,13 +96,6 @@ describe Yast::FirewallStage1FinishClient do
 
         subject.send(:adjust_ay_configuration)
       end
-    end
-
-    it "returns if the firewall is not enabled" do
-      allow(Yast::SuSEFirewall4Network).to receive(:Enabled1stStage).and_return(false)
-      expect(Yast::SuSEFirewall4Network).to_not receive(:EnabledSsh1stStage)
-
-      subject.send(:adjust_ay_configuration)
     end
 
     it "reads the firewall configuration" do

--- a/test/firewall_stage1_finish_test.rb
+++ b/test/firewall_stage1_finish_test.rb
@@ -1,0 +1,127 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+require "yast"
+require_relative "../src/clients/firewall_stage1_finish"
+
+describe Yast::FirewallStage1FinishClient do
+  describe "main" do
+    context "when the client is called with 'Info'" do
+      it "returns a hash with 'steps', 'title' and 'when' keys" do
+
+        res = Yast::WFM.CallFunction("firewall_stage1_finish", ["Info"])
+
+        expect(res).to be_a(Hash)
+        expect(res).to include("steps", "title", "when")
+      end
+    end
+
+    context "when the client is called with 'Write'" do
+      before do
+        allow(Yast::WFM).to receive(:Args).and_return("Write")
+      end
+
+      context "in autoninst Mode" do
+        let(:installed) { false }
+
+        before do
+          allow(Yast::Mode).to receive(:autoinst).and_return(true)
+          allow(Yast::SuSEFirewall).to receive(:WriteConfiguration)
+          allow(Yast::Service).to receive(:Enable)
+          allow(Yast::SuSEFirewall4Network).to receive(:IsInstalled).and_return(installed)
+          allow(subject).to receive(:adjust_ay_configuration)
+        end
+
+        context "with SuSEfirewall2 installed" do
+          let(:installed) { true }
+
+          it "allows the remote installations in use in the SuSEFirewall configuration" do
+            expect(subject).to receive(:adjust_ay_configuration)
+
+            subject.main
+          end
+        end
+
+        context "without SuSEFirewall installed" do
+          it "does nothing special for AutoYaST" do
+            expect(subject).to_not receive(:adjust_ay_configuration)
+
+            subject.main
+          end
+        end
+      end
+
+      it "enables the sshd service in case of ssh remote installation" do
+        expect(Yast::SuSEFirewall4Network).to receive(:EnabledSshd).and_return(true)
+        expect(Yast::Service).to receive(:Enable).with("sshd")
+
+        subject.main
+      end
+
+      it "writes the SuSEFirewall configuration" do
+        expect(Yast::SuSEFirewall).to receive(:WriteConfiguration)
+
+        subject.main
+      end
+    end
+  end
+
+  describe "#adjust_ay_configuration" do
+    before do
+      allow(Yast::Progress).to receive(:set)
+      allow(Yast::SuSEFirewall).to receive(:Read)
+      allow(subject).to receive(:open_ssh_port)
+      allow(subject).to receive(:open_vnc_port)
+      allow(Yast::Linuxrc).to receive(:useiscsi).and_return(false)
+      allow(Yast::SuSEFirewall4Network).to receive(:Enabled1stStage).and_return(true)
+    end
+
+    context "when the user has not modified the proposal" do
+      it "obtains the linuxrc options and defauls from the control file" do
+        allow(Yast::SuSEFirewallProposal).to receive(:GetChangedByUser).and_return(false)
+        expect(Yast::SuSEFirewall4Network).to receive(:prepare_proposal)
+
+        subject.send(:adjust_ay_configuration)
+      end
+    end
+
+    context "when the user has modified the proposal" do
+      it "does not modify it" do
+        allow(Yast::SuSEFirewallProposal).to receive(:GetChangedByUser).and_return(true)
+        expect(Yast::SuSEFirewall4Network).to_not receive(:prepare_proposal)
+
+        subject.send(:adjust_ay_configuration)
+      end
+    end
+
+    it "returns if the firewall is not enabled" do
+      expect(Yast::SuSEFirewall4Network).to receive(:Enabled1stStage).and_return(false)
+      expect(Yast::SuSEFirewall4Network).to_not receive(:EnabledSsh1stStage)
+
+      subject.send(:adjust_ay_configuration)
+    end
+
+    it "reads the firewall configuration" do
+      expect(Yast::SuSEFirewall).to receive(:Read)
+
+      subject.send(:adjust_ay_configuration)
+    end
+
+    it "opens remote access in the firewall when correspond" do
+      expect(Yast::SuSEFirewall4Network).to receive(:EnabledSsh1stStage).and_return(true)
+      expect(Yast::SuSEFirewall4Network).to receive(:EnabledVnc1stStage).and_return(false)
+      expect(subject).to receive(:open_ssh_port).with(true)
+      expect(subject).to receive(:open_vnc_port).with(false)
+
+      subject.send(:adjust_ay_configuration)
+    end
+
+    it "enables firewall complete access in case of a iscsi installation" do
+      expect(Yast::Linuxrc).to receive(:useiscsi).and_return(true)
+      expect(Yast::SuSEFirewallProposal).to receive(:propose_iscsi)
+
+      subject.send(:adjust_ay_configuration)
+    end
+  end
+end


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/pKkPMQI4/1332-3-sle-12-sp3-l3-if-firewall-is-enabled-in-autoyast-ssh-is-not-being-allowed)
- https://bugzilla.suse.com/show_bug.cgi?id=1080630

The problem itself is described in the bug and in the Trello Card but as a summary:

After some changes in the systemd dependencies of our `Second Stage.service`, the SuSEFirewall2 configuration defined in the profiles is applied after the SuSEFirewall2 has already started. We avoided to touch the SuSEFirewall2 services during installation because a deadlock we had in the past, which means that he configuration of the profiles is not applied until the service is not restarted.

So this is the solution proposed taking in account if we don't want to bring back the previous systemd `Before` dependencies.

## Proposed Solution

During an auto-installation, if `SuSEFIrewall2` is part of the software selection and installed, we configure the `SuSEFirewall2` with the defaults settings obtained from the profile and/or enable specific access in case of remote installations (`vnc / ssh`) and in case of an `iscsi` installation (`linuxrc option`) we enable full access during the boot of the `Second Stage`.

For finishing the AutoYaST firewall configuration we should also apply the changes (https://github.com/yast/yast-yast2/pull/701), that is bring back the activation of services.