### PR TITLE
[WIP] Stop systemd socket associated services and ask for installing firewalld service definition

### DIFF
--- a/src/lib/y2remote/modes/socket_based.rb
+++ b/src/lib/y2remote/modes/socket_based.rb
@@ -16,6 +16,11 @@ module Y2Remote
         raise "Not implemented yet"
       end
 
+      # Name of the associated service that will be started
+      def service_name
+        raise "Not implemented yet"
+      end
+
       # Obtain the systemd socket itself
       #
       # @return [Yast::SystemdSocket, nil]
@@ -80,6 +85,10 @@ module Y2Remote
             _("Stopping systemd socket %{socket} has failed") % { socket: socket_name }
           )
           return false
+        end
+
+        if !Yast::Service.Stop(service_name)
+          Yast::Report.Error(Yast::Message.CannotStopService(service_name))
         end
 
         true

--- a/src/lib/y2remote/modes/vnc.rb
+++ b/src/lib/y2remote/modes/vnc.rb
@@ -20,6 +20,10 @@ module Y2Remote
       def socket_name
         SOCKET
       end
+
+      def service_name
+        "#{socket_name}@*"
+      end
     end
   end
 end

--- a/src/lib/y2remote/modes/web.rb
+++ b/src/lib/y2remote/modes/web.rb
@@ -25,6 +25,13 @@ module Y2Remote
       def socket_name
         SOCKET
       end
+
+      # Name of the associated service
+      #
+      # @return [String] service name
+      def service_name
+        socket_name
+      end
     end
   end
 end

--- a/src/lib/y2remote/remote.rb
+++ b/src/lib/y2remote/remote.rb
@@ -30,6 +30,7 @@ module Y2Remote
     include Yast::I18n
 
     GRAPHICAL_TARGET = "graphical".freeze
+    FIREWALL_SERVICES_PACKAGE = "xorg-x11-Xvnc".freeze
     FIREWALL_SERVICES = ["tigervnc", "tigervnc-https"].freeze
 
     # List of Y2Remote::Modes::Base subclasses that are the enabled VNC running


### PR DESCRIPTION
[Trello Card](https://trello.com/c/WbNLhdQb/1414-5-15-ga-or-mu-bug-1088647-build-5502-openqa-test-fails-in-yast2vnc-firewalld-does-not-create-rule-for-vnc-and-bug-1088646-build)
---
In this PR we try to fix these issues:

1. When the module is called and no package have been installed yet we are not able to configure the firewall because the packages are installed once selected one of the available modes.

![screenshot from 2018-04-23 17-20-57](https://user-images.githubusercontent.com/7056681/39139925-170c3092-471b-11e8-99c3-61b0e0c6016d.png)

2. When a systemd socket is stopped the started services associated with it are not stopped

---

For the first issue, we could ask for installing the package that ships the service definition

![screenshot from 2018-04-23 17-20-06](https://user-images.githubusercontent.com/7056681/39139966-36fa3430-471b-11e8-8d83-e394ffae505a.png)

Once installed (tigervnc still needs to reload firewalld), we will be able to configure the firewall without having to run the client twice.

![screenshot from 2018-04-23 17-23-02](https://user-images.githubusercontent.com/7056681/39140315-13211212-471c-11e8-89fa-adec142b5c24.png)

For the second issue, well, as @michalsrb already pointed on IRC it depends on whether we want to close ongoing connections or not.

