### PR TITLE
Fix reading

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb  6 14:16:54 UTC 2019 - knut.anderssen@suse.com
+
+- bsc#1124002
+  - do not crash when cloning and trying to read a device protocol
+    or portname.
+- 4.1.37
+
+-------------------------------------------------------------------
 Tue Jan 29 10:32:17 UTC 2019 - mfilka@suse.com
 
 - bnc#1123102

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.36
+Version:        4.1.37
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2698,9 +2698,18 @@ module Yast
           if !chan_ids["stdout"].empty?
             chanids = String.CutBlanks(Ops.get_string(chan_ids, "stdout", ""))
           end
+
           # we already know that kernel device exist, otherwise next above would apply
-          portname = ::File.read("/sys/class/net/#{device}/device/portname").strip
-          protocol = ::File.read("/sys/class/net/#{device}/device/protocol").strip
+          # FIXME: It seems that it is not always the case (bsc#1124002)
+          begin
+            portname = ::File.read("/sys/class/net/#{device}/device/portname").strip
+            protocol = ::File.read("/sys/class/net/#{device}/device/protocol").strip
+          rescue SystemCallError => e
+            log.error("Failed to read portname or protocol: #{e.inspect}")
+            portname = ""
+            protocol = ""
+          end
+
           layer2_ret = SCR.Execute(
             path(".target.bash"),
             Builtins.sformat(

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2701,14 +2701,11 @@ module Yast
 
           # we already know that kernel device exist, otherwise next above would apply
           # FIXME: It seems that it is not always the case (bsc#1124002)
-          begin
-            portname = ::File.read("/sys/class/net/#{device}/device/portname").strip
-            protocol = ::File.read("/sys/class/net/#{device}/device/protocol").strip
-          rescue SystemCallError => e
-            log.error("Failed to read portname or protocol: #{e.inspect}")
-            portname = ""
-            protocol = ""
-          end
+          portname_file = "/sys/class/net/#{device}/device/portname"
+          portname = ::File.exist?(portname_file) ? ::File.read(portname_file).strip : ""
+
+          protocol_file = "/sys/class/net/#{device}/device/protocol"
+          protocol = ::File.exist?(protocol_file) ? ::File.read(protocol_file).strip : ""
 
           layer2_ret = SCR.Execute(
             path(".target.bash"),


### PR DESCRIPTION
- It seems that in the past some errors were skipped when not able to read some device files, but since #709 some bugs have been reported [1]

[1]: https://bugzilla.suse.com/show_bug.cgi?id=1121087 & https://bugzilla.suse.com/show_bug.cgi?id=1124002

This PR just tries to fix the [bsc#1124002](https://bugzilla.suse.com/show_bug.cgi?id=1124002) initializing to an empty string the device `portname` and `protocol` when not able to read them.
