### PR TITLE
YaST Security Audit Fixes: Calling External Commands and Absolute Paths and Shell-Escaped Arguments

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  6 10:58:23 UTC 2018 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Security audit fixes: Use absolute paths when calling external
+  commands and shell-escape arguments (bsc#1118291)
+- 4.1.22
+
+-------------------------------------------------------------------
 Tue Dec  4 09:35:40 UTC 2018 - mfilka@suse.com
 
 - bnc#1114213

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.21
+Version:        4.1.22
 Release:        0
 BuildArch:      noarch
 


### PR DESCRIPTION
This is part of the YaST security audit by **@jsegitz**.

From the audit:

> yast2-network/yast2-network-4.1.6/src/include/network/routines.rb:680 
> and
> yast2-network/yast2-network-4.1.6/src/include/network/routines.rb:710
>
> RunAndRead and Run should be reworked to receive an absolut path and arguments that then can be quoted/escaped

## Reworking those Functions Completely for General Use

Completely reworking those functions would have meant to make using them a lot more awkward; right now it's simple and well-readable.

But both those functions are only used locally in that same file anyway, nowhere else, so that generic approach seemed very much overkill. But the _TO DO_ comment was extended as a reminder; if this is ever moved to one of our library packages like _yast-yast2_, this should clearly be more security-hardened, for example by passing the arguments separately and automatically quoting them all. But that makes the code a lot less readable

So the change done in this PR was to add absolute paths to all the commands and to shell-escape arguments.

## Using Absolute Paths

Intentionally **not** using paths like /usr/sbin, but plain /bin or /sbin instead because of certain peculiar things with those commands:

```shell
[shundhammer @ morgul] ~ % ls -l /sbin/if{up,down}
lrwxrwxrwx 1 root root 14 20. Nov 22:37 /sbin/ifdown -> /usr/sbin/ifup
lrwxrwxrwx 1 root root 14 20. Nov 22:37 /sbin/ifup -> /usr/sbin/ifup
```

So they both are symlinked to the same binary; `/sbin/ifdown eth0` can check its program name (`argv[0]`) what should be done, but what if we can only call `/usr/sbin/ifup` instead? Will the device go up or down? And what will somebody read in the logs to see what happened?

So, all commands here use the traditional `/sbin` or `/bin` paths, not their new `/usr/sbin` or `/usr/bin` paths; some for the reason above, the others for symmetry within this code.

## Quoting / Shell-Escaping Arguments

Most arguments to those few commands where those functions are used are fixed strings, so that is perfectly safe. In most cases, the kernel device name of a network device is used. It is very unlikely that such a device name contains characters that might be dangerous to not being quoted (blanks, shell wildcards, whatever), but it's always better to be safe than sorry.

With that Ruby [Shellwords.shellescape](https://docs.ruby-lang.org/en/2.5.0/Shellwords.html) function there is only a change if it actually contains such characters, otherwise the argument remains unchanged; in particular, no quotes are ever added.