### PR TITLE
Added missing "textdomain" call (bsc#1081466)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 27 12:26:15 UTC 2018 - lslezak@suse.cz
+
+- Added missing "textdomain" call to properly translate the
+  web access check box label (bsc#1081466)
+- 4.0.24
+
+-------------------------------------------------------------------
 Wed Mar 21 23:20:26 UTC 2018 - knut.anderssen@suse.com
 
 - Added networking interfaces 'zone' element to the AutoYaST schema

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.0.23
+Version:        4.0.24
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/y2remote/widgets/remote.rb
+++ b/src/lib/y2remote/widgets/remote.rb
@@ -157,6 +157,10 @@ module Y2Remote
 
     # Checkbox widget for setting vnc web access as enabled when checked.
     class AllowWeb < CWM::CheckBox
+      def initialize
+        textdomain "network"
+      end
+
       def label
         _("Enable access using a &web browser")
       end
@@ -178,6 +182,7 @@ module Y2Remote
           "services"        => ["tigervnc", "tigervnc-https"],
           "display_details" => true
         )
+        textdomain "network"
       end
 
       def init


### PR DESCRIPTION
- Properly translate the web access check box label
- See https://bugzilla.suse.com/show_bug.cgi?id=1081466
- The second `textdomain` call is actually not needed (no translatable text in that class so far), but fixed as well to avoid similar issue in the future
- 4.0.24

## Original Dialog

![remote_broken_translation](https://user-images.githubusercontent.com/907998/37967420-9960c400-31cb-11e8-95d7-798452b750de.png)


## Fixed Translation

![remote_fixed_translation](https://user-images.githubusercontent.com/907998/37967427-9ee0dbae-31cb-11e8-8d76-288e346a9b62.png)
