### PR TITLE
Do not crash with internal error when adding new device

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 18 09:41:56 UTC 2019 - mfilka@suse.com
+
+- bnc#1122307
+  - do not crash with internal error when adding new device
+- 4.1.32 
+
+-------------------------------------------------------------------
 Fri Jan 18 09:40:00 CET 2019 - schubi@suse.de
 
 - AutoYaST write settings: Fixed crash while reading MAC address

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.31
+Version:        4.1.32
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -754,6 +754,7 @@ module Yast
 
     def AddNew
       @current = @Items.to_h.size
+      @Items[@current] = {}
       @operation = :add
 
       nil

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -754,6 +754,7 @@ module Yast
 
     def AddNew
       @current = @Items.to_h.size
+      # Items[@current] is expected to always exist
       @Items[@current] = {}
       @operation = :add
 


### PR DESCRIPTION
bnc#1122307

unrelated to renaming. Just clicking "add" button was enough to reproduce. consequence of earlier refactoring (Items[current] didn't get initialized when adding new device)