### PR TITLE
 Do not crash when some LanItem does not have hardware info. 

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar  6 11:15:12 UTC 2018 - knut.anderssen@suse.com
+
+- bsc#1078991
+  - Do not crash when some LanItem does not have hardware info.
+- 3.1.186
+
+-------------------------------------------------------------------
 Mon Dec 11 08:26:58 UTC 2017 - mfilka@suse.com
 
 - bnc#1056109

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.1.185
+Version:        3.1.186
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -277,7 +277,8 @@ module Yast
 
         # find item which matches to the given rule definition
         item, matching_item = LanItems.Items.find do |_, i|
-          i["hwinfo"]["busid"].downcase == key || i["hwinfo"]["mac"].downcase == key
+          i["hwinfo"] &&
+            (i["hwinfo"]["busid"].downcase == key || i["hwinfo"]["mac"].downcase == key)
         end
         next if !matching_item
 

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -471,6 +471,11 @@ describe "NetworkAutoYast" do
             "value" => "0000:01:00.0"
           },
           {
+            "name"  => "eth3",
+            "rule"  => "KERNELS",
+            "value" => "0000:01:00.4"
+          },
+          {
             "name"  => "eth0",
             "rule"  => "KERNELS",
             "value" => "0000:01:00.2"
@@ -530,6 +535,7 @@ describe "NetworkAutoYast" do
           .and_return(persistent_udevs)
 
         Yast::LanItems.Read
+        Yast::LanItems.Items[3] = { "ifcfg" => "eth3" }
       end
 
       # see bnc#1056109
@@ -552,7 +558,7 @@ describe "NetworkAutoYast" do
         end
 
         # check if device names are unique
-        expect(names.sort).to eql ["eth0", "eth1", "eth2"]
+        expect(names.sort).to eql ["eth0", "eth1", "eth2", "eth3"]
       end
     end
   end


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/eLMiRWmH/1350-bug-1078991-l3-autoyast-unable-to-find-disk-with-option-withfcoe)
- https://bugzilla.suse.com/show_bug.cgi?id=1078991

We are filtering out the read of harware info for some kind of interfaces

https://github.com/yast/yast-network/blob/541266e3bdf64aa7ee62ed8dfaa7a04a42e4ec55/src/include/network/routines.rb#L639
https://github.com/yast/yast-network/blob/541266e3bdf64aa7ee62ed8dfaa7a04a42e4ec55/src/include/network/routines.rb#L893

For that interfaces and probably also for virtual ones there will not be a hwinfo hash as part of the LanItems entries, so we should warranty that it exists before check the bus_id or mac