### PR TITLE
[RFC] Create a backup of the modified interface and restore if canceled

### DIFF
--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -374,6 +374,7 @@ module Yast
       if Ops.get_string(event, "EventReason", "") == "Activated"
         case Ops.get_symbol(event, "ID")
         when :add
+          LanItems.create_backup!
           LanItems.AddNew
           Lan.Add
 
@@ -388,6 +389,7 @@ module Yast
 
           return :add
         when :edit
+          LanItems.create_backup!
           if LanItems.IsCurrentConfigured
             LanItems.SetItem
 

--- a/src/lib/network/edit_nic_name.rb
+++ b/src/lib/network/edit_nic_name.rb
@@ -74,11 +74,6 @@ module Yast
         # FIXME: it changes udev key used for device identification
         #  and / or its value only, name is changed elsewhere
         LanItems.update_item_udev_rule!(udev_type)
-
-        if new_name != old_name
-          LanItems.update_routing_devices!
-          LanItems.update_routes!(old_name) if update_routes?(old_name)
-        end
       end
 
       close
@@ -161,25 +156,6 @@ module Yast
       end
 
       true
-    end
-
-    # When an interface name has changed, it returns whether the user wants to
-    # update the interface name in the related routes or not.
-    #
-    # return [Boolean] whether the routes have to be updated or not
-    def update_routes?(previous_name)
-      return false unless Routing.device_routes?(previous_name)
-
-      Popup.YesNoHeadline(
-        Label.WarningMsg,
-        # TRANSLATORS: Ask for fixing a possible conflict after renaming
-        # an interface, %s are the previous and current interface names
-        format(_("The interface %s has been renamed to %s. There are \n" \
-                  "some routes that still use the previous name.\n\n" \
-                  "Would you like to update them now?\n"),
-          "'#{previous_name}'",
-          "'#{LanItems.current_name}'")
-      )
     end
   end
 end


### PR DESCRIPTION
I have created a separate PR, so it could be ignored by now or not.

Basically with this PR any modification done during the edit process related to the current LanItem is restored in case of aborted or canceled.