### PR TITLE
Expose the dhcp_ntp_servers method directly in Yast::Lan

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sun Nov 11 16:29:30 UTC 2018 - knut.anderssen@suse.com
+
+- Yast::Lan: Added method for obtaining the NTP servers offered by
+  DHCP (fate#323454)
+- 4.0.44
+
+-------------------------------------------------------------------
 Wed Oct 24 08:26:24 UTC 2018 - mfilka@suse.com
 
 - bnc#1111925

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.0.43
+Version:        4.0.44
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -1024,7 +1024,7 @@ module Yast
       return [] if !NetworkService.isNetworkRunning || Yast::NetworkService.is_network_manager
 
       ReadWithCacheNoGUI()
-      Yast::LanItems.dhcp_ntp_servers.values.reduce(&:concat) || []
+      Yast::LanItems.dhcp_ntp_servers.values.flatten.uniq
     end
 
     publish variable: :ipv6, type: "boolean"

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -1013,6 +1013,20 @@ module Yast
       have_br
     end
 
+    # Provides a list with the NTP servers obtained via any of dhcp aware
+    # interfaces
+    #
+    # @note parsing dhcp ntp servers when NetworkManager is in use is not
+    #   supported yet (bsc#798886)
+    #
+    # @return [Array<String>] list of ntp servers obtained byg DHCP
+    def dhcp_ntp_servers
+      return [] if !NetworkService.isNetworkRunning || Yast::NetworkService.is_network_manager
+
+      ReadWithCacheNoGUI()
+      Yast::LanItems.dhcp_ntp_servers.values.reduce(&:concat) || []
+    end
+
     publish variable: :ipv6, type: "boolean"
     publish variable: :AbortFunction, type: "block <boolean>"
     publish variable: :bond_autoconf_slaves, type: "list <string>"

--- a/test/lan_test.rb
+++ b/test/lan_test.rb
@@ -452,13 +452,14 @@ describe "Yast::LanClass#dhcp_ntp_servers" do
   let(:servers) do
     {
       "eth0" => ["0.pool.ntp.org", "1.pool.ntp.org"],
-      "eth1" => ["2.pool.ntp.org"]
+      "eth1" => ["1.pool.ntp.org", "2.pool.ntp.org"]
     }
   end
 
   before do
     allow(Yast::NetworkService).to receive(:isNetworkRunning).and_return(running)
     allow(Yast::NetworkService).to receive(:is_network_manager).and_return(nm_enabled)
+    allow(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return(servers)
   end
 
   context "when the network is not running" do
@@ -484,8 +485,7 @@ describe "Yast::LanClass#dhcp_ntp_servers" do
     end
 
     it "returns a list of the ntp_servers provided by dhcp " do
-      expect(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return(servers)
-      expect(subject.dhcp_ntp_servers)
+      expect(subject.dhcp_ntp_servers.sort)
         .to eql(["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"])
     end
   end

--- a/test/lan_test.rb
+++ b/test/lan_test.rb
@@ -444,3 +444,49 @@ describe "LanClass#FromAY" do
     expect(actual["config"]).to eq(expected_config)
   end
 end
+
+describe "Yast::LanClass#dhcp_ntp_servers" do
+  subject { Yast::Lan }
+  let(:running) { true }
+  let(:nm_enabled) { true }
+  let(:servers) do
+    {
+      "eth0" => ["0.pool.ntp.org", "1.pool.ntp.org"],
+      "eth1" => ["2.pool.ntp.org"]
+    }
+  end
+
+  before do
+    allow(Yast::NetworkService).to receive(:isNetworkRunning).and_return(running)
+    allow(Yast::NetworkService).to receive(:is_network_manager).and_return(nm_enabled)
+  end
+
+  context "when the network is not running" do
+    let(:running) { false }
+    it "returns an empty array" do
+      expect(subject.dhcp_ntp_servers).to eq([])
+    end
+  end
+
+  context "when NetworkManager is in use" do
+    let(:nm_enabled) { true }
+    it "returns an empty array" do
+      expect(subject.dhcp_ntp_servers).to eq([])
+    end
+  end
+
+  context "when wicked is in use" do
+    let(:nm_enabled) { false }
+
+    it "reads the current network configuration" do
+      expect(Yast::Lan).to receive(:ReadWithCacheNoGUI)
+      subject.dhcp_ntp_servers
+    end
+
+    it "returns a list of the ntp_servers provided by dhcp " do
+      expect(Yast::LanItems).to receive(:dhcp_ntp_servers).and_return(servers)
+      expect(subject.dhcp_ntp_servers)
+        .to eql(["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"])
+    end
+  end
+end


### PR DESCRIPTION
The method for retrieving `dhcp ntp servers` was initially added into [yast-caasp] repository(https://github.com/yast/yast-caasp) (**see https://github.com/yast/yast-caasp/pull/30**) but it was also needed in [yast-ntp-client](https://github.com/yast/yast-ntp-client) for SLES installation.

This PR adds that method into Yast::Lan following the DRY principle.