### PR TITLE
Do not reset /etc/hosts

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 12 13:21:39 CET 2019 - schubi@suse.de
+
+- AutoYaST in running system: Do not reset /etc/hosts (bsc#1122658)
+- 4.1.39
+
+-------------------------------------------------------------------
 Thu Feb  7 13:13:21 UTC 2019 - knut.anderssen@suse.com
 
 - fate#324662

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.38
+Version:        4.1.39
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -407,6 +407,7 @@ module Yast
     end
 
     def writeIPv6
+      log.info("writeIPv6: IPv6 is #{@ipv6 ? "enabled" : "disabled"}")
       filename = "/etc/sysctl.conf"
       sysctl = Convert.to_string(SCR.Read(path(".target.string"), filename))
       sysctl_row = Builtins.sformat(

--- a/test/host_test.rb
+++ b/test/host_test.rb
@@ -176,7 +176,7 @@ describe Yast::Host do
     end
 
     context "import an emtpy host section" do
-      let(:org_etx_hosts) {file.content}
+      let(:org_etx_hosts) { file.content }
 
       before do
         Yast::Host.Import("hosts" => {})
@@ -184,7 +184,8 @@ describe Yast::Host do
 
       it "does not reset /etc/hosts" do
         expect(file).to receive(:write).with(
-          "/etc/hosts", file.content)
+          "/etc/hosts", file.content
+        )
         Yast::Host.Write
       end
     end

--- a/test/host_test.rb
+++ b/test/host_test.rb
@@ -94,10 +94,17 @@ describe Yast::Host do
   end
 
   describe ".Write" do
-    it "do nothing if not modified" do
-      expect(file).to_not receive(:write)
-      Yast::Host.Read
-      Yast::Host.Write
+    context "settings have not been modified" do
+      it "does nothing" do
+        expect(file).to_not receive(:write)
+        Yast::Host.Write
+      end
+
+      it "does nothing although system settings have been read" do
+        expect(file).to_not receive(:write)
+        Yast::Host.Read
+        Yast::Host.Write
+      end
     end
 
     it "writes content of file" do
@@ -165,6 +172,20 @@ describe Yast::Host do
         Yast::Host.Import("hosts" => hosts)
 
         expect(Yast::Host.name_map["10.20.1.29"]).to eql([holder_entries.join(" ")])
+      end
+    end
+
+    context "import an emtpy host section" do
+      let(:org_etx_hosts) {file.content}
+
+      before do
+        Yast::Host.Import("hosts" => {})
+      end
+
+      it "does not reset /etc/hosts" do
+        expect(file).to receive(:write).with(
+          "/etc/hosts", file.content)
+        Yast::Host.Write
       end
     end
   end


### PR DESCRIPTION
I have tested:
- Host changes in the UI and running system
- No Host changes with AY installation.
- Host changes with AY installtion.
- Running AY in an installed system without host changes.
- Running AY in an installed system with host changes.