### PR TITLE
Fix RoutingTable#concat

### DIFF
--- a/src/lib/y2network/config_reader/sysconfig.rb
+++ b/src/lib/y2network/config_reader/sysconfig.rb
@@ -64,13 +64,19 @@ module Y2Network
       # return [RoutingTable] an object with routes
       def load_routes
         # load /etc/sysconfig/network/routes
-        routes = SysconfigRoutesReader.new.config
+        routing_table = SysconfigRoutesReader.new.config
         # load /etc/sysconfig/network/ifroute-*
-        dev_routes = find_interfaces.map do |iface|
-          SysconfigRoutesReader.new(routes_file: "/etc/sysconfig/network/ifroute-#{iface.name}").config
+        dev_routing_tables = find_interfaces.map do |iface|
+          SysconfigRoutesReader.new(
+            routes_file: "/etc/sysconfig/network/ifroute-#{iface.name}"
+          ).config
         end
 
-        dev_routes.inject(routes) { |a, e| a.concat(e.routes) }.uniq
+        dev_routing_tables.reduce(routing_table) do |rt, dev_rt|
+          rt.concat(dev_rt.routes)
+        end
+        routing_table.routes.uniq!
+        routing_table
       end
     end
   end

--- a/src/lib/y2network/routing_table.rb
+++ b/src/lib/y2network/routing_table.rb
@@ -37,10 +37,16 @@ module Y2Network
     attr_reader :routes
 
     def_delegator :@routes, :each
-    def_delegator :@routes, :concat
 
     def initialize(routes = [])
       @routes = routes
+    end
+
+    # @param routing_table [RoutingTable] Routing table
+    # @return [RoutingTable]
+    def concat(routing_table)
+      @routes.concat(routing_table)
+      self
     end
 
     # Determines whether two routing tables are equal


### PR DESCRIPTION
The problem lies in forwarding the `concat` method to the `@routes` array. Bear in mind that `#concat` does not belong to `Enumerable`.