### PR TITLE
Dropped calls to obsolete NetworkInterfaces API

### DIFF
--- a/src/clients/host_auto.rb
+++ b/src/clients/host_auto.rb
@@ -145,7 +145,7 @@ module Yast
     # Semantic AutoYaST profile check
     #
     # Problems will be stored in AutoInstall.issues_list.
-    # @param [Hash] input autoyast settings
+    # @param imported_hosts [Hash] autoyast settings
     def check_profile_for_errors(imported_hosts)
       # Checking for empty hostnames
       imported_hosts.each do |ip, hosts|

--- a/src/include/network/lan/hardware.rb
+++ b/src/include/network/lan/hardware.rb
@@ -33,6 +33,9 @@ include Yast::UIShortcuts
 
 module Yast
   module NetworkLanHardwareInclude
+    # how many device names is proposed in Hardware dialog
+    NEW_DEVICES_COUNT = 10
+
     def initialize_network_lan_hardware(include_target)
       Yast.import "UI"
 
@@ -241,7 +244,7 @@ module Yast
       Builtins.y2milestone("hotplug=%1", LanItems.hotplug)
 
       # list of free device names when e.g. adding new device
-      @hardware["devices"] = LanItems.new_type_devices(@hardware["realtype"], 10)
+      @hardware["devices"] = LanItems.new_type_devices(@hardware["realtype"], NEW_DEVICES_COUNT)
 
       Ops.set(
         @hardware,
@@ -596,7 +599,7 @@ module Yast
           UI.ChangeWidget(
             Id(:ifcfg_name),
             :Items,
-            LanItems.new_type_devices(@hardware["realtype"], 10)
+            LanItems.new_type_devices(@hardware["realtype"], NEW_DEVICES_COUNT)
           )
         end
         Builtins.y2debug("type=%1", Ops.get_string(@hardware, "type", ""))

--- a/src/include/network/lan/hardware.rb
+++ b/src/include/network/lan/hardware.rb
@@ -240,24 +240,8 @@ module Yast
 
       Builtins.y2milestone("hotplug=%1", LanItems.hotplug)
 
-      Ops.set(
-        @hardware,
-        "devices",
-        LanItems.FreeDevices(Ops.get_string(@hardware, "realtype", ""))
-      ) # TODO: id-, bus-, ... here
-      if !Builtins.contains(
-        Ops.get_list(@hardware, "devices", []),
-        Ops.get_string(@hardware, "device", "")
-      )
-        Ops.set(
-          @hardware,
-          "devices",
-          Builtins.prepend(
-            Ops.get_list(@hardware, "devices", []),
-            Ops.get_string(@hardware, "device", "")
-          )
-        )
-      end
+      # list of free device names when e.g. adding new device
+      @hardware["devices"] = LanItems.new_type_devices(@hardware["realtype"], 10)
 
       Ops.set(
         @hardware,
@@ -612,9 +596,7 @@ module Yast
           UI.ChangeWidget(
             Id(:ifcfg_name),
             :Items,
-            LanItems.FreeDevices(@hardware["realtype"]).map do |index|
-              @hardware["realtype"] + index
-            end
+            LanItems.new_type_devices(@hardware["realtype"], 10)
           )
         end
         Builtins.y2debug("type=%1", Ops.get_string(@hardware, "type", ""))

--- a/src/include/network/lan/hardware.rb
+++ b/src/include/network/lan/hardware.rb
@@ -328,7 +328,7 @@ module Yast
           Id(:ifcfg_name),
           Opt(:editable, :hstretch),
           _("&Configuration Name"),
-          [@hardware["device"] || ""]
+          @hardware["devices"]
         )
       )
 

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2530,23 +2530,30 @@ module Yast
     #
     # Method always returns name in the oldfashioned schema (eth0, br1, ...)
     #
-    # Raises an exception when type is incorrect.
-    #
-    # @param [String] device type
+    # @raise [ArgumentError] when type is nil or empty
+    # @param type [String] device type
     # @return [String] available device name
     def new_type_device(type)
       new_type_devices(type, 1).first
     end
 
+    # Returns a list of unused names for devices of given type
+    #
+    # Also @see new_type_device
+    #
+    # @raise [ArgumentError] when type is nil or empty
+    # @param type [String] device type
+    # @param count [Integer] requested count of names
+    # @return [Array<String>] list of free names, empty if count is < 1
     def new_type_devices(type, count)
       raise ArgumentError, "Valid device type expected" if type.nil? || type.empty?
       return [] if count < 1
 
       known_devs = find_type_ifaces(type)
 
-      candidates = (0..known_devs.size + count -1).map { |c| "#{type}#{c}" }
+      candidates = (0..known_devs.size + count - 1).map { |c| "#{type}#{c}" }
 
-      (candidates - known_devs)[0..count-1]
+      (candidates - known_devs)[0..count - 1]
     end
 
     # This helper allows YARD to extract DSL-defined attributes.

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2535,13 +2535,18 @@ module Yast
     # @param [String] device type
     # @return [String] available device name
     def new_type_device(type)
+      new_type_devices(type, 1).first
+    end
+
+    def new_type_devices(type, count)
       raise ArgumentError, "Valid device type expected" if type.nil? || type.empty?
+      return [] if count < 1
 
       known_devs = find_type_ifaces(type)
 
-      candidates = (0..known_devs.size).map { |c| "#{type}#{c}" }
+      candidates = (0..known_devs.size + count -1).map { |c| "#{type}#{c}" }
 
-      (candidates - known_devs).first
+      (candidates - known_devs)[0..count-1]
     end
 
     # This helper allows YARD to extract DSL-defined attributes.

--- a/test/bridge_test.rb
+++ b/test/bridge_test.rb
@@ -70,6 +70,8 @@ describe Yast::LanItems do
     allow(Yast::NetworkInterfaces).to receive(:FilterDevices).with("netcard") { netconfig_items }
     allow(Yast::NetworkInterfaces).to receive(:adapt_old_config!)
     allow(Yast::NetworkInterfaces).to receive(:CleanHotplugSymlink).and_return(true)
+    allow(Yast::NetworkInterfaces).to receive(:GetType).and_call_original
+    allow(Yast::NetworkInterfaces).to receive(:GetType).with("tun0").and_return("tun") # tun type detection relies on sysfs
 
     allow(Yast::LanItems).to receive(:ReadHardware) { hwinfo_items }
 

--- a/test/build_lan_overview_test.rb
+++ b/test/build_lan_overview_test.rb
@@ -45,6 +45,13 @@ describe "LanItemsClass#BuildLanOverview" do
     allow(Yast::NetworkInterfaces)
       .to receive(:Current)
       .and_return(wlan_ifcfg)
+    allow(Yast::NetworkInterfaces)
+      .to receive(:GetType)
+      .and_call_original
+    allow(Yast::NetworkInterfaces)
+      .to receive(:GetType)
+      .with("wlan0")
+      .and_return("wlan")
     allow(FastGettext)
       .to receive(:locale)
       .and_return("de")

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -338,19 +338,35 @@ describe "LanItems#find_type_ifaces" do
   end
 end
 
-describe "LanItems#new_type_device" do
+context "When proposing device names candidates" do
   before(:each) do
     allow(Yast::LanItems).to receive(:find_type_ifaces).and_return([])
     allow(Yast::LanItems).to receive(:find_type_ifaces).with("eth").and_return(["eth0", "eth2", "eth3"])
   end
 
-  it "generates a valid device name" do
-    expect(Yast::LanItems.new_type_device("br")).to eql "br0"
-    expect(Yast::LanItems.new_type_device("eth")).to eql "eth1"
+  describe "LanItems#new_type_device" do
+    it "generates a valid device name" do
+      expect(Yast::LanItems.new_type_device("br")).to eql "br0"
+      expect(Yast::LanItems.new_type_device("eth")).to eql "eth1"
+    end
+
+    it "raises an error when no type is provided" do
+      expect { Yast::LanItems.new_type_device(nil) }.to raise_error(ArgumentError)
+    end
   end
 
-  it "raises an error when no type is provided" do
-    expect { Yast::LanItems.new_type_device(nil) }.to raise_error(ArgumentError)
+  describe "LanItems#new_type_devices" do
+    it "generates as many new device names as requested" do
+      candidates = Yast::LanItems.new_type_devices("eth", 10)
+
+      expect(candidates.size).to eql 10
+      expect(candidates).not_to include(*["eth0", "eth2", "eth3"])
+    end
+
+    it "returns empty lists for device name count < 1" do
+      expect(Yast::LanItems.new_type_devices("eth", 0)).to be_empty
+      expect(Yast::LanItems.new_type_devices("eth", -1)).to be_empty
+    end
   end
 end
 

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -360,7 +360,7 @@ context "When proposing device names candidates" do
       candidates = Yast::LanItems.new_type_devices("eth", 10)
 
       expect(candidates.size).to eql 10
-      expect(candidates).not_to include(*["eth0", "eth2", "eth3"])
+      expect(candidates).not_to include("eth0", "eth2", "eth3")
     end
 
     it "returns empty lists for device name count < 1" do


### PR DESCRIPTION
bnc#964856, bnc#1109312

tests are failing until https://github.com/yast/yast-yast2/pull/838 is merged