### PR TITLE
Disable services when vnc is disabled

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 25 08:31:35 UTC 2018 - knut.anderssen@suse.com
+
+- Y2remote: When vnc is disabled disable also all the services that
+  are still enabled (bsc#1088646)
+- 4.0.30
+
+-------------------------------------------------------------------
 Wed Apr 25 07:01:58 UTC 2018 - mfilka@suse.com
 
 - bnc#1077435

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.0.29
+Version:        4.0.30
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/y2remote/remote.rb
+++ b/src/lib/y2remote/remote.rb
@@ -157,16 +157,11 @@ module Y2Remote
     #
     # @return [Boolean] true if success, false otherwise
     def configure_display_manager
-      if enabled?
-        # Install required packages
-        if !Yast::Package.InstallAll(required_packages)
-          log.error "Installing of required packages failed"
-          return false
-        end
-
-        Y2Remote::Modes.update_status(modes)
+      if enabled? && !Yast::Package.InstallAll(required_packages)
+        log.error "Installing of required packages failed"
+        return false
       end
-
+      Y2Remote::Modes.update_status(modes)
       display_manager.write_remote_access(enabled?)
     end
 


### PR DESCRIPTION
[Trello Card](https://trello.com/c/WbNLhdQb/1414-5-15-ga-or-mu-bug-1088647-build-5502-openqa-test-fails-in-yast2vnc-firewalld-does-not-create-rule-for-vnc-and-bug-1088646-build)

This fix should go to GA, and the rest are probably for MU.