### PR TITLE
network-ng: remove DNS.modified= calls

### DIFF
--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -425,19 +425,16 @@ module Yast
       when NONE_LABEL
         LanItems.clear_set_hostname
 
-        DNS.modified = true if DNS.dhcp_hostname
         DNS.dhcp_hostname = false
       when ANY_LABEL
         LanItems.clear_set_hostname
 
-        DNS.modified = true if !DNS.dhcp_hostname
         DNS.dhcp_hostname = true
       when NO_CHANGE_LABEL
         nil
       else
         LanItems.conf_set_hostname(device)
 
-        DNS.modified = true if DNS.dhcp_hostname
         DNS.dhcp_hostname = false
       end
 


### PR DESCRIPTION
`DNS.modified=` was removed as the new code should be able to detect whether the configuration changed without the need to set a flag.