### PR TITLE
Y2Network::Config.from fix

### DIFF
--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -42,11 +42,12 @@ module Y2Network
     # @return [Symbol] Information source (see {Y2Network::Reader} and {Y2Network::Writer})
     attr_reader :source
 
-    # @param source [Symbol] Source to read the configuration from
     class << self
+      # @param source [Symbol] Source to read the configuration from
+      # @return [Y2Network::Config]
       def from(source)
-        builder = ConfigReader.for(source)
-        builder.network_config
+        reader = ConfigReader.for(source)
+        reader.config
       end
     end
 

--- a/src/lib/y2network/config_reader.rb
+++ b/src/lib/y2network/config_reader.rb
@@ -19,8 +19,8 @@
 module Y2Network
   # This module contains a set of classes to read the network configuration from the system
   #
-  # For the time being, only the wicked reader ({Y2Network::ConfigReader::Sysconfig}) reader is
-  # available.
+  # For the time being, only the wicked (through sysconfig files) reader
+  # ({Y2Network::ConfigReader::Sysconfig}) is available.
   module ConfigReader
     # Config reader for a given source
     #

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -37,6 +37,21 @@ describe Y2Network::Config do
 
   let(:routing_tables) { [table1, table2] }
 
+  describe ".from" do
+    let(:reader) do
+      instance_double(Y2Network::ConfigReader::Sysconfig, config: config)
+    end
+
+    before do
+      allow(Y2Network::ConfigReader).to receive(:for).with(:sysconfig)
+        .and_return(reader)
+    end
+
+    it "returns the configuration from the given reader" do
+      expect(described_class.from(:sysconfig)).to eq(config)
+    end
+  end
+
   describe "#routes" do
     it "returns routes from all tables" do
       expect(config.routes).to eq([route1, route2])


### PR DESCRIPTION
Fixes the `Y2Network::Config.from` method and adds a unit test.