### PR TITLE
Add a basic DNSConfig class

### DIFF
--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -280,7 +280,6 @@ gateway = element gateway { text }
 dns =
   element dns {
     dhcp_hostname ? &
-    write_hostname ? &
     resolv_conf_policy ? &
     hostname ? &
     domain ? &
@@ -288,7 +287,6 @@ dns =
     searchlist ?
   }
 dhcp_hostname = element dhcp_hostname { BOOLEAN }
-write_hostname = element write_hostname { BOOLEAN }
 resolv_conf_policy = element resolv_conf_policy { text }
 hostname = element hostname { text }
 domain = element domain { text }

--- a/src/lib/y2network/autoinst_profile/dns_section.rb
+++ b/src/lib/y2network/autoinst_profile/dns_section.rb
@@ -35,7 +35,6 @@ module Y2Network
     #      <search>example.net</search>
     #      <search>example.org</search>
     #    </searchlist>
-    #    <write_hostname config:type="boolean">false</write_hostname>
     #  </dns>
     class DNSSection < Y2Network::AutoinstProfile::SectionWithAttributes
       def self.attributes
@@ -44,8 +43,7 @@ module Y2Network
           { name: :hostname },
           { name: :nameservers },
           { name: :resolv_conf_policy },
-          { name: :searchlist },
-          { name: :write_hostname }
+          { name: :searchlist }
         ]
       end
 
@@ -74,7 +72,6 @@ module Y2Network
         @nameservers = dns.name_servers.map(&:to_s)
         @resolv_conf_policy = dns.resolv_conf_policy
         @searchlist = dns.search_domains
-        @write_hostname = dns.hostname_to_hosts
         true
       end
     end

--- a/src/lib/y2network/autoinst_profile/dns_section.rb
+++ b/src/lib/y2network/autoinst_profile/dns_section.rb
@@ -1,0 +1,82 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/autoinst_profile/section_with_attributes"
+
+module Y2Network
+  module AutoinstProfile
+    # This class represents an AutoYaST <dns> section under <networking>
+    #
+    #  <dns>
+    #    <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+    #    <hostname>linux</hostname>
+    #    <nameservers config:type="list">
+    #      <nameserver>192.168.122.1</nameserver>
+    #      <nameserver>10.0.0.2</nameserver>
+    #    </nameservers>
+    #    <resolv_conf_policy>auto</resolv_conf_policy>
+    #    <searchlist config:type="list">
+    #      <search>example.net</search>
+    #      <search>example.org</search>
+    #    </searchlist>
+    #    <write_hostname config:type="boolean">false</write_hostname>
+    #  </dns>
+    class DNSSection < Y2Network::AutoinstProfile::SectionWithAttributes
+      def self.attributes
+        [
+          { name: :dhcp_hostname },
+          { name: :hostname },
+          { name: :nameservers },
+          { name: :resolv_conf_policy },
+          { name: :searchlist },
+          { name: :write_hostname }
+        ]
+      end
+
+      define_attr_accessors
+
+      def self.new_from_network(dns)
+        result = new
+        initialized = result.init_from_network(dns)
+        initialized ? result : nil
+      end
+
+      # Constructor
+      def initialize(*_args)
+        super
+        @nameservers = []
+        @searchlist = []
+      end
+
+      # Method used by {.new_from_network} to populate the attributes when cloning DNS options
+      #
+      # @param dns [Y2Network::DNS] DNS settings
+      # @return [Boolean] Result true on success or false otherwise
+      def init_from_network(dns)
+        @dhcp_hostname = dns.dhcp_hostname
+        @hostname = dns.hostname
+        @nameservers = dns.name_servers.map(&:to_s)
+        @resolv_conf_policy = dns.resolv_conf_policy
+        @searchlist = dns.search_domains
+        @write_hostname = dns.hostname_to_hosts
+        true
+      end
+    end
+  end
+end

--- a/src/lib/y2network/autoinst_profile/networking_section.rb
+++ b/src/lib/y2network/autoinst_profile/networking_section.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "y2network/autoinst_profile/routing_section"
+require "y2network/autoinst_profile/dns_section"
 
 module Y2Network
   module AutoinstProfile
@@ -33,6 +34,8 @@ module Y2Network
     class NetworkingSection
       # @return [RoutingSection]
       attr_accessor :routing
+      # @return [DNSSection]
+      attr_accessor :dns
 
       # Creates an instance based on the profile representation used by the AutoYaST modules
       # (hash with nested hashes and arrays).
@@ -42,6 +45,7 @@ module Y2Network
       def self.new_from_hashes(hash)
         result = new
         result.routing = RoutingSection.new_from_hashes(hash["routing"]) if hash["routing"]
+        result.dns = DNSSection.new_from_hashes(hash["dns"]) if hash["dns"]
         result
       end
 
@@ -53,6 +57,7 @@ module Y2Network
         result = new
         return result unless config
         result.routing = RoutingSection.new_from_network(config.routing) if config.routing
+        result.dns = DNSSection.new_from_network(config.dns) if config.dns
         result
       end
 

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -19,6 +19,7 @@
 require "y2network/interface"
 require "y2network/config_writer"
 require "y2network/config_reader"
+require "y2network/dns"
 
 module Y2Network
   # This class represents the current network configuration including interfaces,
@@ -36,8 +37,10 @@ module Y2Network
   class Config
     # @return [Array<Interface>]
     attr_accessor :interfaces
-    # @return [Routing]
+    # @return [Routing] Routing configuration
     attr_accessor :routing
+    # @return [DNS] DNS configuration
+    attr_accessor :dns
     # @return [Symbol] Information source (see {Y2Network::Reader} and {Y2Network::Writer})
     attr_accessor :source
 
@@ -83,10 +86,12 @@ module Y2Network
     #
     # @param interfaces [Array<Interface>] List of interfaces
     # @param routing    [Routing] Object with routing configuration
+    # @param dns        [DNS] Object with DNS configuration
     # @param source     [Symbol] Configuration source
-    def initialize(interfaces:, routing:, source:)
+    def initialize(interfaces:, routing:, dns: nil, source:)
       @interfaces = interfaces
       @routing = routing
+      @dns = dns || Y2Network::DNS.new
       @source = source
     end
 

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -88,10 +88,10 @@ module Y2Network
     # @param routing    [Routing] Object with routing configuration
     # @param dns        [DNS] Object with DNS configuration
     # @param source     [Symbol] Configuration source
-    def initialize(interfaces:, routing:, dns: nil, source:)
+    def initialize(interfaces: [], routing: Y2Network::Routing.new, dns: Y2Network::DNS.new, source:)
       @interfaces = interfaces
       @routing = routing
-      @dns = dns || Y2Network::DNS.new
+      @dns = dns
       @source = source
     end
 

--- a/src/lib/y2network/config_reader/sysconfig.rb
+++ b/src/lib/y2network/config_reader/sysconfig.rb
@@ -23,6 +23,7 @@ require "y2network/routing"
 require "y2network/sysconfig_paths"
 require "y2network/routing_table"
 require "y2network/sysconfig_routes_file"
+require "y2network/config_reader/sysconfig_dns"
 
 Yast.import "NetworkInterfaces"
 
@@ -41,7 +42,7 @@ module Y2Network
           tables: routing_tables, forward_ipv4: forward_ipv4?, forward_ipv6: forward_ipv6?
         )
 
-        Config.new(interfaces: interfaces, routing: routing, source: :sysconfig)
+        Config.new(interfaces: interfaces, routing: routing, dns: dns, source: :sysconfig)
       end
 
     private
@@ -114,6 +115,13 @@ module Y2Network
           interface = interfaces.find { |i| route.interface.name == i.name }
           route.interface = interface if interface
         end
+      end
+
+      # Returns the DNS configuration
+      #
+      # @return [Y2Network::DNS]
+      def dns
+        Y2Network::ConfigReader::SysconfigDNS.new.config
       end
     end
   end

--- a/src/lib/y2network/config_reader/sysconfig_dns.rb
+++ b/src/lib/y2network/config_reader/sysconfig_dns.rb
@@ -1,0 +1,106 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+require "yast"
+require "y2network/dns_config"
+
+module Y2Network
+  module ConfigReader
+    # Reads DNS configuration from sysconfig files
+    class SysconfigDNS
+      include Yast::Logger
+
+      # Return configuration from sysconfig files
+      #
+      # @return [Y2Network::DnsConfig] DNS configuration
+      def config
+        Y2Network::DNSConfig.new(
+          name_servers:        name_servers,
+          hostname:           hostname,
+          search_domains:     search_domains,
+          resolv_conf_policy: resolv_conf_policy,
+          hostname_to_hosts:  hostname_to_hosts,
+          dhcp_hostname:      dhcp_hostname
+        )
+      end
+
+    private
+
+      # Name servers from sysconfig
+      #
+      # Does not include invalid addresses
+      #
+      # @return [Array<IPAddr>]
+      def name_servers
+        servers = Yast::SCR.Read(
+          Yast::Path.new(".sysconfig.network.config.NETCONFIG_DNS_STATIC_SERVERS")
+        ).to_s.split
+
+        servers.each_with_object([]) do |str, ips|
+          begin
+            ips << IPAddr.new(str)
+          rescue IPAddr::InvalidAddressError
+            log.warn "Invalid IP address: #{str}"
+          end
+        end
+      end
+
+      # Returns the resolv.conf update policy
+      #
+      # @return [String]
+      def resolv_conf_policy
+        value = Yast::SCR.Read(
+          Yast::Path.new(".sysconfig.network.config.NETCONFIG_DNS_POLICY")
+        )
+        value.nil? || value.empty? ? "default" : value
+      end
+
+      # Returns the hostname
+      #
+      # @return [String]
+      def hostname
+        Yast::Execute.stdout.on_target!("/bin/hostname").strip
+      end
+
+      # Return the list of search domains
+      #
+      # @return [Array<String>]
+      def search_domains
+        Yast::SCR.Read(
+          Yast::Path.new(".sysconfig.network.config.NETCONFIG_DNS_STATIC_SEARCHLIST")
+        ).to_s.split
+      end
+
+      # Returns whether the hostname should be added to /etc/hosts
+      #
+      # @return [Boolean]
+      def hostname_to_hosts
+        value = Yast::SCR.Read(Yast::Path.new(".sysconfig.network.dhcp.WRITE_HOSTNAME_TO_HOSTS"))
+        value == "yes"
+      end
+
+      # Returns whether the hostname should be taken from DHCP
+      #
+      # @return [Boolean]
+      def dhcp_hostname
+        value = Yast::SCR.Read(Yast::Path.new(".sysconfig.network.dhcp.DHCLIENT_SET_HOSTNAME"))
+        value == "yes"
+      end
+    end
+  end
+end

--- a/src/lib/y2network/config_reader/sysconfig_dns.rb
+++ b/src/lib/y2network/config_reader/sysconfig_dns.rb
@@ -17,7 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 require "yast"
-require "y2network/dns_config"
+require "y2network/dns"
 
 module Y2Network
   module ConfigReader
@@ -29,8 +29,8 @@ module Y2Network
       #
       # @return [Y2Network::DnsConfig] DNS configuration
       def config
-        Y2Network::DNSConfig.new(
-          name_servers:        name_servers,
+        Y2Network::DNS.new(
+          name_servers:       name_servers,
           hostname:           hostname,
           search_domains:     search_domains,
           resolv_conf_policy: resolv_conf_policy,

--- a/src/lib/y2network/config_reader/sysconfig_dns.rb
+++ b/src/lib/y2network/config_reader/sysconfig_dns.rb
@@ -40,7 +40,6 @@ module Y2Network
           hostname:           hostname,
           search_domains:     search_domains,
           resolv_conf_policy: resolv_conf_policy,
-          hostname_to_hosts:  hostname_to_hosts,
           dhcp_hostname:      dhcp_hostname
         )
       end
@@ -123,14 +122,6 @@ module Y2Network
         Yast::SCR.Read(
           Yast::Path.new(".sysconfig.network.config.NETCONFIG_DNS_STATIC_SEARCHLIST")
         ).to_s.split
-      end
-
-      # Returns whether the hostname should be added to /etc/hosts
-      #
-      # @return [Boolean]
-      def hostname_to_hosts
-        value = Yast::SCR.Read(Yast::Path.new(".sysconfig.network.dhcp.WRITE_HOSTNAME_TO_HOSTS"))
-        value == "yes"
       end
 
       # Returns whether the hostname should be taken from DHCP

--- a/src/lib/y2network/dns.rb
+++ b/src/lib/y2network/dns.rb
@@ -19,7 +19,7 @@
 
 module Y2Network
   # DNS configuration (hostname, name servers, etc.).
-  class DNSConfig
+  class DNS
     # @return [String] Hostname (local part)
     attr_reader :hostname
 

--- a/src/lib/y2network/dns.rb
+++ b/src/lib/y2network/dns.rb
@@ -32,9 +32,6 @@ module Y2Network
     # @return [String] resolv.conf update policy
     attr_reader :resolv_conf_policy
 
-    # @return [Boolean] Whether to write the hostname to /etc/hosts
-    attr_reader :hostname_to_hosts
-
     # @return [Boolean] Whether to take the hostname from DHCP
     attr_reader :dhcp_hostname
 
@@ -45,14 +42,12 @@ module Y2Network
     # @option opts [Array<String>] :name_servers
     # @option opts [Array<String>] :search_domains
     # @option opts [ResolvConfPolicy] :resolv_conf_policy
-    # @option opts [Boolean] :hostname_to_hosts
     # @option opts [Boolean] :dhcp_hostname
     def initialize(opts = {})
       @hostname = opts[:hostname]
       @name_servers = opts[:name_servers] || []
       @search_domains = opts[:search_domains] || []
       @resolv_conf_policy = opts[:resolv_conf_policy]
-      @hostname_to_hosts = opts[:hostname_to_hosts]
       @dhcp_hostname = opts[:dhcp_hostname]
     end
 
@@ -64,16 +59,16 @@ module Y2Network
       nil
     end
 
+    ATTRS = [
+      :hostname, :name_servers, :search_domains, :resolv_conf_policy, :dhcp_hostname
+    ].freeze
+
     # Determines whether two set of DNS settings are equal
     #
     # @param other [DNS] DNS settings to compare with
     # @return [Boolean]
     def ==(other)
-      attrs = [
-        :hostname, :name_servers, :search_domains, :resolv_conf_policy,
-        :hostname_to_hosts, :dhcp_hostname
-      ]
-      attrs.all? { |a| public_send(a) == other.public_send(a) }
+      ATTRS.all? { |a| public_send(a) == other.public_send(a) }
     end
   end
 end

--- a/src/lib/y2network/dns.rb
+++ b/src/lib/y2network/dns.rb
@@ -56,6 +56,14 @@ module Y2Network
       @dhcp_hostname = opts[:dhcp_hostname]
     end
 
+    # Sets a hostname is none is present
+    def ensure_hostname!
+      return unless @hostname.nil? || @hostname.empty?
+      suffix = ("a".."z").to_a.sample(4).join
+      @hostname = "linux-#{suffix}"
+      nil
+    end
+
     # Determines whether two set of DNS settings are equal
     #
     # @param other [DNS] DNS settings to compare with

--- a/src/lib/y2network/dns.rb
+++ b/src/lib/y2network/dns.rb
@@ -55,5 +55,17 @@ module Y2Network
       @hostname_to_hosts = opts[:hostname_to_hosts]
       @dhcp_hostname = opts[:dhcp_hostname]
     end
+
+    # Determines whether two set of DNS settings are equal
+    #
+    # @param other [DNS] DNS settings to compare with
+    # @return [Boolean]
+    def ==(other)
+      attrs = [
+        :hostname, :name_servers, :search_domains, :resolv_conf_policy,
+        :hostname_to_hosts, :dhcp_hostname
+      ]
+      attrs.all? { |a| public_send(a) == other.public_send(a) }
+    end
   end
 end

--- a/src/lib/y2network/dns_config.rb
+++ b/src/lib/y2network/dns_config.rb
@@ -1,0 +1,59 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Network
+  # DNS configuration (hostname, name servers, etc.).
+  class DNSConfig
+    # @return [String] Hostname (local part)
+    attr_reader :hostname
+
+    # @return [Array<IPAddr>] List of name servers
+    attr_reader :name_servers
+
+    # @return [Array<String>] List of search domains
+    attr_reader :search_domains
+
+    # @return [String] resolv.conf update policy
+    attr_reader :resolv_conf_policy
+
+    # @return [Boolean] Whether to write the hostname to /etc/hosts
+    attr_reader :hostname_to_hosts
+
+    # @return [Boolean] Whether to take the hostname from DHCP
+    attr_reader :dhcp_hostname
+
+    # @todo receive an array instead all these arguments
+    #
+    # @param opts [Hash] DNS configuration options
+    # @option opts [String] :hostname
+    # @option opts [Array<String>] :name_servers
+    # @option opts [Array<String>] :search_domains
+    # @option opts [ResolvConfPolicy] :resolv_conf_policy
+    # @option opts [Boolean] :hostname_to_hosts
+    # @option opts [Boolean] :dhcp_hostname
+    def initialize(opts = {})
+      @hostname = opts[:hostname]
+      @name_servers = opts[:name_servers] || []
+      @search_domains = opts[:search_domains] || []
+      @resolv_conf_policy = opts[:resolv_conf_policy]
+      @hostname_to_hosts = opts[:hostname_to_hosts]
+      @dhcp_hostname = opts[:dhcp_hostname]
+    end
+  end
+end

--- a/src/lib/y2network/presenters/dns_summary.rb
+++ b/src/lib/y2network/presenters/dns_summary.rb
@@ -1,0 +1,83 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2network/dns"
+Yast.import "Summary"
+Yast.import "NetworkInterfaces"
+
+module Y2Network
+  module Presenters
+    # This class converts a DNS configuration object into a string to be used
+    # in an AutoYaST summary.
+    class DNSSummary
+      include Yast::I18n
+
+      # @return [Y2Network::DNS]
+      attr_reader :dns
+
+      # Constructor
+      #
+      # @param dns [Y2Network::DNS]
+      def initialize(dns)
+        textdomain "network"
+        @dns = dns
+      end
+
+      def text
+        summary = add_hostname("")
+        summary = add_name_servers(summary)
+        summary = add_search_domains(summary)
+        "<ul>#{summary}\n</ul>"
+      end
+
+    private
+
+      def add_hostname(summary)
+        hostname_str = hostname
+        return summary unless hostname_str
+        Yast::Summary.AddListItem(summary, hostname_str)
+      end
+
+      def hostname
+        if dhcp? && dns.dhcp_hostname
+          _("Hostname: Set by DHCP")
+        elsif dns.hostname && !dns.hostname.empty?
+          format(_("Hostname: %s"), dns.hostname)
+        end
+      end
+
+      def add_name_servers(summary)
+        return summary if dns.name_servers.empty?
+        item = format(_("Name Servers: %s"), dns.name_servers.map(&:to_s).join(", "))
+        Yast::Summary.AddListItem(summary, item)
+      end
+
+      def add_search_domains(summary)
+        return summary if dns.search_domains.empty?
+        item = format(_("Search List: %s"), dns.search_domains.join(", "))
+        Yast::Summary.AddListItem(summary, item)
+      end
+
+      def dhcp?
+        Yast::NetworkInterfaces.Locate("BOOTPROTO", "dhcp").empty?
+      end
+    end
+  end
+end

--- a/src/lib/y2network/presenters/routing_summary.rb
+++ b/src/lib/y2network/presenters/routing_summary.rb
@@ -23,7 +23,7 @@ Yast.import "NetHwDetection"
 
 module Y2Network
   module Presenters
-    # This class converts a routing configuration object into a hash to be used
+    # This class converts a routing configuration object into a string to be used
     # in an AutoYaST summary
     class RoutingSummary
       include Yast::I18n

--- a/test/lan_test.rb
+++ b/test/lan_test.rb
@@ -172,10 +172,6 @@ describe "LanClass" do
       expect_modification_succeedes(Yast::LanItems, :GetModified)
     end
 
-    it "returns true when DNS module was modified" do
-      expect_modification_succeedes(Yast::DNS, :modified)
-    end
-
     let(:config) do
       Y2Network::Config.new(interfaces: [], routing: routing, source: :sysconfig)
     end

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -12,9 +12,9 @@ describe "NetworkAutoYast" do
   let(:config) do
     Y2Network::Config.new(
       interfaces: [],
-      routing: Y2Network::Routing.new(tables: []),
-      dns: Y2Network::DNS.new,
-      source: :sysconfig
+      routing:    Y2Network::Routing.new(tables: []),
+      dns:        Y2Network::DNS.new,
+      source:     :sysconfig
     )
   end
 

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -3,13 +3,26 @@
 require_relative "test_helper"
 
 require "network/network_autoyast"
+require "y2network/config_reader/sysconfig"
 Yast.import "Profile"
 Yast.import "Lan"
 
 describe "NetworkAutoYast" do
   subject(:network_autoyast) { Yast::NetworkAutoYast.instance }
+  let(:config) do
+    Y2Network::Config.new(
+      interfaces: [],
+      routing: Y2Network::Routing.new(tables: []),
+      dns: Y2Network::DNS.new,
+      source: :sysconfig
+    )
+  end
+
   before do
     allow(Yast::NetworkInterfaces).to receive(:adapt_old_config!)
+    allow(Y2Network::Config).to receive(:from).and_return(double("config").as_null_object)
+    allow(Yast::Lan).to receive(:Read)
+    Yast::Lan.add_config(:yast, config)
   end
 
   describe "#merge_devices" do

--- a/test/y2network/autoinst_profile/dns_section_test.rb
+++ b/test/y2network/autoinst_profile/dns_section_test.rb
@@ -1,0 +1,68 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/autoinst_profile/dns_section"
+require "y2network/dns"
+
+describe Y2Network::AutoinstProfile::DNSSection do
+  subject(:section) { described_class.new }
+
+  describe ".new_from_network" do
+    let(:dns) do
+      instance_double(
+        Y2Network::DNS, hostname: "linux", dhcp_hostname: true, resolv_conf_policy: "auto",
+        hostname_to_hosts: true, name_servers: name_servers, search_domains: search_domains
+      )
+    end
+
+    let(:name_servers) { [IPAddr.new("1.1.1.1")] }
+    let(:search_domains) { ["example.net"] }
+
+    it "sets the hostname attribute" do
+      section = described_class.new_from_network(dns)
+      expect(section.hostname).to eq("linux")
+    end
+
+    it "sets the dhcp_hostname attribute" do
+      section = described_class.new_from_network(dns)
+      expect(section.dhcp_hostname).to eq(true)
+    end
+
+    it "sets the resolv_conf_policy attribute" do
+      section = described_class.new_from_network(dns)
+      expect(section.resolv_conf_policy).to eq("auto")
+    end
+
+    it "sets the write_hostname attribute" do
+      section = described_class.new_from_network(dns)
+      expect(section.write_hostname).to eq(true)
+    end
+
+    it "sets the nameservers attribute" do
+      section = described_class.new_from_network(dns)
+      expect(section.nameservers).to eq(["1.1.1.1"])
+    end
+
+    it "sets the searchlist attribute" do
+      section = described_class.new_from_network(dns)
+      expect(section.searchlist).to eq(["example.net"])
+    end
+  end
+end

--- a/test/y2network/autoinst_profile/dns_section_test.rb
+++ b/test/y2network/autoinst_profile/dns_section_test.rb
@@ -28,7 +28,7 @@ describe Y2Network::AutoinstProfile::DNSSection do
     let(:dns) do
       instance_double(
         Y2Network::DNS, hostname: "linux", dhcp_hostname: true, resolv_conf_policy: "auto",
-        hostname_to_hosts: true, name_servers: name_servers, search_domains: search_domains
+        name_servers: name_servers, search_domains: search_domains
       )
     end
 
@@ -48,11 +48,6 @@ describe Y2Network::AutoinstProfile::DNSSection do
     it "sets the resolv_conf_policy attribute" do
       section = described_class.new_from_network(dns)
       expect(section.resolv_conf_policy).to eq("auto")
-    end
-
-    it "sets the write_hostname attribute" do
-      section = described_class.new_from_network(dns)
-      expect(section.write_hostname).to eq(true)
     end
 
     it "sets the nameservers attribute" do

--- a/test/y2network/autoinst_profile/networking_section_test.rb
+++ b/test/y2network/autoinst_profile/networking_section_test.rb
@@ -24,14 +24,18 @@ require "y2network/config"
 describe Y2Network::AutoinstProfile::NetworkingSection do
   describe ".new_from_network" do
     let(:config) do
-      Y2Network::Config.new(interfaces: [], routing: routing, source: :sysconfig)
+      Y2Network::Config.new(interfaces: [], routing: routing, dns: dns, source: :sysconfig)
     end
     let(:routing) { double("Y2Network::Routing") }
     let(:routing_section) { double("RoutingSection") }
+    let(:dns) { double("Y2Network::DNS") }
+    let(:dns_section) { double("DNSSection") }
 
     before do
       allow(Y2Network::AutoinstProfile::RoutingSection).to receive(:new_from_network)
         .with(routing).and_return(routing_section)
+      allow(Y2Network::AutoinstProfile::DNSSection).to receive(:new_from_network)
+        .with(dns).and_return(dns_section)
     end
 
     it "initializes the routing section" do
@@ -43,15 +47,20 @@ describe Y2Network::AutoinstProfile::NetworkingSection do
   describe ".new_from_hashes" do
     let(:hash) do
       {
-        "routing" => routing
+        "routing" => routing,
+        "dns"     => dns
       }
     end
     let(:routing) { {} }
     let(:routing_section) { double("RoutingSection") }
+    let(:dns) { {} }
+    let(:dns_section) { double("DNSSection") }
 
     before do
       allow(Y2Network::AutoinstProfile::RoutingSection).to receive(:new_from_hashes)
         .with(routing).and_return(routing_section)
+      allow(Y2Network::AutoinstProfile::DNSSection).to receive(:new_from_hashes)
+        .with(dns).and_return(dns_section)
     end
 
     it "initializes the routing section" do
@@ -67,5 +76,20 @@ describe Y2Network::AutoinstProfile::NetworkingSection do
         expect(section.routing).to eq(nil)
       end
     end
+
+    it "initializes the dns section" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.dns).to eq(dns_section)
+    end
+
+    context "when no dns section is present" do
+      let(:dns) { nil }
+
+      it "does not initialize the dns section" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.dns).to eq(nil)
+      end
+    end
+
   end
 end

--- a/test/y2network/config_reader/sysconfig_dns_test.rb
+++ b/test/y2network/config_reader/sysconfig_dns_test.rb
@@ -56,7 +56,7 @@ describe Y2Network::ConfigReader::SysconfigDNS do
 
     it "returns the DNS configuration" do
       config = reader.config
-      expect(config).to be_a(Y2Network::DNSConfig)
+      expect(config).to be_a(Y2Network::DNS)
     end
 
     it "includes the hostname" do

--- a/test/y2network/config_reader/sysconfig_dns_test.rb
+++ b/test/y2network/config_reader/sysconfig_dns_test.rb
@@ -1,0 +1,148 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+require_relative "../../test_helper"
+require "y2network/config_reader/sysconfig_dns"
+
+describe Y2Network::ConfigReader::SysconfigDNS do
+  subject(:reader) { described_class.new }
+
+  describe "#config" do
+    let(:netconfig_dns) do
+      {
+        "NETCONFIG_DNS_POLICY"            => "auto",
+        "NETCONFIG_DNS_STATIC_SERVERS"    => "1.1.1.1 2.2.2.2",
+        "NETCONFIG_DNS_STATIC_SEARCHLIST" => "example.net mydomain"
+      }
+    end
+
+    let(:netconfig_dhcp) do
+      {
+        "DHCLIENT_SET_HOSTNAME"   => "yes",
+        "WRITE_HOSTNAME_TO_HOSTS" => "yes"
+      }
+    end
+
+    let(:netconfig) do
+      { "config" => netconfig_dns, "dhcp" => netconfig_dhcp }
+    end
+
+    let(:executor) do
+      double("Yast::Execute", on_target!: "")
+    end
+
+    before do
+      allow(Yast::SCR).to receive(:Read) do |arg|
+        key_parts = arg.to_s.split(".")
+        netconfig.dig(*key_parts[3..-1])
+      end
+      allow(Yast::Execute).to receive(:stdout).and_return(executor)
+    end
+
+    it "returns the DNS configuration" do
+      config = reader.config
+      expect(config).to be_a(Y2Network::DNSConfig)
+    end
+
+    it "includes the hostname" do
+      expect(executor).to receive(:on_target!).with(/hostname/).and_return("foo")
+      config = reader.config
+      expect(config.hostname).to eq("foo")
+    end
+
+    it "includes the list of name servers" do
+      config = reader.config
+      expect(config.name_servers).to eq([IPAddr.new("1.1.1.1"), IPAddr.new("2.2.2.2")])
+    end
+
+    context "when no name servers are defined" do
+      let(:netconfig_dns) do
+        { "NETCONFIG_DNS_STATIC_SERVERS" => "" }
+      end
+
+      it "includes an empty list of name servers" do
+        config = reader.config
+        expect(config.name_servers).to eq([])
+      end
+    end
+
+    it "includes a list of domains to search" do
+      config = reader.config
+      expect(config.search_domains).to eq(["example.net", "mydomain"])
+    end
+
+    context "when no list of domains to search is defined" do
+      let(:netconfig_dns) do
+        { "NETCONFIG_DNS_STATIC_SEARCHLIST" => "" }
+      end
+
+      it "includes an empty list of domains to search" do
+        config = reader.config
+        expect(config.search_domains).to eq([])
+      end
+    end
+
+    it "sets the DNS policy" do
+      config = reader.config
+      expect(config.resolv_conf_policy).to eq("auto")
+    end
+
+    context "when no DNS policy is specified" do
+      let(:netconfig_dns) do
+        { "NETCONFIG_DNS_POLICY" => "" }
+      end
+
+      it "sets the policy to the 'default' value" do
+        config = reader.config
+        expect(config.resolv_conf_policy).to eq("default")
+      end
+    end
+
+    it "sets the hostname_to_hosts parameter" do
+      config = reader.config
+      expect(config.hostname_to_hosts).to eq(true)
+    end
+
+    context "when WRITE_HOSTNAME_TO_HOSTS is not set to 'yes'" do
+      let(:netconfig_dhcp) do
+        { "WRITE_HOSTNAME_TO_HOSTS" => "no" }
+      end
+
+      it "sets hostname_to_hosts to false" do
+        config = reader.config
+        expect(config.hostname_to_hosts).to eq(false)
+      end
+    end
+
+    it "sets the dhcp_hostname parameter" do
+      config = reader.config
+      expect(config.hostname_to_hosts).to eq(true)
+    end
+
+    context "when DHCLIENT_SET_HOSTNAME is not set to 'yes'" do
+      let(:netconfig_dhcp) do
+        { "DHCLIENT_SET_HOSTNAME" => "no" }
+      end
+
+      it "sets dhcp_hostname to false" do
+        config = reader.config
+        expect(config.hostname_to_hosts).to eq(false)
+      end
+    end
+  end
+end

--- a/test/y2network/config_reader/sysconfig_dns_test.rb
+++ b/test/y2network/config_reader/sysconfig_dns_test.rb
@@ -32,10 +32,7 @@ describe Y2Network::ConfigReader::SysconfigDNS do
     end
 
     let(:netconfig_dhcp) do
-      {
-        "DHCLIENT_SET_HOSTNAME"   => "yes",
-        "WRITE_HOSTNAME_TO_HOSTS" => "yes"
-      }
+      { "DHCLIENT_SET_HOSTNAME"   => "yes" }
     end
 
     let(:netconfig) do
@@ -163,25 +160,9 @@ describe Y2Network::ConfigReader::SysconfigDNS do
       end
     end
 
-    it "sets the hostname_to_hosts parameter" do
-      config = reader.config
-      expect(config.hostname_to_hosts).to eq(true)
-    end
-
-    context "when WRITE_HOSTNAME_TO_HOSTS is not set to 'yes'" do
-      let(:netconfig_dhcp) do
-        { "WRITE_HOSTNAME_TO_HOSTS" => "no" }
-      end
-
-      it "sets hostname_to_hosts to false" do
-        config = reader.config
-        expect(config.hostname_to_hosts).to eq(false)
-      end
-    end
-
     it "sets the dhcp_hostname parameter" do
       config = reader.config
-      expect(config.hostname_to_hosts).to eq(true)
+      expect(config.dhcp_hostname).to eq(true)
     end
 
     context "when DHCLIENT_SET_HOSTNAME is not set to 'yes'" do
@@ -191,7 +172,7 @@ describe Y2Network::ConfigReader::SysconfigDNS do
 
       it "sets dhcp_hostname to false" do
         config = reader.config
-        expect(config.hostname_to_hosts).to eq(false)
+        expect(config.dhcp_hostname).to eq(false)
       end
     end
   end

--- a/test/y2network/config_reader/sysconfig_dns_test.rb
+++ b/test/y2network/config_reader/sysconfig_dns_test.rb
@@ -65,6 +65,56 @@ describe Y2Network::ConfigReader::SysconfigDNS do
       expect(config.hostname).to eq("foo")
     end
 
+    context "during installation" do
+      before do
+        allow(Yast::Mode).to receive(:installation).and_return(true)
+        allow(Yast::FileUtils).to receive(:Exists).with("/etc/install.inf")
+          .and_return(install_inf_exists)
+        allow(Yast::SCR).to receive(:Read).and_return(hostname)
+        allow(executor).to receive(:on_target!).with(/hostname/).and_return("foo")
+      end
+
+      let(:hostname) { "linuxrc.example.net" }
+      let(:install_inf_exists) { true }
+
+      it "reads the hostname from /etc/install.conf" do
+        config = reader.config
+        expect(config.hostname).to eq("linuxrc")
+      end
+
+      context "and the hostname from /etc/install.conf is an IP address" do
+        let(:hostname) { "192.168.122.1" }
+
+        before do
+          allow(Yast::NetHwDetection).to receive(:ResolveIP).with(hostname)
+            .and_return("router")
+        end
+
+        it "returns the name for the address" do
+          config = reader.config
+          expect(config.hostname).to eq("router")
+        end
+      end
+
+      context "and the hostname is not defined in /etc/install.conf" do
+        let(:hostname) { nil }
+
+        it "reads the hostname from the system" do
+          config = reader.config
+          expect(config.hostname).to eq("foo")
+        end
+      end
+
+      context "and the /etc/install.inf file does not exists" do
+        let(:install_inf_exists) { false }
+
+        it "reads the hostname from the system" do
+          config = reader.config
+          expect(config.hostname).to eq("foo")
+        end
+      end
+    end
+
     it "includes the list of name servers" do
       config = reader.config
       expect(config.name_servers).to eq([IPAddr.new("1.1.1.1"), IPAddr.new("2.2.2.2")])

--- a/test/y2network/config_reader/sysconfig_test.rb
+++ b/test/y2network/config_reader/sysconfig_test.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 require_relative "../../test_helper"
 require "y2network/config_reader/sysconfig"
+require "y2network/config_reader/sysconfig_dns"
 
 describe Y2Network::ConfigReader::Sysconfig do
   subject(:reader) { described_class.new }
@@ -31,6 +32,12 @@ describe Y2Network::ConfigReader::Sysconfig do
   end
 
   let(:routes_file) { instance_double(Y2Network::SysconfigRoutesFile, load: nil, routes: []) }
+  let(:dns_reader) { instance_double(Y2Network::ConfigReader::SysconfigDNS, config: dns) }
+  let(:dns) { double("Y2Network::ConfigReader::DNS") }
+
+  before do
+    allow(Y2Network::ConfigReader::SysconfigDNS).to receive(:new).and_return(dns_reader)
+  end
 
   around { |e| change_scr_root(File.join(DATA_PATH, "scr_read"), &e) }
 
@@ -52,9 +59,14 @@ describe Y2Network::ConfigReader::Sysconfig do
       expect(route.interface).to be(iface)
     end
 
-    it "returns a configuration including routes" do
+    it "returns a configuration which includes routes" do
       config = reader.config
       expect(config.routing.routes.size).to eq(4)
+    end
+
+    it "returns a configuration which includes DNS settings" do
+      config = reader.config
+      expect(config.dns).to eq(dns)
     end
 
     it "sets the config source to :sysconfig" do

--- a/test/y2network/dns_test.rb
+++ b/test/y2network/dns_test.rb
@@ -1,0 +1,81 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2network/dns"
+
+describe Y2Network::DNS do
+  subject(:dns) do
+    described_class.new(attrs)
+  end
+
+  let(:attrs) do
+    { hostname: "linux", resolv_conf_policy: "auto", dhcp_hostname: true }
+  end
+
+  describe "#==" do
+    let(:other) { described_class.new(attrs) }
+
+    context "given to DNS settings with the same values" do
+      it "returns true" do
+        expect(dns).to eq(other)
+      end
+    end
+
+    context "when the hostnames are different" do
+      let(:other) { described_class.new(attrs.merge(hostname: "another")) }
+
+      it "returns false" do
+        expect(dns).to_not eq(other)
+      end
+    end
+
+    context "when the resolv.conf policies are different" do
+      let(:other) { described_class.new(attrs.merge(resolv_conf_policy: "another")) }
+
+      it "returns false" do
+        expect(dns).to_not eq(other)
+      end
+    end
+
+    context "when the dhcp_hostname settings are different" do
+      let(:other) { described_class.new(attrs.merge(dhcp_hostname: !attrs[:dhcp_hostname])) }
+
+      it "returns false" do
+        expect(dns).to_not eq(other)
+      end
+    end
+
+    context "when the list of name servers are different" do
+      let(:other) { described_class.new(attrs.merge(name_servers: ["1.1.1.1"])) }
+
+      it "returns false" do
+        expect(dns).to_not eq(other)
+      end
+    end
+
+    context "when the list of domains to search are different" do
+      let(:other) { described_class.new(attrs.merge(search_domains: ["example.net"])) }
+
+      it "returns false" do
+        expect(dns).to_not eq(other)
+      end
+    end
+  end
+end

--- a/test/y2network/dns_test.rb
+++ b/test/y2network/dns_test.rb
@@ -78,4 +78,33 @@ describe Y2Network::DNS do
       end
     end
   end
+
+  describe "#ensure_hostname!" do
+    context "when no hostname was given" do
+      subject(:dns) { described_class.new }
+
+      it "returns a random name" do
+        dns.ensure_hostname!
+        expect(dns.hostname).to match(/linux-\w{4}/)
+      end
+    end
+
+    context "when an empty hostname was given" do
+      subject(:dns) { described_class.new(hostname: "") }
+
+      it "returns a random name" do
+        dns.ensure_hostname!
+        expect(dns.hostname).to match(/linux-\w{4}/)
+      end
+    end
+
+    context "when a hostname was given" do
+      subject(:dns) { described_class.new(hostname: "foo") }
+
+      it "returns the given name" do
+        dns.ensure_hostname!
+        expect(dns.hostname).to eq("foo")
+      end
+    end
+  end
 end

--- a/test/y2network/presenters/dns_summary_test.rb
+++ b/test/y2network/presenters/dns_summary_test.rb
@@ -1,0 +1,71 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/presenters/dns_summary"
+require "y2network/dns"
+
+describe Y2Network::Presenters::DNSSummary do
+  subject(:presenter) { described_class.new(dns) }
+
+  let(:dns) do
+    Y2Network::DNS.new(
+      hostname: hostname, name_servers: name_servers, search_domains: search_domains
+    )
+  end
+  let(:hostname) { "test" }
+  let(:name_servers) { [IPAddr.new("1.1.1.1"), IPAddr.new("8.8.8.8")] }
+  let(:search_domains) { ["example.net", "example.org"] }
+
+  describe "#text" do
+    it "returns a summary in text form" do
+      text = presenter.text
+      expect(text).to include("Hostname: test")
+      expect(text).to include("Name Servers: 1.1.1.1, 8.8.8.8")
+      expect(text).to include("Search List: example.net, example.org")
+    end
+
+    context "when no hostname is given" do
+      let(:hostname) { "" }
+
+      it "does not show the hostname" do
+        text = presenter.text
+        expect(text).to_not include("Hostname")
+      end
+    end
+
+    context "when name servers are given" do
+      let(:name_servers) { [] }
+
+      it "does not show the name servers" do
+        text = presenter.text
+        expect(text).to_not include("Name Servers")
+      end
+    end
+
+    context "when search domains are given" do
+      let(:search_domains) { [] }
+
+      it "does not show the search domains" do
+        text = presenter.text
+        expect(text).to_not include("Search List")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds:

* a Y2Network::DNS class
* a reader for DNS configuration
* a presenter for the DNS summary
