### PR TITLE
Backport schema fix

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -3,6 +3,7 @@ Thu Oct  4 21:46:23 UTC 2018 - knut.anderssen@suse.com
 
 - Fixes to the networking AY schema (bsc#1103712, bsc#1108852)
   - Permitted the use of 'listentry' element in list entries.
+  - Added missed s390 device 'layer2' boolean element.
 - 3.2.55
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,10 +1,17 @@
 -------------------------------------------------------------------
+Thu Oct  4 21:46:23 UTC 2018 - knut.anderssen@suse.com
+
+- Fixes to the networking AY schema (bsc#1103712, bsc#1108852)
+  - Permitted the use of 'listentry' element in list entries.
+- 3.2.55
+
+-------------------------------------------------------------------
 Wed Sep 12 11:20:35 UTC 2018 - mfilka@suse.com
 
 - bnc#1105230
   - do not crash with internal error when 0.0.0.0 netmask is used
     in the routing tab
-- 3.2.54 
+- 3.2.54
 
 -------------------------------------------------------------------
 Fri Jul 27 12:30:00 UTC 2018 - mvidner@suse.com

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.2.54
+Version:        3.2.55
 Release:        0
 BuildArch:      noarch
 

--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -39,7 +39,7 @@ interfaces =
   }
 
 interface =
-  element interface {
+  element (interface | listentry) {
     element device { text }? &	#overloaded
     element name { text }? &
 
@@ -89,13 +89,13 @@ interface =
 
 
 s390-devices =
-  element device {
+  element s390-devices {
     LIST,
     device+
   }
 
 device =
-  element device {
+  element (device | listentry) {
     element type { text }? &
     element chanids { text }? &
     element portname { text }? &
@@ -111,7 +111,7 @@ net-udev =
   }
 
 rule =
-  element rule {
+  element (rule | listentry) {
     element rule { text }? &
     element value { text }? &
     element name { text }?
@@ -222,7 +222,7 @@ modules =
     module_entry+
   }
 module_entry =
-  element module_entry {
+  element (module_entry | listentry) {
     element ccw_chan_ids { text }? &
     element ccw_chan_num { text }? &
     element device { text } &	# overloaded
@@ -262,7 +262,7 @@ routes =
     route+
   }
 route =
-  element route {
+  element (route | listentry) {
     destination &
     element netmask { text } &	#overloaded
     element device { text } &	#overloaded

--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -97,6 +97,7 @@ s390-devices =
 device =
   element (device | listentry) {
     element type { text }? &
+    element layer2 { BOOLEAN}? &
     element chanids { text }? &
     element portname { text }? &
     element protocol { text }? &


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1108852

It backports #663  and also adds the `s390-device/layer2` boolean element