### PR TITLE
Fix root filesystem check for adjusting ifcfg config files

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed May  9 10:35:36 UTC 2018 - knut.anderssen@suse.com
+
+- Fix the check for adjusting ifcfg configuration in case of
+  network based root filesystem when saving the network at the end
+  of the installation (bsc#1090752).
+- 4.0.31
+
+-------------------------------------------------------------------
 Wed Apr 25 08:31:35 UTC 2018 - knut.anderssen@suse.com
 
 - Y2remote: When vnc is disabled disable also all the services that

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.0.30
+Version:        4.0.31
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -37,16 +37,14 @@ module Yast
       # storage-ng
       # Check if installation is targeted to a remote destination.
       devicegraph = Y2Storage::StorageManager.instance.staging
-      is_disk_in_network = devicegraph.filesystem_in_network?(
-        Installation.destdir
-      )
+      is_disk_in_network = devicegraph.filesystem_in_network?("/")
 
       if !is_disk_in_network
-        log.info("Directory \"#{Installation.destdir}\" is not on a network based device")
+        log.info("Root filesystem is not on a network based device")
         return
       end
 
-      log.info("Directory \"#{Installation.destdir}\" is on a network based device")
+      log.info("Root filesystem is on a network based device")
 
       # tune ifcfg file for remote filesystem
       SCR.Execute(

--- a/test/save_network_test.rb
+++ b/test/save_network_test.rb
@@ -22,13 +22,13 @@ describe Yast::SaveNetworkClient do
       Y2Storage::StorageManager.create_test_instance
 
       staging = Y2Storage::StorageManager.instance.staging
-      allow(staging).to receive(:filesystem_in_network?).and_return(in_network)
+      allow(staging).to receive(:filesystem_in_network?).with("/").and_return(in_network)
       allow(subject).to receive(:save_network)
       # Mainly for import
       subject.main
     end
 
-    context "when installation directory is in a network device" do
+    context "when the root filesystem of the target system is in a network device" do
       let(:in_network) { true }
 
       it "tunes ifcfg file for remote filesystem" do
@@ -38,7 +38,7 @@ describe Yast::SaveNetworkClient do
       end
     end
 
-    context "when installation directory is in a local device" do
+    context "when the root filesystem of the target system is in a local device" do
       let(:in_network) { false }
 
       it "does not touch any configuration file" do


### PR DESCRIPTION
[Trello Card](https://trello.com/c/siYsznJj/1433-3-help-with-nfs-root-in-mbrgap-bug)

See #555 & #529 & https://github.com/yast/yast-network/pull/553/commits/02412f2134502523b4fa355e3ba0e1474b99e1d7

Probably the original modifications were pushed directly to the storage-ng branch