### PR TITLE
network-ng: fix gateways summary and interfaces linking

### DIFF
--- a/src/lib/y2network/clients/routing.rb
+++ b/src/lib/y2network/clients/routing.rb
@@ -313,7 +313,7 @@ module Y2Network
 
       # Handler for action "delete"
       #
-      # @param [Hash]
+      # @param options [Hash]
       # @return [Boolean] true if deleted; false otherwise
       def DeleteHandler(options)
         destination = options["dest"]

--- a/src/lib/y2network/config_reader/sysconfig.rb
+++ b/src/lib/y2network/config_reader/sysconfig.rb
@@ -110,6 +110,7 @@ module Y2Network
       # @param interfaces [Array<Interface>] Interfaces
       def link_routes_to_interfaces(routes, interfaces)
         routes.each do |route|
+          next if route.interface == :any
           interface = interfaces.find { |i| route.interface.name == i.name }
           route.interface = interface if interface
         end

--- a/src/lib/y2network/routing.rb
+++ b/src/lib/y2network/routing.rb
@@ -51,6 +51,13 @@ module Y2Network
       routes.find(&:default?)
     end
 
+    # Returns the default routes
+    #
+    # @return [Array<Route>] Default routes
+    def default_routes
+      routes.select(&:default?)
+    end
+
     # Remove default routes from routing tables
     def remove_default_routes
       tables.each(&:remove_default_routes)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,12 +2,13 @@ srcdir = File.expand_path("../../src", __FILE__)
 y2dirs = ENV.fetch("Y2DIR", "").split(":")
 ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
 
+# Ensure the tests runs with english locales
+ENV["LC_ALL"] = "en_US.UTF-8"
+ENV["LANG"] = "en_US.UTF-8"
+
 require "yast"
 require "yast/rspec"
 Yast.import "Lan"
-
-# Ensure the tests runs with english locales
-ENV["LC_ALL"] = "en_US.UTF-8"
 
 require_relative "SCRStub"
 

--- a/test/y2network/presenters/routing_summary_test.rb
+++ b/test/y2network/presenters/routing_summary_test.rb
@@ -27,12 +27,13 @@ describe Y2Network::Presenters::RoutingSummary do
   subject(:presenter) { described_class.new(routing) }
   let(:routing) do
     instance_double(
-      Y2Network::Routing, default_route: default_route, forward_ipv4: true, forward_ipv6: false,
+      Y2Network::Routing, default_routes: default_routes, forward_ipv4: true, forward_ipv6: false,
       routes: [double("Y2Network::Route")]
     )
   end
-  let(:default_route) { instance_double(Y2Network::Route, gateway: IPAddr.new("10.0.0.1")) }
+  let(:default_route) { Y2Network::Route.new(to: :default, gateway: IPAddr.new("10.0.0.1")) }
   let(:gw_hostname) { "gw.example.net" }
+  let(:default_routes) { [default_route] }
 
   before do
     allow(Yast::NetHwDetection).to receive(:ResolveIP).with("10.0.0.1")
@@ -42,16 +43,16 @@ describe Y2Network::Presenters::RoutingSummary do
   describe "#text" do
     it "returns a summary in text form" do
       text = presenter.text
-      expect(text).to include("Gateway: 10.0.0.1 (gw.example.net)")
+      expect(text).to include("10.0.0.1 (gw.example.net)")
       expect(text).to include("IP Forwarding for IPv4: on")
       expect(text).to include("IP Forwarding for IPv6: off")
     end
 
     context "when no default route is defined" do
-      let(:default_route) { nil }
+      let(:default_routes) { [] }
 
       it "does not include the gateway" do
-        expect(presenter.text).to_not include("Gateway")
+        expect(presenter.text).to_not include("Gateways")
       end
     end
 
@@ -59,7 +60,7 @@ describe Y2Network::Presenters::RoutingSummary do
       let(:gw_hostname) { "" }
 
       it "only includes the gateway IP" do
-        expect(presenter.text).to include("<li>Gateway: 10.0.0.1</li>")
+        expect(presenter.text).to include("<li>10.0.0.1</li>")
       end
     end
 

--- a/test/y2network/routing_test.rb
+++ b/test/y2network/routing_test.rb
@@ -69,10 +69,10 @@ describe Y2Network::Routing do
 
   describe "#default_route" do
     let(:routes) { [no_default, route1] }
-    let(:no_default) { Y2Network::Route.new }
+    let(:no_default) { Y2Network::Route.new(to: IPAddr.new("192.168.122.0/24")) }
 
     it "returns the default route" do
-      expect(routing.default_route).to eq(route1)
+      expect(routing.default_route).to be(route1)
     end
 
     context "when there are no routes" do
@@ -80,6 +80,25 @@ describe Y2Network::Routing do
 
       it "returns nil" do
         expect(routing.default_route).to be_nil
+      end
+    end
+  end
+
+  describe "#default_routes" do
+    let(:routes) { [default1, default2, no_default] }
+    let(:default1) { Y2Network::Route.new(to: :default) }
+    let(:default2) { Y2Network::Route.new(to: :default) }
+    let(:no_default) { Y2Network::Route.new(to: IPAddr.new("192.168.122.0/24")) }
+
+    it "returns the default routes" do
+      expect(routing.default_routes).to eq([default1, default2])
+    end
+
+    context "when there are no default routes" do
+      let(:routes) { [] }
+
+      it "returns an empty array" do
+        expect(routing.default_routes).to eq([])
       end
     end
   end


### PR DESCRIPTION
* All the gateways are now included in the summary.
* Fixes a problem when linking routes and interfaces.