### PR TITLE
Permit to choose between NetworkManger and wicked correctly

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Feb 19 09:31:26 UTC 2019 - knut.anderssen@suse.com
+
+- Installation proposal (bsc#1124478, bsc#1124498):
+  - Do not offer NetworkManager when the package is not available
+  - Respect the network backend selected in the proposal at the end
+    of the installation
+  - Removed the hostname write (127.0.0.2) from the summary
+- 4.1.40
+
+-------------------------------------------------------------------
 Tue Feb 12 13:21:39 CET 2019 - schubi@suse.de
 
 - AutoYaST in running system: Do not reset /etc/hosts (bsc#1122658)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.39
+Version:        4.1.40
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -54,8 +54,10 @@ module Yast
   private
 
     def preformatted_proposal
+      return lan_summary unless settings.network_manager_available?
+
       proposal_text = switch_backend_link
-      proposal_text.prepend(Yast::Lan.Summary("proposal")) if wicked_backend?
+      proposal_text.prepend(lan_summary) if wicked_backend?
       proposal_text
     end
 
@@ -106,6 +108,10 @@ module Yast
     def Hyperlink(href, text)
       Builtins.sformat("<a href=\"%1\">%2</a>", href, CGI.escapeHTML(text))
     end
+  end
+
+  def lan_summary
+    Yast::Lan.Summary("proposal")
   end
 
   def settings

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -1,5 +1,6 @@
 require "cgi"
 require "installation/proposal_client"
+require "y2network/proposal_settings"
 
 module Yast
   # Proposal client for Network configuration
@@ -88,22 +89,26 @@ module Yast
     end
 
     def switch_to_wicked
-      Yast::NetworkService.use_wicked
+      settings.enable_wicked!
       :next
     end
 
     def switch_to_network_manager
-      Yast::NetworkService.use_network_manager
+      settings.enable_network_manager!
       :next
     end
 
     def wicked_backend?
-      Yast::NetworkService.wicked?
+      settings.backend != :network_manager
     end
 
     # TODO: move to HTML.ycp
     def Hyperlink(href, text)
       Builtins.sformat("<a href=\"%1\">%2</a>", href, CGI.escapeHTML(text))
     end
+  end
+
+  def settings
+    Y2Network::ProposalSettings.instance
   end
 end

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -2,6 +2,7 @@ require "y2storage"
 require "network/install_inf_convertor"
 require "network/network_autoconfiguration"
 require "network/network_autoyast"
+require "y2network/proposal_settings"
 
 require "cfa/generic_sysconfig"
 
@@ -296,7 +297,8 @@ module Yast
 
       log.info("Setting network service according to product preferences")
 
-      if Lan.UseNetworkManager
+      case Y2Network::ProposalSettings.instance.backend
+      when :network_manager
         log.info("- using NetworkManager")
         NetworkService.use_network_manager
       else

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -33,11 +33,16 @@ module Y2Network
 
     # Constructor
     def initialize
+      Yast.import "Arch"
       Yast.import "ProductFeatures"
       Yast.import "PackagesProposal"
       Yast.import "Lan"
 
       @backend = use_network_manager? ? :network_manager : :wicked
+
+      log.info("The default proposed network backend is: #{@backend}")
+
+      @backend
     end
 
     # Adds the NetworkManager package to the {Yast::PackagesProposal} and sets
@@ -66,7 +71,10 @@ module Y2Network
     # @return [Boolean] false if no package available, true otherwise
     def network_manager_available?
       p = Y2Packager::Package.find("NetworkManager").first
-      return false if p.nil?
+      if p.nil?
+        log.info("The NetworkManager package is not available")
+        return false
+      end
       log.info("The NetworkManager package status: #{p.status}")
       true
     end
@@ -112,7 +120,7 @@ module Y2Network
       when "always"
         true
       when "laptop"
-        laptop = Arch.is_laptop
+        laptop = Yast::Arch.is_laptop
         log.info("Is a laptop: #{laptop}")
         laptop
       end

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -33,6 +33,7 @@ module Y2Network
 
     # Constructor
     def initialize
+      Yast.import "ProductFeatures"
       Yast.import "PackagesProposal"
       Yast.import "Lan"
 
@@ -95,7 +96,26 @@ module Y2Network
     def use_network_manager?
       return false unless network_manager_available?
 
-      Yast::Lan.UseNetworkManager
+      network_manager_default?
+    end
+
+    # Determine whether NetworkManager should be selected by default according
+    # to the product control file
+    #
+    # @return [Boolean] true if NM should be enabled; false otherwise
+    def network_manager_default?
+      case Yast::ProductFeatures.GetStringFeature("network", "network_manager")
+      when ""
+        # compatibility: use the boolean feature
+        # (defaults to false)
+        Yast::ProductFeatures.GetBooleanFeature("network", "network_manager_is_default")
+      when "always"
+        true
+      when "laptop"
+        laptop = Arch.is_laptop
+        log.info("Is a laptop: #{laptop}")
+        laptop
+      end
     end
   end
 end

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -1,0 +1,76 @@
+# encoding: utf-8
+#
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+module Y2Network
+  # Class that stores the proposal settings for network during installation.
+  class ProposalSettings
+    include Yast::Logger
+    include Yast::I18n
+
+    # [Boolean] network service to be used after the installation
+    attr_accessor :backend
+
+    # Constructor
+    def initialize
+      Yast.import "PackagesProposal"
+      Yast.import "Lan"
+
+      @backend = Yast::Lan.UseNetworkManager ? :network_manager : :wicked
+    end
+
+    # Services
+
+    # Add the NetworkManager package to be installed and sets NetworkManager as
+    # the backend to be used
+    def enable_network_manager!
+      Yast::PackagesProposal.AddResolvables("NetworkManager", :package, ["NetworkManager"])
+
+      log.info "Enabling NetworkManager"
+      self.backend = :network_manager
+    end
+
+    def enable_wicked!
+      Yast::PackagesProposal.AddResolvables("wicked", :package, ["wicked"])
+
+      log.info "Enabling Wicked"
+      self.backend = :wicked
+    end
+
+    class << self
+      # Singleton instance
+      def instance
+        create_instance unless @instance
+        @instance
+      end
+
+      # Enforce a new clean instance
+      def create_instance
+        @instance = new
+      end
+
+      # Make sure only .instance and .create_instance can be used to
+      # create objects
+      private :new, :allocate
+    end
+  end
+end

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -413,12 +413,6 @@ module Yast
           )
         )
       end
-      if !@write_hostname
-        summary = Summary.AddListItem(
-          summary,
-          _("Hostname will not be written to /etc/hosts")
-        )
-      end
 
       # if (has_dhcp && NetworkConfig::DHCP["DHCLIENT_MODIFY_RESOLV_CONF"]:false) {
       # Summary text

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -94,6 +94,8 @@ module Yast
 
       # Lan::Read (`cache) will do nothing if initialized already.
       @initialized = false
+
+      @backend = nil
     end
 
     #------------------

--- a/test/lib/y2network/proposal_settings_test.rb
+++ b/test/lib/y2network/proposal_settings_test.rb
@@ -1,0 +1,201 @@
+#!/usr/bin/env rspec
+
+require_relative "../../test_helper"
+require "y2network/proposal_settings"
+
+describe Y2Network::ProposalSettings do
+  subject { described_class.create_instance }
+  let(:nm_available) { true }
+  let(:feature) { { "network" => { "network_manager" => "always" } } }
+
+  before do
+    allow_any_instance_of(Y2Network::ProposalSettings)
+      .to receive(:network_manager_available?).and_return(nm_available)
+    stub_features(feature)
+  end
+
+  def stub_features(features)
+    Yast.import "ProductFeatures"
+    Yast::ProductFeatures.Import(features)
+  end
+
+  describe ".instance" do
+    context "no instance has been created yet" do
+      before do
+        described_class.instance_variable_set("@instance", nil)
+      end
+
+      it "creates a new instance" do
+        expect(described_class).to receive(:new).and_call_original
+        described_class.instance
+      end
+    end
+
+    context "when a instance has been already created" do
+      before do
+        described_class.instance
+      end
+
+      it "does not create any new instance" do
+        expect(described_class).to_not receive(:new)
+        described_class.instance
+      end
+
+      it "returns the existent instance" do
+        instance = described_class.instance
+        expect(instance.object_id).to eql(described_class.instance.object_id)
+      end
+    end
+  end
+
+  describe ".create_instance" do
+    let(:created_instance) { described_class.create_instance }
+    let(:logger) { double(info: true) }
+
+    it "creates a new network proposal settings instance" do
+      instance = described_class.instance
+      expect(created_instance).to be_a(described_class)
+      expect(created_instance).to_not equal(instance)
+    end
+
+    context "when the NetworkManager package is not available" do
+      let(:nm_available) { false }
+
+      it "sets :wicked as the default backend" do
+        expect(created_instance.backend).to eql(:wicked)
+      end
+    end
+
+    context "when the NetworkManager package is available" do
+      context "and the ProductFeature .network.network_manager is not defined" do
+        context "and neither .network.network_manager_is_default is" do
+          let(:feature) { { "network" => {} } }
+
+          it "sets :wicked as the default backend" do
+            expect(created_instance.backend).to eql(:wicked)
+          end
+        end
+
+        context "but .network.network_manager_is_default is" do
+          let(:feature) { { "network" => { "network_manager_is_default" => true } } }
+
+          it "sets :network_manager as the default backend" do
+            expect(created_instance.backend).to eql(:network_manager)
+          end
+        end
+      end
+
+      context "and the ProductFeature .network.network_manager is 'always'" do
+        it "sets :network_manager as the default backend" do
+          expect(created_instance.backend).to eql(:network_manager)
+        end
+      end
+
+      context "and the ProductFeature .network.network_manager is 'laptop'" do
+        let(:is_laptop) { true }
+        let(:feature) { { "network" => { "network_manager" => "laptop" } } }
+
+        before do
+          allow(Yast::Arch).to receive(:is_laptop).and_return(is_laptop)
+        end
+
+        context "and the machine is a laptop" do
+          it "sets :network_manager as the backend to be used" do
+            expect(created_instance.backend).to eql(:network_manager)
+          end
+        end
+
+        context "and the machine is not a laptop" do
+          let(:is_laptop) { false }
+          it "sets :wicked as the backend to be used" do
+            expect(created_instance.backend).to eql(:wicked)
+          end
+        end
+      end
+
+      it "initializes the default network backend from the product control file" do
+        expect(described_class.create_instance.backend).to eql(:network_manager)
+        stub_features("network" => { "network_manager" => "" })
+        expect(described_class.create_instance.backend).to eql(:wicked)
+      end
+    end
+
+    it "logs which backend has been selected as the default" do
+      allow_any_instance_of(described_class).to receive(:log).and_return(logger)
+      expect(logger).to receive(:info).with(/backend is: network_manager/)
+      described_class.create_instance
+    end
+  end
+
+  describe "#enable_wicked!" do
+    it "adds the wicked package to the list of resolvables " do
+      expect(Yast::PackagesProposal).to receive(:AddResolvables)
+        .with("network", :package, ["wicked"])
+      subject.enable_wicked!
+    end
+
+    it "removes the NetworkManager package from the list of resolvables " do
+      expect(Yast::PackagesProposal).to receive(:RemoveResolvables)
+        .with("network", :package, ["NetworkManager"])
+      subject.enable_wicked!
+    end
+
+    it "sets :wicked as the backend" do
+      expect(subject.backend).to eql(:network_manager)
+    end
+  end
+
+  describe "#enable_network_manager!" do
+    it "adds the NetworkManager package to the list of resolvables " do
+      expect(Yast::PackagesProposal).to receive(:AddResolvables)
+        .with("network", :package, ["NetworkManager"])
+      subject.enable_network_manager!
+    end
+
+    it "removes the wicked package from the list of resolvables " do
+      expect(Yast::PackagesProposal).to receive(:RemoveResolvables)
+        .with("network", :package, ["wicked"])
+      subject.enable_network_manager!
+    end
+
+    it "sets :network_manager as the backend" do
+      expect(subject.backend).to eql(:network_manager)
+    end
+  end
+
+  describe "#network_manager_available?" do
+    let(:package) { instance_double(Y2Packager::Package, status: :available) }
+    let(:packages) { [package] }
+    let(:settings) { described_class.instance }
+
+    before do
+      allow(settings).to receive(:network_manager_available?).and_call_original
+      allow(Y2Packager::Package).to receive(:find).with("NetworkManager")
+        .and_return(packages)
+    end
+
+    context "when there is no NetworkManager package available" do
+      let(:packages) { [] }
+
+      it "returns false" do
+        expect(settings.network_manager_available?).to eql(false)
+      end
+
+      it "logs that the package is no available" do
+        expect(settings.log).to receive(:info).with(/is not available/)
+        settings.network_manager_available?
+      end
+    end
+
+    context "when there are some NetworkManager packages available" do
+      it "returns true" do
+        expect(settings.network_manager_available?).to eql(true)
+      end
+
+      it "logs the status of the NetworkManager package" do
+        expect(settings.log).to receive(:info).with(/status: available/)
+        settings.network_manager_available?
+      end
+    end
+  end
+end

--- a/test/network_proposal_test.rb
+++ b/test/network_proposal_test.rb
@@ -24,7 +24,8 @@ describe Yast::NetworkProposal do
     let(:proposal) { subject.make_proposal({}) }
 
     before do
-      allow(Yast::NetworkService).to receive(:wicked?).and_return(using_wicked)
+      allow(Yast::Lan).to receive(:UseNetworkManager).and_return(!using_wicked)
+      Y2Network::ProposalSettings.create_instance
     end
 
     it "returns a hash describing the proposal" do
@@ -63,6 +64,7 @@ describe Yast::NetworkProposal do
   end
 
   describe "#ask_user" do
+    let(:settings) { Y2Network::ProposalSettings.instance }
     let(:chosen_id) { "" }
     let(:args) do
       {
@@ -103,8 +105,8 @@ describe Yast::NetworkProposal do
         expect(Yast::WFM).to_not receive(:CallFuntion).with("inst_lan", anything)
       end
 
-      it "changes the netwotk backend to wicked" do
-        expect(Yast::NetworkService).to receive(:use_wicked)
+      it "changes the network backend to wicked" do
+        expect(settings).to receive(:enable_wicked!)
 
         subject.ask_user(args)
       end
@@ -122,7 +124,7 @@ describe Yast::NetworkProposal do
       end
 
       it "changes the netwotk backend to NetworkManager" do
-        expect(Yast::NetworkService).to receive(:use_network_manager)
+        expect(settings).to receive(:enable_network_manager!)
 
         subject.ask_user(args)
       end

--- a/test/network_proposal_test.rb
+++ b/test/network_proposal_test.rb
@@ -20,12 +20,13 @@ describe Yast::NetworkProposal do
   end
 
   describe "#make_proposal" do
+    let(:settings) { Y2Network::ProposalSettings.create_instance }
     let(:using_wicked) { true }
     let(:proposal) { subject.make_proposal({}) }
 
     before do
       allow(Yast::Lan).to receive(:UseNetworkManager).and_return(!using_wicked)
-      Y2Network::ProposalSettings.create_instance
+      allow(settings).to receive(:network_manager_available?).and_return(true)
     end
 
     it "returns a hash describing the proposal" do
@@ -47,6 +48,10 @@ describe Yast::NetworkProposal do
     end
 
     context "when using the NetworkManager backend" do
+      before do
+        settings.backend = :network_manager
+      end
+
       let(:using_wicked) { false }
 
       it "does not include the Yast::Lan proposal summary" do


### PR DESCRIPTION
## Problem

Recently, we have added back the network proposal to the installation proposal overview page ([related PBI](https://trello.com/c/DLi2b1mG/338-fate-326480-add-network-to-installation-proposal-overview-page)). 

As part of the network summary it shows the **network backend** in use, permitting the user to choose between **wicked** or **Network Manager**.

The first problem  to solve arises when the package for the selected backend is not available. In that case the backend is selected and in case the dependency was added, it does not permit to continue with the installation.

But there was another problem when the dependencies were satisfied. 

The selection in the proposal is overwritten when saving the network at the end of the installation with the value determined by the control file [**network_manager**](https://github.com/yast/skelcd-control-SLED/blob/master/control/installation.SLED.xml#L172) option. (see [save_network](https://github.com/yast/yast-network/blob/master/src/lib/network/clients/save_network.rb#L299))

- https://bugzilla.suse.com/show_bug.cgi?id=1124478
- https://bugzilla.suse.com/show_bug.cgi?id=1124498
- Related PBI https://trello.com/c/eBiqtDo7/706-2-bug-1124478-and-1124498-build-1584-switching-from-nm-to-wicked-and-back-and-forth


## Solution

- A **ProposalSettings** class has been added under the Y2Network namespace, it will determine at initialization the backend to use and also offers a method to check if **Network Manager** is available at all during the installation.

- When saving the network, it is checked which network backend has been selected and the Network service is set accordingly to it avoiding the override of any change during the proposal.

- As part of the PR we have removed also the summary about not written the hostname into /etc/hosts as that option was already [removed](https://trello.com/c/so0amSNp/342-sle-15-sp1-yast2-network-clarify-hostname-setup) from the GUI.


## Testing

- *Added unit tests*
- *Tested manually*

## Screenshots

### Without registering NM package is not available, thus the switch is not offered.

![screenshot_testing_2019-02-18_08 59 48](https://user-images.githubusercontent.com/7056681/52940239-fb251f80-335d-11e9-99fb-fa1e5b14ac3e.png)

### After going back and registering the system we are able to choose the backend to be used

![screenshot_testing_2019-02-18_09 06 02](https://user-images.githubusercontent.com/7056681/52940273-0b3cff00-335e-11e9-8ea3-7bc603dcbabd.png)
![screenshot_testing_2019-02-18_09 06 15](https://user-images.githubusercontent.com/7056681/52940285-1001b300-335e-11e9-98c6-d96ba7c489f0.png)

### Backend default defined by the control file is respected in the proposal

![screenshot_testing_2019-02-18_11 12 14](https://user-images.githubusercontent.com/7056681/52948931-ce2f3780-3372-11e9-9c97-265f8b1a07a2.png)

### The selected backend is correctly enabled at the end of the installation

![wickedselected](https://user-images.githubusercontent.com/7056681/52948926-c7082980-3372-11e9-9431-d90a4c49cf5b.png)

