### PR TITLE
"yast lan add" needs "type" now

### DIFF
--- a/t/add-del.t
+++ b/t/add-del.t
@@ -23,7 +23,7 @@ ip addr show dev $BASEDEVICE
 echo "ok 1 $BASEDEVICE: found"
 
 echo "# add a (virtual) interface"
-$YAST lan add name=vlan50 ethdevice=$BASEDEVICE bootproto=dhcp || tapfail
+$YAST lan add name=vlan50 type=vlan ethdevice=$BASEDEVICE bootproto=dhcp || tapfail
 echo "ok 2 vlan50: added"
 
 # check it has worked


### PR DESCRIPTION
https://openqa.suse.de/tests/2096097#step/yast2_cmdline/22 fails,
broken since 9abc2864df02710e30682874c71f98db81f73571
reported by @mloviska