### PR TITLE
YaST Security Audit Fixes: Removing Unused Function that could Call External Programs

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 10 13:21:27 UTC 2018 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Security audit fixes: Removed unused function stdout_of()
+  (part of bsc#1118291)
+- 4.1.23
+
+-------------------------------------------------------------------
 Thu Dec  6 10:58:23 UTC 2018 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Security audit fixes: Use absolute paths when calling external

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.22
+Version:        4.1.23
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/network/install_inf_convertor.rb
+++ b/src/lib/network/install_inf_convertor.rb
@@ -89,9 +89,5 @@ module Yast
       Proxy.Import(ex)
       Proxy.Write
     end
-
-    def stdout_of(command)
-      SCR.Execute(path(".target.bash_output"), command)["stdout"].to_s
-    end
   end
 end


### PR DESCRIPTION
This is part of the YaST security audit by **@jsegitz**.

From the audit:

> yast2-network/yast2-network-4.1.6/src/lib/network/install_inf_convertor.rb:93
>
> stdout_of should be reworked to receive an absolut path and arguments that then can be quoted/escaped

This was a private function that was never used (anymore?) anyway. 

Simply removing that function is the simplest fix.