### PR TITLE
checking if address file exists before reading

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 18 09:40:00 CET 2019 - schubi@suse.de
+
+- AutoYaST write settings: Fixed crash while reading MAC address
+  (bsc#1121087).
+- 4.1.31
+
+-------------------------------------------------------------------
 Wed Jan 16 09:23:11 UTC 2019 - mfilka@suse.com
 
 - bnc#1121421

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.30
+Version:        4.1.31
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -183,7 +183,8 @@ module Yast
             to:   "list <string>"
           )
         ) do |devname|
-          mac = ::File.read("/sys/class/net/#{devname}/address").chomp
+          address_file = "/sys/class/net/#{devname}/address"
+          mac = ::File.read(address_file).chomp if ::File.file?(address_file)
           Builtins.y2milestone("confname %1", mac)
           if !Builtins.haskey(link_status, mac)
             Builtins.y2error(


### PR DESCRIPTION
With this fix it does not crash anymore:
2019-01-18 08:28:01 <1> vtest3(2812) [Ruby] modules/Lan.rb:188 confname 02:00:00:12:34:56
2019-01-18 08:28:01 <1> vtest3(2812) [Ruby] modules/Lan.rb:188 confname nil
2019-01-18 08:28:01 <3> vtest3(2812) [Ruby] modules/Lan.rb:190 Mac address nil not found in map $["02:00:00:12:34:56":true]!
2019-01-18 08:28:01 <1> vtest3(2812) [Ruby] modules/Lan.rb:188 confname nil
2019-01-18 08:28:01 <3> vtest3(2812) [Ruby] modules/Lan.rb:190 Mac address nil not found in map $["02:00:00:12:34:56":true]!
2019-01-18 08:28:01 <1> vtest3(2812) [Ruby] clients/lan_auto.rb:122 Lan auto finished ()
