### PR TITLE
Routing default zero

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue May 14 09:47:43 UTC 2019 - monstruitojose89@gmail.com
+
+- bsc#1100432
+  - Permit to define a default route with destination 0.0.0.0 and
+    netmask 0.0.0.0 when adding a new route with the table routing
+    popup dialog.
+- 3.2.58
+
+-------------------------------------------------------------------
 Fri Apr 12 10:00:58 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1131588

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.2.57
+Version:        3.2.58
 Release:        0
 BuildArch:      noarch
 

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -472,7 +472,7 @@ module Yast
       end
 
       route_dest = "#{dest}/#{cidr}"
-      route["destination"] = route_dest.start_with?("0.0.0.0" ) ? "default" : route_dest
+      route["destination"] = route_dest.start_with?("0.0.0.0") ? "default" : route_dest
       route["netmask"] = "-"
 
       route

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -152,7 +152,7 @@ module Yast
       return true if Netmask.Check4(netmask)
 
       if netmask.start_with?("/")
-        return true if netmask[1..-1].to_i.between?(1, 128)
+        return true if netmask[1..-1].to_i.between?(0, 128)
       end
 
       false
@@ -471,7 +471,8 @@ module Yast
         raise ArgumentError, "Invalid netmask or prefix length: #{netmask}"
       end
 
-      route["destination"] = "#{dest}/#{cidr}"
+      route_dest = "#{dest}/#{cidr}"
+      route["destination"] = route_dest.start_with?("0.0.0.0" ) ? "default" : route_dest
       route["netmask"] = "-"
 
       route

--- a/test/routing_helpers_test.rb
+++ b/test/routing_helpers_test.rb
@@ -69,13 +69,11 @@ describe "RoutingHelpers" do
       expect(routing.valid_netmask?("/255/")).to be false
       expect(routing.valid_netmask?("/255")).to be false
       expect(routing.valid_netmask?("/-255")).to be false
-      expect(routing.valid_netmask?("/0")).to be false
     end
 
     it "declines malformed IPv4 netmask" do
       expect(routing.valid_netmask?("/255.0.0.0")).to be false
       expect(routing.valid_netmask?("255.0.255.0")).to be false
-      expect(routing.valid_netmask?("0.0.0.0")).to be false
     end
   end
 end


### PR DESCRIPTION
This PR fix the issue reported in this [bug](https://bugzilla.opensuse.org/show_bug.cgi?id=1100432) and replaces #809 where I did some mistakes merging master into SLE-15-SP1 and other issues so preferred to close it opening a new one.

It just permits to use a 0.0.0.0 ip address with a /0 netmask to defined a default route from the table route addition dialog as reported / requested in the bug.

![bug img](https://bugzilla.opensuse.org/attachment.cgi?id=776612)
[fix img]()