### PR TITLE
Fix convertion of multiple line entries into a single one (bsc#1095971)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,7 +1,15 @@
 -------------------------------------------------------------------
+Thu Jun  7 10:48:42 UTC 2018 - knut.anderssen@suse.com
+
+- AutoYaST: Do not crash when trying to convert the /etc/hosts
+  profile declaration from multiple line host entries for the same
+  host to just one line (bnc#1095971)
+- 3.2.52
+
+-------------------------------------------------------------------
 Mon Apr 30 06:40:28 UTC 2018 - mfilka@suse.com
 
-- bnc#1077435 
+- bnc#1077435
   - do not crash with internal error when /etc/hosts is corrupted
 - 3.2.51
 

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.2.51
+Version:        3.2.52
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/Host.rb
+++ b/src/modules/Host.rb
@@ -174,7 +174,7 @@ module Yast
       # use ::1 entry as a reference
       if (imported_hosts["::1"] || []).size > 1
         imported_hosts.each_pair do |k, v|
-          imported_hosts[k] = v.join(" ")
+          imported_hosts[k] = [v.join(" ")]
         end
       end
 

--- a/test/host_test.rb
+++ b/test/host_test.rb
@@ -143,6 +143,22 @@ describe Yast::Host do
 
       expect(Yast::Host.name_map).to eql(etc_hosts.merge("10.20.1.29" => ["beholder"]))
     end
+
+    context "when the profile contains multiple host entries for ::1" do
+      let(:holder_entries) { ["beholder.test.com test.com", "second.test.com second"] }
+      let(:hosts) do
+        {
+          "::1"        => ["localhost", "ipv6-localhost", "ipv6-loopback"],
+          "10.20.1.29" => holder_entries
+        }
+      end
+
+      it "converts each duplicated entry to just one line" do
+        Yast::Host.Import("hosts" => hosts)
+
+        expect(Yast::Host.name_map["10.20.1.29"]).to eql([holder_entries.join(" ")])
+      end
+    end
   end
 
   describe ".Export" do


### PR DESCRIPTION
I have used this bug because I discovered the error through it: https://bugzilla.suse.com/show_bug.cgi?id=1095971

But if needed I can fill a new one for this particular case.

## Some context (Omit if you already know about it)

The origin of the history is this bug https://bugzilla.suse.com/show_bug.cgi?id=152036

And these commits:

https://github.com/yast/yast-network/commit/4df49192e12956ef26f37af9e27134da0677ebbc
https://github.com/yast/yast-network/commit/5c1b2e96357c3eccd8ee05758d7b61b8304c8fea

Basically, before these changes a /etc/hosts config like:

```sh
# special IPv6 addresses
::1             localhost ipv6-localhost ipv6-loopback
```

Was exported as:

```xml
  <host>
    <hosts config:type="list">
      <hosts_entry>
        <host_address>::1</host_address>
        <names config:type="list">
          <name>localhost</name>
          <name>ipv6-localhost</name>
          <name>ipv6-loopback</name>
        </names>
      </hosts_entry>
    </hosts>
  </host>
```

But that is not the case anymore, and now each name entry represent a /etc/hosts entry for the host_address, that is:

```xml
  <host>
    <hosts config:type="list">
      <hosts_entry>
        <host_address>::1</host_address>
        <names config:type="list">
          <name>localhost ipv6-localhost pv6-loopback</name>
        </names>
      </hosts_entry>
    </hosts>
  </host>
```

So the hack introduced was basically use ::1 entries as reference and in case of multiple name entries like in the previous example then join all of them in a single line.

When we moved to CFA for improving the read performance we maintained the hack but we assigned the joined string directly when we expect it to be an array of strings.

https://github.com/yast/yast-network/pull/454/files#diff-4be40ec54e4c9b91ae249f9931c14eb8R180
https://github.com/yast/yast-network/blob/3a9432ceb34ce1adb175e8d5d0f2f3dab67c25ba/src/modules/Host.rb#L182 (where it will crash)

 So this PR will just fix that.