### PR TITLE
Fixed restart of services & firewalld services modifications

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Apr 19 00:31:15 UTC 2018 - knut.anderssen@suse.com
+
+- Y2Remote:
+  - Fixed the start of services when writing (bsc#1088646)
+  - Fixed the modification of vnc services configuration according
+    to the selection of allowed interfaces (bsc#1088647)
+- 4.0.26
+
+-------------------------------------------------------------------
 Fri Apr  6 16:17:45 UTC 2018 - knut.anderssen@suse.com
 
 - Fixed preformatted proposal for network module (bsc#1088488)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.0.25
+Version:        4.0.26
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/y2remote/modes.rb
+++ b/src/lib/y2remote/modes.rb
@@ -48,9 +48,11 @@ module Y2Remote
     # @param [Array<Y2Remote::Modes::Base>] list of modes to be restarted, the
     # rest will be stopped
     def self.restart_modes(enable_modes = [])
-      all.each do |mode|
-        enable_modes.include?(mode.instance) ? mode.instance.restart! : mode.instance.stop!
-      end
+      # There are conflicts between modes. Therefore we have to stop first the
+      # disabled ones.
+      all.each { |mc| mc.instance.stop! unless enable_modes.include?(mc.instance) }
+
+      enable_modes.each(&:restart!)
     end
 
     # Enable all the given list of Y2Remote::Modes::Base instances and

--- a/src/lib/y2remote/remote.rb
+++ b/src/lib/y2remote/remote.rb
@@ -30,8 +30,7 @@ module Y2Remote
     include Yast::I18n
 
     GRAPHICAL_TARGET = "graphical".freeze
-
-    FIREWALL_SERVICES_PACKAGE = "xorg-x11-Xvnc".freeze
+    FIREWALL_SERVICES = ["tigervnc", "tigervnc-https"].freeze
 
     # List of Y2Remote::Modes::Base subclasses that are the enabled VNC running
     # modes

--- a/src/lib/y2remote/remote.rb
+++ b/src/lib/y2remote/remote.rb
@@ -174,7 +174,7 @@ module Y2Remote
     # Restarts services, reporting errors to the user
     def restart_services
       Yast::SystemdTarget.set_default(GRAPHICAL_TARGET) if enabled?
-      Y2Remote::Modes.restart_modes
+      Y2Remote::Modes.restart_modes(modes)
 
       display_manager.restart if enabled?
     end

--- a/src/lib/y2remote/widgets/remote.rb
+++ b/src/lib/y2remote/widgets/remote.rb
@@ -177,28 +177,47 @@ module Y2Remote
     # Widget for opening VNC services in the firewall
     class RemoteFirewall < CWM::CustomWidget
       attr_accessor :cwm_interfaces
+
+      # Constructor
       def initialize
+        textdomain "network"
         @cwm_interfaces = Yast::CWMFirewallInterfaces.CreateOpenFirewallWidget(
-          "services"        => ["tigervnc", "tigervnc-https"],
+          "services"        => services,
           "display_details" => true
         )
-        textdomain "network"
+      end
+
+      def opt
+        [:notify]
       end
 
       def init
-        Yast::CWMFirewallInterfaces.OpenFirewallInit(@cwm_interfaces, "")
+        Yast::CWMFirewallInterfaces.OpenFirewallInit(cwm_interfaces, "")
       end
 
       def contents
-        @cwm_interfaces["custom_widget"]
+        cwm_interfaces["custom_widget"]
       end
 
       def help
-        @cwm_interfaces["help"] || ""
+        cwm_interfaces["help"] || ""
       end
 
       def handle(event)
-        Yast::CWMFirewallInterfaces.OpenFirewallHandle(@cwm_interfaces, "", event)
+        Yast::CWMFirewallInterfaces.OpenFirewallHandle(cwm_interfaces, "", event)
+      end
+
+      # Applies the configuration of the vnc services according to the allowed
+      # interfaces.
+      def store
+        Yast::CWMFirewallInterfaces.StoreAllowedInterfaces(services)
+      end
+
+    private
+
+      # Convenience method to obtain the vnc firewalld services
+      def services
+        Y2Remote::Remote::FIREWALL_SERVICES
       end
     end
   end

--- a/test/lib/y2remote/widgets/remote_test.rb
+++ b/test/lib/y2remote/widgets/remote_test.rb
@@ -150,6 +150,41 @@ describe Y2Remote::Widgets do
   end
 
   describe Y2Remote::Widgets::RemoteFirewall do
+    let("firewall_widget") { { "help" => "", "custom_widget" => Yast::Term.new(:Empty) } }
     include_examples "CWM::CustomWidget"
+
+    before do
+      allow(Yast::CWMFirewallInterfaces).to receive(:CreateOpenFirewallWidget)
+        .and_return(firewall_widget)
+      allow(Yast::CWMFirewallInterfaces).to receive(:OpenFirewallInit)
+      allow(Yast::CWMFirewallInterfaces).to receive(:OpenFirewallHandle)
+      allow(Yast::CWMFirewallInterfaces).to receive(:StoreAllowedInterfaces)
+    end
+
+    describe ".new" do
+      it "initializes the widget" do
+        expect(Yast::CWMFirewallInterfaces).to receive(:CreateOpenFirewallWidget)
+          .with("services" => Y2Remote::Remote::FIREWALL_SERVICES, "display_details" => true)
+
+        described_class.new
+      end
+    end
+
+    describe ".handle" do
+      it "handles changes in the widget" do
+        expect(Yast::CWMFirewallInterfaces).to receive(:OpenFirewallHandle)
+          .with(firewall_widget, "", "event")
+        subject.handle("event")
+      end
+    end
+
+    describe ".store" do
+      it "enables vnc firewall services in the allowed interfaces" do
+        expect(Yast::CWMFirewallInterfaces).to receive(:StoreAllowedInterfaces)
+          .with(Y2Remote::Remote::FIREWALL_SERVICES)
+
+        subject.store
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello Card](https://trello.com/c/WbNLhdQb/1414-15-ga-or-mu-bug-1088647-build-5502-openqa-test-fails-in-yast2vnc-firewalld-does-not-create-rule-for-vnc-and-bug-1088646-build-55)
