### PR TITLE
Allow to change network backend from proposal

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov  9 16:38:35 UTC 2018 - dgonzalez@suse.com
+
+- Allow to swich the network backend from the proposal
+- 4.1.16
+
+-------------------------------------------------------------------
 Wed Oct 31 08:37:13 UTC 2018 - mfilka@suse.com
 
 - bnc#1111925

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.15
+Version:        4.1.16
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -6,6 +6,11 @@ module Yast
     include Yast::I18n
     include Yast::Logger
 
+    BACKEND_LINKS = [
+      SWITCH_TO_WICKED = "network--switch-to-wicked".freeze,
+      SWITCH_TO_NETWORK_MANAGER = "network--switch-to-nm".freeze
+    ].freeze
+
     def initialize
       Yast.import "UI"
       Yast.import "Lan"
@@ -24,24 +29,79 @@ module Yast
 
     def make_proposal(_)
       {
-        "preformatted_proposal" => Yast::Lan.Summary("proposal"),
-        "label_proposal"        => [Yast::LanItems.summary("one_line")]
+        "preformatted_proposal" => preformatted_proposal,
+        "label_proposal"        => [Yast::LanItems.summary("one_line")],
+        "links"                 => BACKEND_LINKS
       }
     end
 
     def ask_user(args)
-      log.info "Launching network configuration"
-      begin
-        Yast::Wizard.OpenAcceptDialog
-
-        result = Yast::WFM.CallFunction("inst_lan", [args.merge("skip_detection" => true)])
-
-        log.info "Returning from the network configuration with: #{result}"
-      ensure
-        Yast::Wizard.CloseDialog
-      end
+      result =
+        case args["chosen_id"]
+        when "network--switch-to-wicked"
+          switch_to_wicked
+        when "network--switch-to-nm"
+          switch_to_network_manager
+        else
+          launch_network_configuration(args)
+        end
 
       { "workflow_sequence" => result }
+    end
+
+  private
+
+    def preformatted_proposal
+      proposal_text = switch_backend_link
+      proposal_text.prepend(Yast::Lan.Summary("proposal")) if wicked_backend?
+      proposal_text
+    end
+
+    def switch_backend_link
+      if wicked_backend?
+        info     = _("Using Wicked")
+        switcher = Hyperlink(SWITCH_TO_NETWORK_MANAGER, _("switch to Network Manager"))
+      else
+        info     = _("Using Network Manager")
+        switcher = Hyperlink(SWITCH_TO_WICKED, _("switch to Wicked"))
+      end
+
+      "<ul><li>#{info} (#{switcher})</li></ul>"
+    end
+
+    def launch_network_configuration(args)
+      log.info "Launching network configuration"
+
+      Yast::Wizard.OpenAcceptDialog
+
+      result = Yast::WFM.CallFunction("inst_lan", [args.merge("skip_detection" => true)])
+
+      log.info "Returning from the network configuration with: #{result}"
+
+      result
+    ensure
+      Yast::Wizard.CloseDialog
+    end
+
+    def switch_to_wicked
+      Yast::NetworkService.use_wicked
+
+      :next
+    end
+
+    def switch_to_network_manager
+      Yast::NetworkService.use_network_manager
+
+      :next
+    end
+
+    def wicked_backend?
+      Yast::NetworkService.wicked?
+    end
+
+    # TODO: move to HTML.ycp
+    def Hyperlink(href, text)
+      Builtins.sformat("<a href=\"%1\">%2</a>", href, text)
     end
   end
 end

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -1,3 +1,4 @@
+require "cgi"
 require "installation/proposal_client"
 
 module Yast
@@ -58,26 +59,29 @@ module Yast
     end
 
     def switch_backend_link
+      # TRANSLATORS: information about the network backend in use. %s is the name of backend,
+      # example "wicked" or "NetworkManager"
+      backend_in_use = _("Using <b>%s</b>")
+      # TRANSLATORS: text of link for switch to another network backend. %s is the name of backend,
+      # example "wicked" or "NetworkManager"
+      switch_to = _("switch to %s")
+
       if wicked_backend?
-        info     = _("Using Wicked")
-        switcher = Hyperlink(SWITCH_TO_NETWORK_MANAGER, _("switch to Network Manager"))
+        current_backend         = "wicked"
+        link_to_another_backend = Hyperlink(SWITCH_TO_NETWORK_MANAGER, switch_to % "NetworkManager")
       else
-        info     = _("Using Network Manager")
-        switcher = Hyperlink(SWITCH_TO_WICKED, _("switch to Wicked"))
+        current_backend         = "NetworkManager"
+        link_to_another_backend = Hyperlink(SWITCH_TO_WICKED, switch_to % "wicked")
       end
 
-      "<ul><li>#{info} (#{switcher})</li></ul>"
+      "<ul><li>#{backend_in_use % current_backend} (#{link_to_another_backend})</li></ul>"
     end
 
     def launch_network_configuration(args)
       log.info "Launching network configuration"
-
       Yast::Wizard.OpenAcceptDialog
-
       result = Yast::WFM.CallFunction("inst_lan", [args.merge("skip_detection" => true)])
-
       log.info "Returning from the network configuration with: #{result}"
-
       result
     ensure
       Yast::Wizard.CloseDialog
@@ -85,13 +89,11 @@ module Yast
 
     def switch_to_wicked
       Yast::NetworkService.use_wicked
-
       :next
     end
 
     def switch_to_network_manager
       Yast::NetworkService.use_network_manager
-
       :next
     end
 
@@ -101,7 +103,7 @@ module Yast
 
     # TODO: move to HTML.ycp
     def Hyperlink(href, text)
-      Builtins.sformat("<a href=\"%1\">%2</a>", href, text)
+      Builtins.sformat("<a href=\"%1\">%2</a>", href, CGI.escapeHTML(text))
     end
   end
 end

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -808,52 +808,6 @@ module Yast
       end
     end
 
-    # Create a textual summary for the general network settings
-    # proposal (NetworkManager + ipv6)
-    # @return [rich text, links]
-    def SummaryGeneral
-      # header for network summary list
-      header_nm = _("Network Mode")
-
-      if NetworkService.is_network_manager
-        href_nm = "lan--nm-disable"
-        # network mode: the interfaces are controlled by the user
-        status_nm = _("Interfaces controlled by NetworkManager")
-        # switch from network manager to wicked
-        link_nm = Hyperlink(href_nm, _("switch to Wicked"))
-      else
-        href_nm = "lan--nm-enable"
-        # network mode
-        status_nm = _("Traditional network setup with Wicked")
-        # switch from wicked to network manager
-        link_nm = Hyperlink(href_nm, _("switch to NetworkManager"))
-      end
-
-      if @ipv6
-        href_v6 = "ipv6-disable"
-        # ipv6 support is enabled
-        status_v6 = _("Support for IPv6 protocol is enabled")
-        # disable ipv6 support
-        link_v6 = Hyperlink(href_v6, _("disable"))
-      else
-        href_v6 = "ipv6-enable"
-        # ipv6 support is disabled
-        status_v6 = _("Support for IPv6 protocol is disabled")
-        # enable ipv6 support
-        link_v6 = Hyperlink(href_v6, _("enable"))
-      end
-      descr = Builtins.sformat(
-        "<ul><li>%1: %2 (%3)</li></ul> \n\t\t\t     <ul><li>%4 (%5)</li></ul>",
-        header_nm,
-        status_nm,
-        link_nm,
-        status_v6,
-        link_v6
-      )
-      links = [href_nm, href_v6]
-      [descr, links]
-    end
-
     # Add a new device
     # @return true if success
     def Add
@@ -1005,7 +959,6 @@ module Yast
     publish function: :Import, type: "boolean (map)"
     publish function: :Export, type: "map ()"
     publish function: :Summary, type: "list (string)"
-    publish function: :SummaryGeneral, type: "list ()"
     publish function: :Add, type: "boolean ()"
     publish function: :Delete, type: "boolean ()"
     publish function: :AnyDHCPDevice, type: "boolean ()"

--- a/test/network_proposal_test.rb
+++ b/test/network_proposal_test.rb
@@ -31,33 +31,33 @@ describe Yast::NetworkProposal do
       expect(proposal).to include("label_proposal", "preformatted_proposal", "links")
     end
 
-    context "when using a Wicked backend" do
+    context "when using the wicked backend" do
       it "includes the Yast::Lan proposal summary" do
         expect(proposal["preformatted_proposal"]).to include("rich_text_summary")
       end
 
-      it "includes a link for switch to Network Manager" do
-        expect(proposal["preformatted_proposal"]).to match(/.*href.*Network Manager.*/)
+      it "includes a link for switch to NetworkManager" do
+        expect(proposal["preformatted_proposal"]).to match(/.*href.*NetworkManager.*/)
       end
 
-      it "does not include a link for switch to Wicked" do
-        expect(proposal["preformatted_proposal"]).to_not match(/.*href.*Wicked.*/)
+      it "does not include a link for switch to wicked" do
+        expect(proposal["preformatted_proposal"]).to_not match(/.*href.*wicked.*/)
       end
     end
 
-    context "when using a Network Manager backend" do
+    context "when using the NetworkManager backend" do
       let(:using_wicked) { false }
 
       it "does not include the Yast::Lan proposal summary" do
         expect(proposal["preformatted_proposal"]).to_not include("rich_text_summary")
       end
 
-      it "does not include a link for switch to Network Manager" do
-        expect(proposal["preformatted_proposal"]).to_not match(/.*href.*Network Manager.*/)
+      it "does not include a link for switch to NetworkManager" do
+        expect(proposal["preformatted_proposal"]).to_not match(/.*href.*NetworkManager.*/)
       end
 
-      it "includes a link for switch to Wicked" do
-        expect(proposal["preformatted_proposal"]).to match(/.*href.*Wicked.*/)
+      it "includes a link for switch to wicked" do
+        expect(proposal["preformatted_proposal"]).to match(/.*href.*wicked.*/)
       end
     end
   end
@@ -103,7 +103,7 @@ describe Yast::NetworkProposal do
         expect(Yast::WFM).to_not receive(:CallFuntion).with("inst_lan", anything)
       end
 
-      it "changes the netwotk backend to Wicked" do
+      it "changes the netwotk backend to wicked" do
         expect(Yast::NetworkService).to receive(:use_wicked)
 
         subject.ask_user(args)
@@ -121,7 +121,7 @@ describe Yast::NetworkProposal do
         expect(Yast::WFM).to_not receive(:CallFuntion).with("inst_lan", anything)
       end
 
-      it "changes the netwotk backend to Network Manager" do
+      it "changes the netwotk backend to NetworkManager" do
         expect(Yast::NetworkService).to receive(:use_network_manager)
 
         subject.ask_user(args)

--- a/test/network_proposal_test.rb
+++ b/test/network_proposal_test.rb
@@ -20,27 +20,116 @@ describe Yast::NetworkProposal do
   end
 
   describe "#make_proposal" do
-    it "returns a map with 'label_proposal' as an array with one line summary'" do
-      expect(subject.make_proposal({})["label_proposal"]).to eql(["one_line_summary"])
+    let(:using_wicked) { true }
+    let(:proposal) { subject.make_proposal({}) }
+
+    before do
+      allow(Yast::NetworkService).to receive(:wicked?).and_return(using_wicked)
     end
 
-    it "returns a map with 'preformatted_proposal' as an array with the network summary'" do
-      expect(subject.make_proposal({})["preformatted_proposal"]).to eql("rich_text_summary")
+    it "returns a hash describing the proposal" do
+      expect(proposal).to include("label_proposal", "preformatted_proposal", "links")
+    end
+
+    context "when using a Wicked backend" do
+      it "includes the Yast::Lan proposal summary" do
+        expect(proposal["preformatted_proposal"]).to include("rich_text_summary")
+      end
+
+      it "includes a link for switch to Network Manager" do
+        expect(proposal["preformatted_proposal"]).to match(/.*href.*Network Manager.*/)
+      end
+
+      it "does not include a link for switch to Wicked" do
+        expect(proposal["preformatted_proposal"]).to_not match(/.*href.*Wicked.*/)
+      end
+    end
+
+    context "when using a Network Manager backend" do
+      let(:using_wicked) { false }
+
+      it "does not include the Yast::Lan proposal summary" do
+        expect(proposal["preformatted_proposal"]).to_not include("rich_text_summary")
+      end
+
+      it "does not include a link for switch to Network Manager" do
+        expect(proposal["preformatted_proposal"]).to_not match(/.*href.*Network Manager.*/)
+      end
+
+      it "includes a link for switch to Wicked" do
+        expect(proposal["preformatted_proposal"]).to match(/.*href.*Wicked.*/)
+      end
     end
   end
 
   describe "#ask_user" do
-    it "launchs the inst_lan client forcing the manual configuration" do
-      expect(Yast::WFM).to receive(:CallFunction).with("inst_lan", [{ "skip_detection" => true }])
-      subject.ask_user({})
+    let(:chosen_id) { "" }
+    let(:args) do
+      {
+        "chosen_id"      => chosen_id,
+        "skip_detection" => false
+      }
+    end
+
+    before do
+      allow(Yast::WFM).to receive(:CallFunction)
+        .with("inst_lan", anything)
+        .and_return("result")
     end
 
     it "returns a map with 'workflow_sequence' as the result of the client output" do
-      allow(Yast::WFM).to receive(:CallFunction)
-        .with("inst_lan", [{ "skip_detection" => true }])
-        .and_return("result")
+      expect(subject.ask_user(args)).to have_key("workflow_sequence")
+    end
 
-      expect(subject.ask_user({})).to eql("workflow_sequence" => "result")
+    context "by default" do
+      let(:args) { { "chosen_id" => "network" } }
+
+      it "launchs the inst_lan client forcing the manual configuration" do
+        expect(Yast::WFM).to receive(:CallFunction)
+          .with("inst_lan", [hash_including("skip_detection" => true)])
+
+        subject.ask_user(args)
+      end
+
+      it "returns the result of the client output as 'workflow_sequence'" do
+        expect(subject.ask_user(args)).to eql("workflow_sequence" => "result")
+      end
+    end
+
+    context "when 'chosen_id' is 'network--switch-to-wicked'" do
+      let(:args) { { "chosen_id" => "network--switch-to-wicked" } }
+
+      it "does not launchs the inst_lan client" do
+        expect(Yast::WFM).to_not receive(:CallFuntion).with("inst_lan", anything)
+      end
+
+      it "changes the netwotk backend to Wicked" do
+        expect(Yast::NetworkService).to receive(:use_wicked)
+
+        subject.ask_user(args)
+      end
+
+      it "returns :next as 'workflow_sequence'" do
+        expect(subject.ask_user(args)).to include("workflow_sequence" => :next)
+      end
+    end
+
+    context "when 'chosen_id' is 'network--switch-to-wicked'" do
+      let(:args) { { "chosen_id" => "network--switch-to-nm" } }
+
+      it "does not launchs the inst_lan client" do
+        expect(Yast::WFM).to_not receive(:CallFuntion).with("inst_lan", anything)
+      end
+
+      it "changes the netwotk backend to Network Manager" do
+        expect(Yast::NetworkService).to receive(:use_network_manager)
+
+        subject.ask_user(args)
+      end
+
+      it "returns :next as 'workflow_sequence'" do
+        expect(subject.ask_user(args)).to include("workflow_sequence" => :next)
+      end
     end
   end
 end


### PR DESCRIPTION
Related to https://trello.com/c/4ptXAFVW/441-network-proposal-in-leap-151-networkmanager

Examples of resulting proposals: 

| Using wicked | Using NetworkManager |
|--------------|-----------------------|
| ![using wicked](https://user-images.githubusercontent.com/1691872/48346679-d2610000-e673-11e8-8135-42bd4027f6ab.png) | ![using NetworkManager](https://user-images.githubusercontent.com/1691872/48346606-a04f9e00-e673-11e8-8ad6-ea7648727b6e.png) |

