### PR TITLE
Include some recommended python packages as required when remote web mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM yastdevel/ruby
+FROM yastdevel/ruby:sle15-sp1
 COPY . /usr/src/app
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "yast/rake"
 
+Yast::Tasks.submit_to :sle15sp1
+
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr  2 08:11:19 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Force the installation of some recommended python packages that
+  are needed for VNC with web encryption support (bsc#1131024).
+- 4.1.45
+
+-------------------------------------------------------------------
 Thu Mar 21 10:09:32 UTC 2019 - knut.anderssen@suse.com
 
 - bnc#1094934

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.44
+Version:        4.1.45
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/y2remote/modes/web.rb
+++ b/src/lib/y2remote/modes/web.rb
@@ -1,6 +1,8 @@
 require "y2remote/modes/base"
 require "y2remote/modes/socket_based"
 
+Yast.import "OSRelease"
+
 module Y2Remote
   module Modes
     # Class responsible of handle the systemd socket for vnc web access
@@ -16,7 +18,7 @@ module Y2Remote
       #
       # @return [Array<String>] list of packages required by the service
       def required_packages
-        PACKAGES
+        PACKAGES + recommended_packages
       end
 
       # Name of the socket
@@ -24,6 +26,22 @@ module Y2Remote
       # @return [String] socket name
       def socket_name
         SOCKET
+      end
+
+      # Return a list of recommended packages names
+      #
+      # VNC web access relies on python-websockify, which has dependency on some other python
+      # packages related to Web Cryptography API. Those packages are actually marked as
+      # "recommended" but are necessaries to have enabled VNC with web support. In addition,
+      # packages are not the same for SLE and openSUSE (bsc#1131024).
+      #
+      # @return [Array<String>] lisf of "recommended" packages names
+      def recommended_packages
+        if Yast::OSRelease.ReleaseInformation =~ /openSUSE/
+          ["python-jwcrypto"]
+        else
+          ["python-PyJWT", "python-cryptography"]
+        end
       end
     end
   end

--- a/test/lib/y2remote/modes/web_test.rb
+++ b/test/lib/y2remote/modes/web_test.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env rspec
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2019 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require_relative "../../../test_helper.rb"
+require "y2remote/remote"
+
+describe Y2Remote::Modes::Web do
+  subject { Y2Remote::Modes::Web.instance }
+
+  it "requires xorg-x11-Xvnc-novnc" do
+    expect(subject.required_packages).to include("xorg-x11-Xvnc-novnc")
+  end
+
+  context "when system is SLE" do
+    before do
+      allow(Yast::OSRelease).to receive(:ReleaseInformation).and_return("SUSE Linux Enterprise")
+    end
+
+    it "requires python-PyJWT" do
+      expect(subject.required_packages).to include("python-PyJWT")
+    end
+
+    it "requires python-cryptography" do
+      expect(subject.required_packages).to include("python-cryptography")
+    end
+
+    it "does not require python-jwcrypto" do
+      expect(subject.required_packages).to_not include("python-jwcrypto")
+    end
+  end
+
+  context "when system is openSUSE" do
+    before do
+      allow(Yast::OSRelease).to receive(:ReleaseInformation).and_return("openSUSE TW")
+    end
+
+    it "requires python-jwcrypto" do
+      expect(subject.required_packages).to include("python-jwcrypto")
+    end
+
+    it "does not require python-PyJWT" do
+      expect(subject.required_packages).to_not include("python-PyJWT")
+    end
+
+    it "does not require python-cryptography" do
+      expect(subject.required_packages).to_not include("python-cryptography")
+    end
+  end
+end


### PR DESCRIPTION
This PR is not valid. The problem [is in a patch](https://build.opensuse.org/package/view_file/openSUSE:Factory/python-websockify/PyJWT-token-plugin.patch?expand=1) for `python-websockify`

See https://bugzilla.suse.com/show_bug.cgi?id=1131024#c10 for a detailed explanation.