### PR TITLE
Fetch also the parent busid when using a virtio netcard

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Mar 20 21:44:27 UTC 2019 - knut.anderssen@suse.com
+
+- bnc#1129012
+  - AY: Use the bus_id of the udev parent device when using virtio
+    netcards and matching the existent rules with the defined in
+    in the profile.
+- 3.4.3
+
+-------------------------------------------------------------------
 Wed Jan  2 17:17:58 CET 2019 - schubi@suse.de
 
 - Showing correct start mode for nfsroot device (bsc#1105692).

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.4.2
+Version:        3.4.3
 Release:        0
 BuildArch:      noarch
 

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -625,6 +625,7 @@ module Yast
 
           one["bus"] = bus
           one["busid"] = card["sysfs_bus_id"] || ""
+          one["parent_busid"] = one["sysfs_id"].split("/")[-2] if one["driver"] == "virtio_net"
           one["mac"] = Ops.get_string(resource, ["hwaddr", 0, "addr"], "")
           # is the cable plugged in? nil = don't know
           one["link"] = Ops.get(resource, ["link", 0, "state"])

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -625,7 +625,9 @@ module Yast
 
           one["bus"] = bus
           one["busid"] = card["sysfs_bus_id"] || ""
-          one["parent_busid"] = one["sysfs_id"].split("/")[-2] if one["driver"] == "virtio_net"
+          if one["busid"].start_with?("virtio")
+            one["parent_busid"] = one["sysfs_id"].split("/")[-2]
+          end
           one["mac"] = Ops.get_string(resource, ["hwaddr", 0, "addr"], "")
           # is the cable plugged in? nil = don't know
           one["link"] = Ops.get(resource, ["link", 0, "state"])

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -284,10 +284,11 @@ module Yast
         item_id, matching_item = LanItems.Items.find do |_, i|
           next unless i["hwinfo"]
           busid = i["hwinfo"]["busid"]
+          # Match also parent busid if exist (bsc#1129012)
           parent_busid = i["hwinfo"]["parent_busid"] || busid
           mac = i["hwinfo"]["mac"]
 
-          [busid, parent_busid, mac].any? { |v| v.downcase == key }
+          [busid, parent_busid, mac].any? { |v| v.casecmp?(key) }
         end
         next if !matching_item
 

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -288,7 +288,7 @@ module Yast
           parent_busid = i["hwinfo"]["parent_busid"] || busid
           mac = i["hwinfo"]["mac"]
 
-          [busid, parent_busid, mac].any? { |v| v.casecmp?(key) }
+          [busid, parent_busid, mac].any? { |v| v.casecmp(key).zero? }
         end
         next if !matching_item
 

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -281,20 +281,24 @@ module Yast
         key.downcase!
 
         # find item which matches to the given rule definition
-        item, matching_item = LanItems.Items.find do |_, i|
-          i["hwinfo"] &&
-            (i["hwinfo"]["busid"].downcase == key || i["hwinfo"]["mac"].downcase == key)
+        item_id, matching_item = LanItems.Items.find do |_, i|
+          next unless i["hwinfo"]
+          busid = i["hwinfo"]["busid"]
+          parent_busid = i["hwinfo"]["parent_busid"] || busid
+          mac = i["hwinfo"]["mac"]
+
+          [busid, parent_busid, mac].any? { |v| v.downcase == key }
         end
         next if !matching_item
 
-        name_from = item_name(item)
+        name_from = item_name(item_id)
         log.info("Matching device found - renaming <#{name_from}> -> <#{name_to}>")
 
         # rename item in collision
         rename_lan_item(colliding_item(name_to), name_from)
 
         # rename matching item
-        rename_lan_item(item, name_to, attr, key)
+        rename_lan_item(item_id, name_to, attr, key)
       end
     end
 


### PR DESCRIPTION
- https://trello.com/c/sFSmetoI/883-sles12-sp4-p3-1129012-sles-12-sp4-when-installing-sles-12-sp4-with-kvm-virt-install-autoyast-net-udev-is-not-renaming-the-networ
- https://bugzilla.suse.com/show_bug.cgi?id=1129012

## Problem

The bug appears in a **KVM** autoinstallation with **virtio** netcards. The user defines two **udev rules** using the **busid**, but we are not able to **match** the current rules, because while udev write_net_rules uses the pci busid, hwinfo used the virtio netcard busid.

![Screenshot_testing_2019-03-18_09_31_42](https://user-images.githubusercontent.com/7056681/55181400-824a8c00-5183-11e9-8cdb-8496c6dfb9cf.png)

## Solution

There are different solutions at different layers that could be used as workarounds, but maybe the less risky would be adding the parent_bus_id and use it also during the match, when using a virtio card that is what has been implemented.

