### PR TITLE
Network ng add presenters

### DIFF
--- a/src/lib/y2network/presenters/route_profile.rb
+++ b/src/lib/y2network/presenters/route_profile.rb
@@ -1,0 +1,83 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Network
+  module Presenters
+    # This class converts a route into a hash to be used in an AutoYaST profile
+    class RouteProfile
+      def initialize(route)
+        @route = route
+      end
+
+      # Returns a representation of the route to use in an AutoYaST profile
+      #
+      # @return [Hash]
+      def to_profile
+        hash = {
+          "destination" => destination(route),
+          "device"      => device(route),
+          "gateway"     => gateway(route),
+          "extrapara"   => extrapara(route)
+        }
+        hash["source"] = route.source.to_s if route.source
+        hash
+      end
+
+    private
+
+      # @return [Y2Network::Route]
+      attr_reader :route
+
+      # Returns the destination for the given route
+      #
+      # @param route [Route] Route to get the destination from
+      # @return [String] Route destination
+      def destination(route)
+        return "default" if route.to == :default
+        [route.to.to_s, route.to.prefix].join("/")
+      end
+
+      # Returns the device (interface) for the given route
+      #
+      # @param route [Route] Route to get the device from
+      # @return [String] Device name
+      def device(route)
+        return "-" unless route.interface.respond_to?(:name)
+        route.interface.name
+      end
+
+      # Returns the gateway for the given route
+      #
+      # @param route [Route] Route to get the gateway from
+      # @return [String] Gateway address
+      def gateway(route)
+        return "-" unless route.gateway
+        route.gateway.to_s
+      end
+
+      # Returns the extra parameters for the given route
+      #
+      # @param route [Route] Route to get the options from
+      # @return [String] Extra parameters
+      def extrapara(route)
+        route.options
+      end
+    end
+  end
+end

--- a/src/lib/y2network/presenters/routing_profile.rb
+++ b/src/lib/y2network/presenters/routing_profile.rb
@@ -1,0 +1,58 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/presenters/route_profile"
+
+module Y2Network
+  module Presenters
+    # This class converts a routing configuration object into a hash to be used
+    # in an AutoYaST profile
+    class RoutingProfile
+      # Constructor
+      #
+      # @param routing [Y2Network::Routing] Routing configuration
+      def initialize(routing)
+        @routing = routing
+      end
+
+      # Returns a representation to use in an AutoYaST profile
+      #
+      # @return [Hash]
+      def to_profile
+        {
+          "ipv4_forward" => routing.forward_ipv4,
+          "ipv6_forward" => routing.forward_ipv6,
+          "routes"       => routing.routes.map { |r| route_to_profile(r) }
+        }
+      end
+
+    private
+
+      # @return [Y2Network::Routing] Routing configuration
+      attr_reader :routing
+
+      # Return a representation of a route to use in an AutoYaST profile
+      #
+      # @todo It might be implemented in a separate class
+      def route_to_profile(route)
+        Y2Network::Presenters::RouteProfile.new(route).to_profile
+      end
+    end
+  end
+end

--- a/src/lib/y2network/presenters/routing_summary.rb
+++ b/src/lib/y2network/presenters/routing_summary.rb
@@ -1,0 +1,46 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Network
+  module Presenters
+    # This class converts a routing configuration object into a hash to be used
+    # in an AutoYaST summary
+    class RoutingSummary
+      # @return [Y2Network::Config]
+      attr_reader :config
+
+      # Constructor
+      #
+      # @param config [Y2Network::Config] Network configuration to represent
+      def initialize(config)
+        @config = config
+      end
+
+      # Returns the summary of network configuration settings in text form
+      #
+      # @todo Export the real summary.
+      #
+      # @param mode [Symbol] Summary mode (:summary or :proposal)
+      # @return [String]
+      def text(mode:)
+        "Config summary in #{mode} mode"
+      end
+    end
+  end
+end

--- a/test/y2network/presenters/route_profile_test.rb
+++ b/test/y2network/presenters/route_profile_test.rb
@@ -1,0 +1,81 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/presenters/route_profile"
+require "y2network/route"
+
+describe Y2Network::Presenters::RouteProfile do
+  subject(:presenter) { described_class.new(route) }
+
+  let(:route) do
+    Y2Network::Route.new(
+      to: to, interface: interface, gateway: gateway, source: source, options: options
+    )
+  end
+  let(:to) { IPAddr.new("192.168.122.0/24") }
+  let(:interface) { double("interface", name: "eth0") }
+  let(:gateway) { IPAddr.new("192.168.122.1") }
+  let(:source) { IPAddr.new("192.168.122.122") }
+  let(:options) { "some-option" }
+
+  describe "#to_profile" do
+    it "returns a hash containing the information for the profile" do
+      expect(presenter.to_profile).to eq(
+        "destination" => "192.168.122.0/24",
+        "device"      => "eth0",
+        "gateway"     => "192.168.122.1",
+        "source"      => "192.168.122.122",
+        "extrapara"   => "some-option"
+      )
+    end
+
+    context "when it is the default route" do
+      let(:to) { :default }
+
+      it "exports the destination as 'default'" do
+        expect(presenter.to_profile).to include("destination" => "default")
+      end
+    end
+
+    context "when there is no gateway" do
+      let(:gateway) { nil }
+
+      it "exports the destination as '-'" do
+        expect(presenter.to_profile).to include("gateway" => "-")
+      end
+    end
+
+    context "when there is no associated interface" do
+      let(:interface) { :any }
+
+      it "exports the destination as '-'" do
+        expect(presenter.to_profile).to include("device" => "-")
+      end
+    end
+
+    context "when there is no source" do
+      let(:source) { nil }
+
+      it "does not export any value as source" do
+        expect(presenter.to_profile["source"]).to be_nil
+      end
+    end
+  end
+end

--- a/test/y2network/presenters/routing_profile_test.rb
+++ b/test/y2network/presenters/routing_profile_test.rb
@@ -1,0 +1,46 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/presenters/routing_profile"
+require "y2network/routing"
+require "y2network/routing_table"
+require "y2network/route"
+
+describe Y2Network::Presenters::RoutingProfile do
+  subject(:presenter) { described_class.new(routing) }
+
+  let(:routing) do
+    instance_double(Y2Network::Routing, forward_ipv4: true, forward_ipv6: true, routes: [route1])
+  end
+  let(:route1) { Y2Network::Route.new }
+
+  describe "#to_profile" do
+    it "returns a hash containing the routing information for the profile" do
+      profile = presenter.to_profile
+      expect(profile).to include(
+        "ipv4_forward" => true,
+        "ipv6_forward" => true
+      )
+      expect(profile["routes"]).to include(
+        "destination" => "default", "device" => "-", "gateway" => "-", "extrapara" => ""
+      )
+    end
+  end
+end

--- a/test/y2network/presenters/routing_summary_test.rb
+++ b/test/y2network/presenters/routing_summary_test.rb
@@ -1,0 +1,29 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/presenters/routing_summary"
+require "y2network/config"
+
+describe Y2Network::Presenters::RoutingSummary do
+  subject(:presenter) { described_class.new(config) }
+  let(:config) { instance_double(Y2Network::Config) }
+
+  it "returns a summary in text form"
+end


### PR DESCRIPTION
As part of the effort to drop the `Routing` module, I have added some presenter classes to convert the routing information into a section for the 1) AutoYaST profile and the 2) network summary. The latter is a WIP which will be finished as part of dropping the `Routing` module.