### PR TITLE
Fixed several rpmlint warnings

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 18 08:01:44 UTC 2018 - mfilka@suse.com
+
+- bnc#1097954
+  - fixed several rpmlint warnings
+- 4.0.34
+
+-------------------------------------------------------------------
 Tue Jun 12 10:29:30 CEST 2018 - schubi@suse.de
 
 - AutoYaST: Checking for empty host name entries and informing

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.0.33
+Version:        4.0.34
 Release:        0
 BuildArch:      noarch
 

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -22,6 +22,7 @@ Release:        0
 BuildArch:      noarch
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+Url:		https://github.com/yast/yast-network
 Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  update-desktop-files
@@ -64,11 +65,14 @@ Conflicts:      yast2-core < 2.10.6
 
 Requires:       yast2-ruby-bindings >= 1.0.0
 
-Obsoletes:      yast2-network-devel-doc
+Obsoletes:      yast2-network-devel-doc <= 3.1.154
+Provides:       yast2-network-devel-doc = %{version}
 
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0
 Group:          System/YaST
+
+%build
 
 %description 
 This package contains the YaST2 component for network configuration.


### PR DESCRIPTION
Those two reported in https://bugzilla.opensuse.org/show_bug.cgi?id=1097954 plus 

yast2-network.noarch: W: obsolete-not-provided yast2-network-devel-doc
 If a package is obsoleted by a compatible replacement, the obsoleted package
 should also be provided in order to not cause unnecessary dependency breakage.
 If the obsoleting package is not a compatible replacement for the old one,
 leave out the Provides.