### PR TITLE
Require the installation of wireless-tools for scanning (bsc#1112952)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jan 25 13:24:03 UTC 2019 - knut.anderssen@suse.com
+
+- bsc#112952
+  - Try to install the wireless-tools package when the package is
+    not installed and the wifi networks are scanned.
+- 4.1.35
+
+-------------------------------------------------------------------
 Wed Jan 23 08:52:03 UTC 2019 - mfilka@suse.com
 
 - bnc#1122387

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.34
+Version:        4.1.35
 Release:        0
 BuildArch:      noarch
 

--- a/src/include/network/lan/wireless.rb
+++ b/src/include/network/lan/wireless.rb
@@ -510,6 +510,10 @@ module Yast
       UI.ChangeWidget(Id(:authmode), :Value, authmode)
       UI.ChangeWidget(Id(:type_g), :CurrentButton, type) if authmode != "eap"
 
+      # Require wireless-tools installation in order to be able to scan the
+      # wlan network (bsc#1112952)
+      UI.ChangeWidget(Id(:scan_for_networks), :Enabled, scan_supported?)
+
       ckey = nil
       ret = nil
       loop do
@@ -1393,6 +1397,20 @@ module Yast
         "next_button"        => Label.OKButton,
         "fallback_functions" => functions
       )
+    end
+
+  private
+
+    IWLIST_PKG = "wireless-tools".freeze
+
+    def scan_supported?
+      return true if Stage.initial || Package.Installed(IWLIST_PKG) || Package.Install(IWLIST_PKG)
+
+      Popup.Error(
+        _("The required package is not installed.\n" \
+          "Some options could not be available")
+      )
+      false
     end
   end
 end


### PR DESCRIPTION
Possible fix for https://bugzilla.suse.com/show_bug.cgi?id=1112952

It requires the installation of wireless-tools package only when it tries to configure a new interface in order to enable the scanning functionality.

![screenshot from 2018-10-26 09-56-52](https://user-images.githubusercontent.com/7056681/47556157-97d23600-d905-11e8-8346-1df5a917407a.png)

## If canceled the installation then the scanning functionality is disabled
![screenshot from 2018-10-26 09-57-20](https://user-images.githubusercontent.com/7056681/47556164-9b65bd00-d905-11e8-83e7-8eee039359bb.png)
