### PR TITLE
Network Proposal: Enhanced dependencies handling (bsc#1127228)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Wed Feb 27 15:08:09 UTC 2019 - knut.anderssen@suse.com
+
+- Installation proposal (bsc#1127228, bsc#1124478, bsc#1124498):
+  - Fixed issue refreshing the list of packages needed for the
+    default backend the first time the proposal is called.
+  - Do not cache the default network backend but only the current
+    one when modified by the user in the proposal
+  - Fallback to :wicked when saving the network if NetworkManager
+    is selected as the service to be used but not installed.
+- 4.1.42
+
+-------------------------------------------------------------------
 Thu Feb 21 17:50:32 UTC 2019 - knut.anderssen@suse.com
 
 - When renaming an interface (bsc#1060207):

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.41
+Version:        4.1.42
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -19,6 +19,8 @@ module Yast
       Yast.import "LanItems"
 
       textdomain "installation"
+
+      wicked_backend? ? settings.enable_wicked! : settings.enable_network_manager!
     end
 
     def description

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -20,7 +20,7 @@ module Yast
 
       textdomain "installation"
 
-      wicked_backend? ? settings.enable_wicked! : settings.enable_network_manager!
+      settings.refresh_packages
     end
 
     def description
@@ -103,7 +103,7 @@ module Yast
     end
 
     def wicked_backend?
-      settings.backend != :network_manager
+      settings.current_backend != :network_manager
     end
 
     # TODO: move to HTML.ycp

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -297,7 +297,7 @@ module Yast
 
       log.info("Setting network service according to product preferences")
 
-      case Y2Network::ProposalSettings.instance.backend
+      case Y2Network::ProposalSettings.instance.network_service
       when :network_manager
         log.info("- using NetworkManager")
         NetworkService.use_network_manager

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -37,7 +37,6 @@ module Y2Network
       Yast.import "ProductFeatures"
       Yast.import "Package"
       Yast.import "PackagesProposal"
-      Yast.import "Lan"
 
       @selected_backend = nil
     end

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -38,11 +38,7 @@ module Y2Network
       Yast.import "PackagesProposal"
       Yast.import "Lan"
 
-      @backend = use_network_manager? ? :network_manager : :wicked
-
-      log.info("The default proposed network backend is: #{@backend}")
-
-      @backend
+      use_network_manager? ? enable_network_manager! : enable_wicked!
     end
 
     # Adds the NetworkManager package to the {Yast::PackagesProposal} and sets

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -39,6 +39,8 @@ module Y2Network
       Yast.import "Lan"
 
       use_network_manager? ? enable_network_manager! : enable_wicked!
+      log.info("The default proposed network backend is: #{@backend}")
+      @backend
     end
 
     # Adds the NetworkManager package to the {Yast::PackagesProposal} and sets

--- a/test/lib/y2network/proposal_settings_test.rb
+++ b/test/lib/y2network/proposal_settings_test.rb
@@ -135,9 +135,10 @@ describe Y2Network::ProposalSettings do
 
   describe "#current_backend" do
     let(:selected_backend) { :wicked }
-    let(:default_backend) { "wicked_or_nm" }
+    let(:default_backend) { "wicked_or_nm_based_on_control_file" }
+
     before do
-      allow(subject).to receive(:default_backend).and_return("wicked_or_nm")
+      allow(subject).to receive(:default_backend).and_return(default_backend)
       subject.selected_backend = selected_backend
     end
 
@@ -157,10 +158,6 @@ describe Y2Network::ProposalSettings do
   end
 
   describe "#enable_wicked!" do
-    before do
-      subject
-    end
-
     it "adds the wicked package to the list of resolvables " do
       expect(Yast::PackagesProposal).to receive(:AddResolvables)
         .with("network", :package, ["wicked"])
@@ -219,9 +216,6 @@ describe Y2Network::ProposalSettings do
   end
 
   describe "#enable_network_manager!" do
-    before do
-      subject
-    end
     before do
       subject.selected_backend = nil
     end

--- a/test/network_proposal_test.rb
+++ b/test/network_proposal_test.rb
@@ -26,7 +26,7 @@ describe Yast::NetworkProposal do
     let(:proposal) { subject.make_proposal({}) }
 
     before do
-      settings.backend = current_backend
+      settings.selected_backend = current_backend
       allow(settings).to receive(:network_manager_available?).and_return(nm_available)
     end
 


### PR DESCRIPTION
## Problem

In #727 we did some fixes for SLES improving the switch handling between network backends. But once the network proposal was added into openSUSE (https://github.com/yast/skelcd-control-openSUSE/pull/170 & https://github.com/yast/skelcd-control-openSUSE/pull/169), the selection of the generic desktop role shown that the initialization of the packages requirement was not correct at all (although the backend was correctly selected)

So, it worked fine when switching between backends, but the packages were not added when entering the proposal the first time or when the role selected was modified going back & forth. Which means a not network installation in case **NetworkManager** was not installed by other pattern dependencies. 

- https://bugzilla.opensuse.org/show_bug.cgi?id=1127228

## Solution

- We have modified the proposal network client to refresh the list of resolvables 
 packages at initialization, so the software selection reflects them, and in case of removed a red warning / error will be shown.
- The **backend** used will be the `default` defined by the **control** file `until manual selection`, that is, a click switching between backends.
- At the end of the initialization (**save_network**), if for any reason (like removing the proposal) the package for the **backend selected is not available**, then, we will enable **wicked** as we did in the past (having at least a network configuration).
 
## Testing

- *Added unit tests*
- *Tested manually*

## Screenshots

## Selection of role (default backend NM) and package removed later in the proposal

![roleselection](https://user-images.githubusercontent.com/7056681/53577155-13224d80-3b6d-11e9-9281-97ac671c43dd.png)

![warningafterremoval](https://user-images.githubusercontent.com/7056681/53577158-14ec1100-3b6d-11e9-9b32-e3899c36fd2d.png) |
