### PR TITLE
through instead of throught

### DIFF
--- a/src/lib/y2network/widgets/devices.rb
+++ b/src/lib/y2network/widgets/devices.rb
@@ -18,7 +18,7 @@ module Y2Network
 
       def help
         _(
-          "<p><b>Device</b> specifies the device throught which the traffic" \
+          "<p><b>Device</b> specifies the device through which the traffic" \
             " to the defined network will be routed.</p>"
         )
       end


### PR DESCRIPTION
There is a spelling error in yast-network.
It should be "through" instead of "throught".