### PR TITLE
Network ng autoinst profile

### DIFF
--- a/src/lib/y2network/autoinst_profile/networking_section.rb
+++ b/src/lib/y2network/autoinst_profile/networking_section.rb
@@ -1,0 +1,42 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Network
+  module AutoinstProfile
+    class NetworkingSection
+      # @return [RoutingSection]
+      attr_accessor :routing
+
+      # Creates an instance based on the profile representation used by the AutoYaST modules
+      # (hash with nested hashes and arrays).
+      #
+      # @param hash [Hash] Networking section from an AutoYaST profile
+      # @return [NetworkingSection]
+      def self.new_from_hashes(hash)
+        result = new
+        result.routing = RoutingSection.new_from_hashes(hash["routing"]) if hash["routing"]
+        result
+      end
+
+      def to_hashes
+        { "routing" => routing.to_hashes }
+      end
+    end
+  end
+end

--- a/src/lib/y2network/autoinst_profile/networking_section.rb
+++ b/src/lib/y2network/autoinst_profile/networking_section.rb
@@ -19,6 +19,15 @@
 
 module Y2Network
   module AutoinstProfile
+    # This class represents an AutoYaST <networking> section
+    #
+    #  <networking>
+    #    <routing>
+    #      <!-- the routing configuration -->
+    #    </routing>
+    #  </networking>
+    #
+    # @see RoutingSection
     class NetworkingSection
       # @return [RoutingSection]
       attr_accessor :routing
@@ -44,6 +53,9 @@ module Y2Network
         result
       end
 
+      # Export the section to a hash so it might be used when cloning the system
+      #
+      # @return [Hash]
       def to_hashes
         { "routing" => routing.to_hashes }
       end

--- a/src/lib/y2network/autoinst_profile/networking_section.rb
+++ b/src/lib/y2network/autoinst_profile/networking_section.rb
@@ -17,6 +17,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "y2network/autoinst_profile/routing_section"
+
 module Y2Network
   module AutoinstProfile
     # This class represents an AutoYaST <networking> section

--- a/src/lib/y2network/autoinst_profile/networking_section.rb
+++ b/src/lib/y2network/autoinst_profile/networking_section.rb
@@ -34,6 +34,16 @@ module Y2Network
         result
       end
 
+      # Creates an instance based on the network configuration representation
+      #
+      # @param config [Y2Network::Config]
+      # @return [NetworkingSection]
+      def self.new_from_network(config)
+        result = new
+        result.routing = RoutingSection.new_from_network(config.routing)
+        result
+      end
+
       def to_hashes
         { "routing" => routing.to_hashes }
       end

--- a/src/lib/y2network/autoinst_profile/route_section.rb
+++ b/src/lib/y2network/autoinst_profile/route_section.rb
@@ -1,0 +1,64 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/autoinst_profile/section_with_attributes"
+
+module Y2Network
+  module AutoinstProfile
+    # This class represents an AutoYaST <route> section under <routing>
+    #
+    #  <route>
+    #    <destination>192.168.1.0</destination>
+    #    <device>eth0</device>
+    #    <extrapara>foo</extrapara>
+    #    <gateway>-</gateway>
+    #    <netmask>-</netmask>
+    #  </route>
+    #
+    # @see RoutingSection
+    class RouteSection < SectionWithAttributes
+      def self.attributes
+        [
+          { name: :destination },
+          { name: :device },
+          { name: :extrapara },
+          { name: :gateway },
+          { name: :netmask }
+        ]
+      end
+
+      define_attr_accessors
+
+      # @!attribute destination
+      #  @return [String] Route destination
+
+      # @!attribute device
+      #  @return [String] Interface name
+
+      # @!attribute extrapara
+      #  @return [String] Route options
+
+      # @!attribute gateway
+      #  @return [String] Route gateway
+
+      # @!attribute netmask
+      #  @return [String] Netmask
+    end
+  end
+end

--- a/src/lib/y2network/autoinst_profile/routing_section.rb
+++ b/src/lib/y2network/autoinst_profile/routing_section.rb
@@ -44,7 +44,7 @@ module Y2Network
         [
           { name: :ipv4_forward },
           { name: :ipv6_forward },
-          { name: :routes}
+          { name: :routes }
         ]
       end
 
@@ -59,15 +59,39 @@ module Y2Network
       # @!attribute routes
       #   @return [Array<RouteSection>]
 
+      # Clones network routing settings into an AutoYaST routing section
+      #
+      # @param routing [Y2Network::Routing] Routing settings
+      # @return [RoutingSection]
+      def self.new_from_network(routing)
+        result = new
+        initialized = result.init_from_network(routing)
+        initialized ? result : nil
+      end
+
+      # Constructor
       def initialize(_parent = nil)
         super
         @routes = []
       end
 
+      # Method used by {.new_from_hashes} to populate the attributes when importing a profile
+      #
       # @param hash [Hash] see {.new_from_hashes}
       def init_from_hashes(hash)
         super
         @routes = routes_from_hash(hash)
+      end
+
+      # Method used by {.new_from_network} to populate the attributes when cloning routing settings
+      #
+      # @param routing [Y2Network::Routing] Network settings
+      # @return [Boolean]
+      def init_from_network(routing)
+        @ipv4_forward = routing.forward_ipv4
+        @ipv6_forward = routing.forward_ipv6
+        @routes = routes_section(routing.routes)
+        true
       end
 
     private
@@ -78,6 +102,10 @@ module Y2Network
       def routes_from_hash(hash)
         hashes = hash["routes"] || []
         hashes.map { |h| RouteSection.new_from_hashes(h) }
+      end
+
+      def routes_section(routes)
+        routes.map { |r| Y2Network::AutoinstProfile::RouteSection.new_from_network(r) }
       end
     end
   end

--- a/src/lib/y2network/autoinst_profile/routing_section.rb
+++ b/src/lib/y2network/autoinst_profile/routing_section.rb
@@ -1,0 +1,84 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/autoinst_profile/section_with_attributes"
+require "y2network/autoinst_profile/route_section"
+
+module Y2Network
+  module AutoinstProfile
+    # This class represents an AutoYaST <routing> section under <networking>
+    #
+    #  <routing>
+    #    <ipv4_forward config:type="boolean">false</ipv4_forward>
+    #    <ipv6_forward config:type="boolean">false</ipv6_forward>
+    #    <routes config:type="list">
+    #      <route> <!-- see RouteSection class -->
+    #        <destination>192.168.1.0</destination>
+    #        <device>eth0</device>
+    #        <extrapara>foo</extrapara>
+    #        <gateway>-</gateway>
+    #        <netmask>-</netmask>
+    #      </route>
+    #    </routes>
+    #  </routing>
+    #
+    # @see NetworkingSection
+    class RoutingSection < SectionWithAttributes
+      def self.attributes
+        [
+          { name: :ipv4_forward },
+          { name: :ipv6_forward },
+          { name: :routes}
+        ]
+      end
+
+      define_attr_accessors
+
+      # @!attribute ipv4_forward
+      #  @return [Boolean]
+
+      # @!attribute ipv6_forward
+      #  @return [Boolean]
+
+      # @!attribute routes
+      #   @return [Array<RouteSection>]
+
+      def initialize(_parent = nil)
+        super
+        @routes = []
+      end
+
+      # @param hash [Hash] see {.new_from_hashes}
+      def init_from_hashes(hash)
+        super
+        @routes = routes_from_hash(hash)
+      end
+
+    private
+
+      # Returns an array of routing sections
+      #
+      # @param hash [Hash] Routing section hash
+      def routes_from_hash(hash)
+        hashes = hash["routes"] || []
+        hashes.map { |h| RouteSection.new_from_hashes(h) }
+      end
+    end
+  end
+end

--- a/src/lib/y2network/autoinst_profile/routing_section.rb
+++ b/src/lib/y2network/autoinst_profile/routing_section.rb
@@ -70,7 +70,7 @@ module Y2Network
       end
 
       # Constructor
-      def initialize(_parent = nil)
+      def initialize(*_args)
         super
         @routes = []
       end
@@ -86,7 +86,7 @@ module Y2Network
       # Method used by {.new_from_network} to populate the attributes when cloning routing settings
       #
       # @param routing [Y2Network::Routing] Network settings
-      # @return [Boolean]
+      # @return [Boolean] Result true on success or false otherwise
       def init_from_network(routing)
         @ipv4_forward = routing.forward_ipv4
         @ipv6_forward = routing.forward_ipv6

--- a/src/lib/y2network/autoinst_profile/section_with_attributes.rb
+++ b/src/lib/y2network/autoinst_profile/section_with_attributes.rb
@@ -1,0 +1,189 @@
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+module Y2Network
+  module AutoinstProfile
+    # Abstract base class for some AutoYaST profile sections
+    #
+    # @todo This class is supposed to live in autoyast2 or yast2. When done,
+    #   please, adapt yast2-storage-ng accordingly.
+    class SectionWithAttributes
+      include Yast::Logger
+
+      class << self
+        # Description of the attributes in the section.
+        #
+        # To be defined by each subclass. Each entry contains a hash with the
+        # mandatory key :name and an optional key :xml_name.
+        #
+        # @return [Array<Hash>]
+        def attributes
+          []
+        end
+
+        # Creates an instance based on the profile representation used by the
+        # AutoYaST modules (nested arrays and hashes).
+        #
+        # This method provides no extra validation, type conversion or
+        # initialization to default values. Those responsibilities belong to the
+        # AutoYaST modules. The hash is expected to be valid and
+        # contain the relevant information. Attributes are set to nil for
+        # missing keys and for blank values.
+        #
+        # @param hash   [Hash] content of the corresponding section of the profile.
+        #   Each element of the hash corresponds to one of the attributes
+        #   defined in the section.
+        # @param parent [#parent,#section_name] parent section
+        # @return [SectionWithAttributes]
+        def new_from_hashes(hash, parent = nil)
+          result = new(parent)
+          result.init_from_hashes(hash)
+          result
+        end
+
+      protected
+
+        # Macro used in the subclasses to define accessors for all the
+        # attributes defined by {.attributes}
+        def define_attr_accessors
+          attributes.each do |attrib|
+            attr_accessor attrib[:name]
+          end
+        end
+      end
+
+      # This value only makes sense when {.new_from_hashes} is used.
+      #
+      # @return [#parent,#section_name] Parent section
+      attr_reader :parent
+
+      # Constructor
+      #
+      # @param parent [SectionWithAttributes] Parent section
+      def initialize(parent = nil)
+        @parent = parent
+      end
+
+      # Method used by {.new_from_hashes} to populate the attributes.
+      #
+      # By default, it simply assigns the non-empty hash values to the
+      # corresponding attributes, logging unknown keys. The subclass is expected
+      # to refine this behavior if needed.
+      #
+      # @param hash [Hash] see {.new_from_hashes}
+      def init_from_hashes(hash)
+        init_scalars_from_hash(hash)
+      end
+
+      # Content of the section in the format used by the AutoYaST modules
+      # (nested arrays and hashes).
+      #
+      # @return [Hash] each element of the hash corresponds to one of the
+      #     attributes defined in the section. Blank attributes are not
+      #     included.
+      def to_hashes
+        attributes.each_with_object({}) do |attrib, result|
+          value = attrib_value(attrib)
+          next if attrib_skip?(value)
+
+          key = attrib_key(attrib)
+          result[key] = value
+        end
+      end
+
+      # Returns the section name
+      #
+      # In some cases, the section name does not match with the XML name
+      # and this method should be redefined.
+      #
+      # @example
+      #   section = PartitioningSection.new
+      #   section.section_name #=> "partitioning"
+      #
+      # @return [String] Section name
+      def section_name
+        klass_name = self.class.name.split("::").last
+        klass_name
+          .gsub(/([a-z])([A-Z])/, "\\1_\\2").downcase
+          .chomp("_section")
+      end
+
+    protected
+
+      def attributes
+        self.class.attributes
+      end
+
+      # Whether an attribute must be skipped during import/export.
+      #
+      # @return [Boolean] true is the value is blank
+      def attrib_skip?(value)
+        value.nil? || value == [] || value == ""
+      end
+
+      def attrib_key(attrib)
+        (attrib[:xml_name] || attrib[:name]).to_s
+      end
+
+      def attrib_value(attrib)
+        value = send(attrib[:name])
+        if value.is_a?(Array)
+          value.map { |v| attrib_scalar(v) }
+        else
+          attrib_scalar(value)
+        end
+      end
+
+      def attrib_scalar(element)
+        element.respond_to?(:to_hashes) ? element.to_hashes : element
+      end
+
+      def attrib_name(key)
+        attrib = attributes.detect { |a| a[:xml_name] == key.to_sym || a[:name] == key.to_sym }
+        return nil unless attrib
+        attrib[:name]
+      end
+
+      def init_scalars_from_hash(hash)
+        hash.each_pair do |key, value|
+          name = attrib_name(key)
+
+          if name.nil?
+            log.warn "Attribute #{key} not recognized by #{self.class}. Check the XML schema."
+            next
+          end
+
+          # This method only reads scalar values
+          next if value.is_a?(Array) || value.is_a?(Hash)
+
+          if attrib_skip?(value)
+            log.debug "Ignored blank value (#{value}) for #{key}"
+            next
+          end
+
+          send(:"#{name}=", value)
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2network/autoinst_profile/section_with_attributes.rb
+++ b/src/lib/y2network/autoinst_profile/section_with_attributes.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2019] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/test/y2network/autoinst_profile/networking_section_test.rb
+++ b/test/y2network/autoinst_profile/networking_section_test.rb
@@ -19,8 +19,27 @@
 
 require_relative "../../test_helper"
 require "y2network/autoinst_profile/networking_section"
+require "y2network/config"
 
 describe Y2Network::AutoinstProfile::NetworkingSection do
+  describe ".new_from_network" do
+    let(:config) do
+      Y2Network::Config.new(interfaces: [], routing: routing, source: :sysconfig)
+    end
+    let(:routing) { double("Y2Network::Routing") }
+    let(:routing_section) { double("RoutingSection") }
+
+    before do
+      allow(Y2Network::AutoinstProfile::RoutingSection).to receive(:new_from_network)
+        .with(routing).and_return(routing_section)
+    end
+
+    it "initializes the routing section" do
+      section = described_class.new_from_network(config)
+      expect(section.routing).to eq(routing_section)
+    end
+  end
+
   describe ".new_from_hashes" do
     let(:hash) do
       {

--- a/test/y2network/autoinst_profile/networking_section_test.rb
+++ b/test/y2network/autoinst_profile/networking_section_test.rb
@@ -1,0 +1,52 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/autoinst_profile/networking_section"
+
+describe Y2Network::AutoinstProfile::NetworkingSection do
+  describe ".new_from_hashes" do
+    let(:hash) do
+      {
+        "routing" => routing
+      }
+    end
+    let(:routing) { {} }
+    let(:routing_section) { double("RoutingSection") }
+
+    before do
+      allow(Y2Network::AutoinstProfile::RoutingSection).to receive(:new_from_hashes)
+        .with(routing).and_return(routing_section)
+    end
+
+    it "initializes the routing section" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.routing).to eq(routing_section)
+    end
+
+    context "when no routing section is present" do
+      let(:routing) { nil }
+
+      it "does not initialize the routing section" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.routing).to eq(nil)
+      end
+    end
+  end
+end

--- a/test/y2network/autoinst_profile/route_section_test.rb
+++ b/test/y2network/autoinst_profile/route_section_test.rb
@@ -19,9 +19,93 @@
 
 require_relative "../../test_helper"
 require "y2network/autoinst_profile/route_section"
+require "y2network/route"
 
 describe Y2Network::AutoinstProfile::RouteSection do
   subject(:section) { described_class.new }
+
+  describe ".new_from_network" do
+    let(:route) do
+      Y2Network::Route.new(
+        to: to, interface: interface, gateway: gateway, source: source, options: options
+      )
+    end
+    let(:to) { IPAddr.new("192.168.122.0/24") }
+    let(:interface) { double("interface", name: "eth0") }
+    let(:gateway) { IPAddr.new("192.168.122.1") }
+    let(:source) { IPAddr.new("192.168.122.122") }
+    let(:options) { "some-option" }
+
+    it "initializes the destination value" do
+      section = described_class.new_from_network(route)
+      expect(section.destination).to eq("192.168.122.0")
+    end
+
+    context "when it is the default route" do
+      let(:to) { :default }
+
+      it "initializes the destination to 'default'" do
+        section = described_class.new_from_network(route)
+        expect(section.destination).to eq("default")
+      end
+    end
+
+    it "initializes the device value" do
+      section = described_class.new_from_network(route)
+      expect(section.device).to eq("eth0")
+    end
+
+    context "when the interface is any" do
+      let(:interface) { :any }
+
+      it "initializes the device to '-'" do
+        section = described_class.new_from_network(route)
+        expect(section.device).to eq("-")
+      end
+    end
+
+    it "initializes the gateway value" do
+      section = described_class.new_from_network(route)
+      expect(section.gateway).to eq("192.168.122.1")
+    end
+
+    context "when the gateway is missing" do
+      let(:gateway) { nil }
+
+      it "initializes the gateway to '-'" do
+        section = described_class.new_from_network(route)
+        expect(section.gateway).to eq("-")
+      end
+    end
+
+    it "initializes the netmask value" do
+      section = described_class.new_from_network(route)
+      expect(section.netmask).to eq("255.255.255.0")
+    end
+
+    context "when it is the default route" do
+      let(:to) { :default }
+
+      it "initializes the netmask to '-'" do
+        section = described_class.new_from_network(route)
+        expect(section.netmask).to eq("-")
+      end
+    end
+
+    it "initializes the extrapara value" do
+      section = described_class.new_from_network(route)
+      expect(section.extrapara).to eq("some-option")
+    end
+
+    context "when options are missing" do
+      let(:options) { nil }
+
+      it "initializes the options to ''" do
+        section = described_class.new_from_network(route)
+        expect(section.extrapara).to eq("")
+      end
+    end
+  end
 
   describe ".new_from_hashes" do
     let(:hash) do
@@ -42,7 +126,7 @@ describe Y2Network::AutoinstProfile::RouteSection do
     it "initializes netmask" do
       section = described_class.new_from_hashes(hash)
       expect(section.netmask).to eq(hash["netmask"])
-      end
+    end
 
     it "initializes device" do
       section = described_class.new_from_hashes(hash)

--- a/test/y2network/autoinst_profile/route_section_test.rb
+++ b/test/y2network/autoinst_profile/route_section_test.rb
@@ -1,0 +1,62 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/autoinst_profile/route_section"
+
+describe Y2Network::AutoinstProfile::RouteSection do
+  subject(:section) { described_class.new }
+
+  describe ".new_from_hashes" do
+    let(:hash) do
+      {
+        "destination" => "192.168.122.0",
+        "netmask"     => "255.255.255.0",
+        "device"      => "eth0",
+        "gateway"     => "192.168.122.1",
+        "extrapara"   => "foo"
+      }
+    end
+
+    it "initializes destination" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.destination).to eq(hash["destination"])
+    end
+
+    it "initializes netmask" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.netmask).to eq(hash["netmask"])
+      end
+
+    it "initializes device" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.device).to eq(hash["device"])
+    end
+
+    it "initializes gateway" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.gateway).to eq(hash["gateway"])
+    end
+
+    it "initializes extrapara" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.extrapara).to eq(hash["extrapara"])
+    end
+  end
+end

--- a/test/y2network/autoinst_profile/routing_section_test.rb
+++ b/test/y2network/autoinst_profile/routing_section_test.rb
@@ -1,0 +1,67 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/autoinst_profile/routing_section"
+
+describe Y2Network::AutoinstProfile::RoutingSection do
+  subject(:section) { described_class.new }
+
+  describe ".new_from_hashes" do
+    let(:hash) do
+      {
+        "ipv4_forward" => true,
+        "ipv6_forward" => true,
+        "routes"       => routes
+      }
+    end
+    let(:route) { { "destination" => "default" }}
+    let(:routes) { [route] }
+    let(:route_section) { double("RouteSection") }
+
+    before do
+      allow(Y2Network::AutoinstProfile::RouteSection).to receive(:new_from_hashes).with(route)
+        .and_return(route_section)
+    end
+
+    it "initializes ipv4_forward" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.ipv4_forward).to eq(true)
+    end
+
+    it "initializes ipv6_forward" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.ipv4_forward).to eq(true)
+    end
+
+    it "includes one route section for each route" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.routes).to eq([route_section])
+    end
+
+    context "when no routes are defined" do
+      let(:routes) { nil }
+
+      it "defaults to an empty array" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.routes).to eq([])
+      end
+    end
+  end
+end

--- a/test/y2network/autoinst_profile/routing_section_test.rb
+++ b/test/y2network/autoinst_profile/routing_section_test.rb
@@ -19,9 +19,38 @@
 
 require_relative "../../test_helper"
 require "y2network/autoinst_profile/routing_section"
+require "y2network/routing"
 
 describe Y2Network::AutoinstProfile::RoutingSection do
   subject(:section) { described_class.new }
+
+  describe ".new_from_network" do
+    let(:routing) do
+      instance_double(Y2Network::Routing, routes: [route1], forward_ipv4: true, forward_ipv6: true)
+    end
+    let(:route1) { double("Y2Network::Route") }
+    let(:route_section) { double("Y2Network::AutoinstProfile::RouteSection") }
+
+    before do
+      allow(Y2Network::AutoinstProfile::RouteSection).to receive(:new_from_network).with(route1)
+        .and_return(route_section)
+    end
+
+    it "sets the ipv4_forward attribute" do
+      section = described_class.new_from_network(routing)
+      expect(section.ipv4_forward).to eq(true)
+    end
+
+    it "sets the ipv6_forward attribute" do
+      section = described_class.new_from_network(routing)
+      expect(section.ipv6_forward).to eq(true)
+    end
+
+    it "sets the routing section" do
+      section = described_class.new_from_network(routing)
+      expect(section.routes).to eq([route_section])
+    end
+  end
 
   describe ".new_from_hashes" do
     let(:hash) do
@@ -31,7 +60,7 @@ describe Y2Network::AutoinstProfile::RoutingSection do
         "routes"       => routes
       }
     end
-    let(:route) { { "destination" => "default" }}
+    let(:route) { { "destination" => "default" } }
     let(:routes) { [route] }
     let(:route_section) { double("RouteSection") }
 


### PR DESCRIPTION
This classes implements the same approach followed in storage-ng to handle the conversion to/from an AutoYaST profile. The idea is:

* Model the networking section of the AutoYaST profile using OOP (stop thinking about AutoYaST as a big hash where possible).
* Keeping the import/export logic in the same place. It can do conversions if needed.
* Building real Y2Network::Config objects is out of the scope of these classes. It should belong to `ConfigReader+  (which makes me think that `ConfigBuilder` was a better name).

I've decided to keep the method names as similar as possible to the storage-ng implementation. On the other hand, the `Y2Network::AutoinstProfile::SectionWithAttributes` is basically copied&pasted from storage-ng and, in the future, it should be moved to somewhere else (probably to `autoyast2`).

## Using the OOP layer

Converting from an AutoYaST profile:

```ruby
def Import(settings)
  networking = Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(settings)
  # Now you can do whatever you want with the information in the profile. For instance, building
  # a Y2Network::Config object using a ConfigReader class.
end
```

And exporting:

```ruby
def Export(settings)
  config = find_config(id: :yast)
  networking = Y2Network::AutoinstProfile::NetworkingSection.new_from_network(config)
  networking.to_hashes
end
```