### PR TITLE
Add an InterfacesCollection class

### DIFF
--- a/examples/connection.rb
+++ b/examples/connection.rb
@@ -9,19 +9,19 @@ require "y2network/connection_config/wireless"
 
 config = Y2Network::Config.from(:sysconfig)
 
-eth0 = config.interfaces.find { |i| i.name == "eth0" }
+eth0 = config.interfaces.by_name("eth0")
 eth_conn = Y2Network::ConnectionConfig::Ethernet.new
 eth_conn.interface = eth0
 
-eth1 = config.interfaces.find { |i| i.name == "eth1" }
-eth2 = config.interfaces.find { |i| i.name == "eth2" }
+eth1 = config.interfaces.by_name("eth1")
+eth2 = config.interfaces.by_name("eth2")
 bond = Y2Network::ConnectionConfig::Bond.new
 bond.slaves = [eth1, eth2]
 bond.options = "mode=active-backup miimon=100"
 bond.interface = Y2Network::VirtualInterface.new("bond0")
 config.interfaces << bond
 
-wlan0 = config.interfaces.find { |i| i.name == "wlan0" }
+wlan0 = config.interfaces.by_name("wlan0")
 wlan_conn = Y2Network::ConnectionConfig::Wireless.new
 wlan_conn.essid = "TEST_WIFI"
 wlan_conn.interface = wlan0

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -16,11 +16,11 @@
 #
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
-require "y2network/interface"
 require "y2network/config_writer"
 require "y2network/config_reader"
 require "y2network/routing"
 require "y2network/dns"
+require "y2network/interfaces_collection"
 
 module Y2Network
   # This class represents the current network configuration including interfaces,
@@ -36,7 +36,7 @@ module Y2Network
   #   config.routing.tables.first << route
   #   config.write
   class Config
-    # @return [Array<Interface>]
+    # @return [InterfacesCollection]
     attr_accessor :interfaces
     # @return [Routing] Routing configuration
     attr_accessor :routing
@@ -85,11 +85,11 @@ module Y2Network
 
     # Constructor
     #
-    # @param interfaces [Array<Interface>] List of interfaces
+    # @param interfaces [InterfacesCollection] List of interfaces
     # @param routing    [Routing] Object with routing configuration
     # @param dns        [DNS] Object with DNS configuration
     # @param source     [Symbol] Configuration source
-    def initialize(interfaces: [], routing: Y2Network::Routing.new, dns: Y2Network::DNS.new, source:)
+    def initialize(interfaces: InterfacesCollection.new, routing: Routing.new, dns: DNS.new, source:)
       @interfaces = interfaces
       @routing = routing
       @dns = dns
@@ -114,8 +114,7 @@ module Y2Network
     #
     # @return [Boolean] true if both configurations are equal; false otherwise
     def ==(other)
-      source == other.source &&
-        ((interfaces - other.interfaces) | (other.interfaces - interfaces)).empty? &&
+      source == other.source && interfaces == other.interfaces &&
         routing == other.routing && dns == other.dns
     end
 

--- a/src/lib/y2network/config_reader/sysconfig.rb
+++ b/src/lib/y2network/config_reader/sysconfig.rb
@@ -112,7 +112,7 @@ module Y2Network
       def link_routes_to_interfaces(routes, interfaces)
         routes.each do |route|
           next unless route.interface
-          interface = interfaces.find { |i| route.interface.name == i.name }
+          interface = interfaces.find(route.interface.name)
           route.interface = interface if interface
         end
       end

--- a/src/lib/y2network/config_reader/sysconfig.rb
+++ b/src/lib/y2network/config_reader/sysconfig.rb
@@ -24,6 +24,7 @@ require "y2network/sysconfig_paths"
 require "y2network/routing_table"
 require "y2network/sysconfig_routes_file"
 require "y2network/config_reader/sysconfig_dns"
+require "y2network/interfaces_collection"
 
 Yast.import "NetworkInterfaces"
 
@@ -58,9 +59,10 @@ module Y2Network
       def find_interfaces
         Yast::NetworkInterfaces.Read
         # TODO: for the time being, we are just relying in the underlying stuff.
-        Yast::NetworkInterfaces.List("").map do |name|
+        interfaces = Yast::NetworkInterfaces.List("").map do |name|
           Y2Network::Interface.new(name)
         end
+        Y2Network::InterfacesCollection.new(interfaces)
       end
 
       # Reads routes
@@ -112,7 +114,7 @@ module Y2Network
       def link_routes_to_interfaces(routes, interfaces)
         routes.each do |route|
           next unless route.interface
-          interface = interfaces.find(route.interface.name)
+          interface = interfaces.by_name(route.interface.name)
           route.interface = interface if interface
         end
       end

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -51,6 +51,8 @@ module Y2Network
 
     # Returns an interface with the given name if present
     #
+    # @todo It uses the hardware's name as a fallback if interface's name is not set
+    #
     # @param name [String] Returns the interface with the given name
     # @return [Interface,nil] Interface with the given name or nil if not found
     def by_name(name)

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -65,7 +65,7 @@ module Y2Network
     # @return [Boolean] true when both collections contain only equal interfaces,
     #                   false otherwise
     def ==(other)
-      @interfaces - other.interfaces && other.interfaces == @interfaces
+      ((interfaces - other.interfaces) | (other.interfaces - interfaces)).empty?
     end
 
     alias_method :eql?, :==

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -1,0 +1,73 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/interface"
+require "forwardable"
+
+module Y2Network
+  # A container for network devices. In the end should implement methods for mass operations over
+  # network interfaces like old LanItems::find_dhcp_ifaces.
+  #
+  # @example Create a new collection
+  #   eth0 = Y2Network::Interface.new("eth0")
+  #   collection = Y2Network::InterfacesCollection.new(eth0)
+  #
+  # @example Find an interface using its name
+  #   iface = collection.find("eth0") #=> #<Y2Network::Interface:0x...>
+  class InterfacesCollection
+    # FIXME: Direct access to be replaced to make possible
+    # Y2Network::Config.interfaces.eth0
+    # Y2Network::Config.interfaces.of_type(:eth)
+    # ...
+    attr_reader :interfaces
+
+    extend Forwardable
+
+    def_delegators :@interfaces, :each, :map, :select, :push
+
+    # Constructor
+    #
+    # @param interfaces [Array<Interface>] List of interfaces
+    def initialize(interfaces)
+      @interfaces = interfaces
+    end
+
+    # @param name [String] Returns the interface with the given name
+    def find(name)
+      interfaces.find { |i| !i.name.nil? ? i.name == name : i.hardware.name }
+    end
+
+    # Add an interface with the given name
+    #
+    # @param name [String] Interface's name
+    def add(name)
+      interfaces.push(Interface.new(name))
+    end
+
+    # Compares InterfacesCollections
+    #
+    # @return [Boolean] true when both collections contain only equal interfaces,
+    #                   false otherwise
+    def ==(other)
+      @interfaces - other.interfaces && other.interfaces == @interfaces
+    end
+
+    alias_method :eql?, :==
+  end
+end

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -64,7 +64,10 @@ module Y2Network
     # @param name [String] Returns the interface with the given name
     # @return [Interface,nil] Interface with the given name or nil if not found
     def by_name(name)
-      interfaces.find { |i| i.name ? i.name == name : i.hardware.name }
+      interfaces.find do |iface|
+        iface_name = iface.name ? iface.name : iface.hwinfo.name
+        iface_name == name
+      end
     end
 
     # Deletes elements which meet a given condition

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -29,14 +29,14 @@ module Y2Network
   #   collection = Y2Network::InterfacesCollection.new(eth0)
   #
   # @example Find an interface using its name
-  #   iface = collection.find("eth0") #=> #<Y2Network::Interface:0x...>
+  #   iface = collection.by_name("eth0") #=> #<Y2Network::Interface:0x...>
   class InterfacesCollection
     # Objects of this class are able to keep a list of interfaces and perform simple queries
     # on such a list.
     #
     # @example Finding an interface by its name
     #   interfaces = Y2Network::InterfacesCollection.new([eth0, wlan0])
-    #   interfaces.find("wlan0") # => wlan0
+    #   interfaces.by_name("wlan0") # => wlan0
     #
     # @example FIXME (not implemented yet). For the future, we are aiming at this kind of API.
     #   interfaces = Y2Network::InterfacesCollection.new([eth0, wlan0])

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -43,13 +43,12 @@ module Y2Network
     #   interfaces.of_type(:eth).to_a # => [eth0]
 
     extend Forwardable
-    include Enumerable
 
     # @return [Array<Interface>] List of interfaces
     attr_reader :interfaces
-    alias_method :interfaces, :to_a
+    alias_method :to_a, :interfaces
 
-    def_delegators :@interfaces, :each, :push, :<<, :reject!
+    def_delegators :@interfaces, :each, :push, :<<, :reject!, :map, :flat_map, :any?
 
     # Constructor
     #
@@ -65,7 +64,15 @@ module Y2Network
     # @param name [String] Returns the interface with the given name
     # @return [Interface,nil] Interface with the given name or nil if not found
     def by_name(name)
-      find { |i| i.name ? i.name == name : i.hardware.name }
+      interfaces.find { |i| i.name ? i.name == name : i.hardware.name }
+    end
+
+    # Deletes elements which meet a given condition
+    #
+    # @return [InterfacesCollection]
+    def delete_if(&block)
+      interfaces.delete_if(&block)
+      self
     end
 
     # Compares InterfacesCollections

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -38,8 +38,9 @@ module Y2Network
     attr_reader :interfaces
 
     extend Forwardable
+    include Enumerable
 
-    def_delegators :@interfaces, :each, :map, :select, :push
+    def_delegators :@interfaces, :each, :push, :<<, :reject!
 
     # Constructor
     #
@@ -48,9 +49,12 @@ module Y2Network
       @interfaces = interfaces
     end
 
+    # Returns a interface with the given name if present
+    #
     # @param name [String] Returns the interface with the given name
-    def find(name)
-      interfaces.find { |i| i.name ? i.name == name : i.hardware.name }
+    # @return [Interface,nil] Interface with the given name or nil if not found
+    def by_name(name)
+      find { |i| i.name ? i.name == name : i.hardware.name }
     end
 
     # Add an interface with the given name

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -31,14 +31,23 @@ module Y2Network
   # @example Find an interface using its name
   #   iface = collection.find("eth0") #=> #<Y2Network::Interface:0x...>
   class InterfacesCollection
-    # FIXME: Direct access to be replaced to make possible
-    # Y2Network::Config.interfaces.eth0
-    # Y2Network::Config.interfaces.of_type(:eth)
-    # ...
-    attr_reader :interfaces
+    # Objects of this class are able to keep a list of interfaces and perform simple queries
+    # on such a list.
+    #
+    # @example Finding an interface by its name
+    #   interfaces = Y2Network::InterfacesCollection.new([eth0, wlan0])
+    #   interfaces.find("wlan0") # => wlan0
+    #
+    # @example FIXME (not implemented yet). For the future, we are aiming at this kind of API.
+    #   interfaces = Y2Network::InterfacesCollection.new([eth0, wlan0])
+    #   interfaces.of_type(:eth).to_a # => [eth0]
 
     extend Forwardable
     include Enumerable
+
+    # @return [Array<Interface>] List of interfaces
+    attr_reader :interfaces
+    alias_method :interfaces, :to_a
 
     def_delegators :@interfaces, :each, :push, :<<, :reject!
 

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -69,7 +69,7 @@ module Y2Network
     # @return [Boolean] true when both collections contain only equal interfaces,
     #                   false otherwise
     def ==(other)
-      ((interfaces - other.interfaces) | (other.interfaces - interfaces)).empty?
+      ((interfaces - other.interfaces) + (other.interfaces - interfaces)).empty?
     end
 
     alias_method :eql?, :==

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -44,13 +44,13 @@ module Y2Network
     # Constructor
     #
     # @param interfaces [Array<Interface>] List of interfaces
-    def initialize(interfaces)
+    def initialize(interfaces = [])
       @interfaces = interfaces
     end
 
     # @param name [String] Returns the interface with the given name
     def find(name)
-      interfaces.find { |i| !i.name.nil? ? i.name == name : i.hardware.name }
+      interfaces.find { |i| i.name ? i.name == name : i.hardware.name }
     end
 
     # Add an interface with the given name

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -49,19 +49,12 @@ module Y2Network
       @interfaces = interfaces
     end
 
-    # Returns a interface with the given name if present
+    # Returns an interface with the given name if present
     #
     # @param name [String] Returns the interface with the given name
     # @return [Interface,nil] Interface with the given name or nil if not found
     def by_name(name)
       find { |i| i.name ? i.name == name : i.hardware.name }
-    end
-
-    # Add an interface with the given name
-    #
-    # @param name [String] Interface's name
-    def add(name)
-      interfaces.push(Interface.new(name))
     end
 
     # Compares InterfacesCollections

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -65,7 +65,7 @@ module Y2Network
     # @return [Interface,nil] Interface with the given name or nil if not found
     def by_name(name)
       interfaces.find do |iface|
-        iface_name = iface.name ? iface.name : iface.hwinfo.name
+        iface_name = iface.name || iface.hwinfo.name
         iface_name == name
       end
     end

--- a/src/lib/y2network/physical_interface.rb
+++ b/src/lib/y2network/physical_interface.rb
@@ -23,7 +23,11 @@ require "y2network/hwinfo"
 module Y2Network
   # Physical interface class (ethernet, wireless, infiniband...)
   class PhysicalInterface < Interface
+    attr_writer :hwinfo
+
     # @return [Hwinfo]
-    attr_accessor :hwinfo
+    def hwinfo
+      @hwinfo ||= Hwinfo.new({})
+    end
   end
 end

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2709,7 +2709,7 @@ module Yast
       return if config.nil?
       name = current_name
       return if name.empty?
-      config.interfaces.reject! { |i| i.name == name }
+      config.interfaces.delete_if { |i| i.name == name }
     end
 
   private

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2694,7 +2694,7 @@ module Yast
     def rename_current_device_in_routing(old_name)
       config = yast_config
       return if config.nil?
-      interface = config.interfaces.find { |i| i.name == old_name }
+      interface = config.interfaces.find(old_name)
       return unless interface
       interface.name = current_name
     end

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2694,7 +2694,7 @@ module Yast
     def rename_current_device_in_routing(old_name)
       config = yast_config
       return if config.nil?
-      interface = config.interfaces.find(old_name)
+      interface = config.interfaces.by_name(old_name)
       return unless interface
       interface.name = current_name
     end

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -619,8 +619,10 @@ describe "LanItems renaming methods" do
   describe "LanItems.add_current_device_to_routing" do
     let(:eth0) { Y2Network::Interface.new("eth0") }
     let(:wlan0) { Y2Network::Interface.new("wlan0") }
+    let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, wlan0]) }
+
     let(:yast_config) do
-      instance_double(Y2Network::Config, interfaces: [eth0, wlan0], routing: double("routing"))
+      instance_double(Y2Network::Config, interfaces: interfaces, routing: double("routing"))
     end
 
     before do
@@ -650,8 +652,9 @@ describe "LanItems renaming methods" do
   describe "LanItems.rename_current_device_in_routing" do
     let(:eth0) { Y2Network::Interface.new("eth0") }
     let(:wlan0) { Y2Network::Interface.new("wlan0") }
+    let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, wlan0]) }
     let(:yast_config) do
-      instance_double(Y2Network::Config, interfaces: [eth0, wlan0], routing: double("routing"))
+      instance_double(Y2Network::Config, interfaces: interfaces, routing: double("routing"))
     end
 
     before do
@@ -669,8 +672,10 @@ describe "LanItems renaming methods" do
   describe "LanItems.remove_current_device_from_routing" do
     let(:eth0) { Y2Network::Interface.new("eth0") }
     let(:wlan0) { Y2Network::Interface.new("wlan0") }
+    let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, wlan0]) }
+
     let(:yast_config) do
-      instance_double(Y2Network::Config, interfaces: [eth0, wlan0], routing: double("routing"))
+      instance_double(Y2Network::Config, interfaces: interfaces, routing: double("routing"))
     end
 
     before do
@@ -688,8 +693,10 @@ describe "LanItems renaming methods" do
   describe "LanItems.update_routing_devices?" do
     let(:eth0) { Y2Network::Interface.new("eth0") }
     let(:wlan0) { Y2Network::Interface.new("wlan0") }
+    let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, wlan0]) }
+
     let(:yast_config) do
-      instance_double(Y2Network::Config, interfaces: [eth0, wlan0], routing: double("routing"))
+      instance_double(Y2Network::Config, interfaces: interfaces, routing: double("routing"))
     end
 
     before do

--- a/test/network/edit_nic_name_test.rb
+++ b/test/network/edit_nic_name_test.rb
@@ -8,6 +8,7 @@ require "network/edit_nic_name"
 require "y2network/route"
 require "y2network/routing"
 require "y2network/routing_table"
+require "y2network/interfaces_collection"
 require "y2network/interface"
 require "y2network/config"
 
@@ -24,8 +25,9 @@ describe Yast::EditNicName do
   let(:table1) { Y2Network::RoutingTable.new(routes: [route1]) }
   let(:routing) { Y2Network::Routing.new(tables: table1) }
   let(:iface) { Y2Network::Interface.new(current_name) }
+  let(:ifaces) { Y2Network::InterfacesCollection.new([iface]) }
   let(:yast_config) do
-    Y2Network::Config.new(interfaces: [iface], routing: routing, source: :sysconfig)
+    Y2Network::Config.new(interfaces: ifaces, routing: routing, source: :sysconfig)
   end
 
   before do

--- a/test/y2network/config_reader/sysconfig_test.rb
+++ b/test/y2network/config_reader/sysconfig_test.rb
@@ -53,9 +53,8 @@ describe Y2Network::ConfigReader::Sysconfig do
 
     it "links routes with detected network devices" do
       config = reader.config
-      route = config.routing.routes.find { |r| !!r.interface }
-
-      iface = config.interfaces.find { |i| i.name == route.interface.name }
+      route = config.routing.routes.find(&:interface)
+      iface = config.interfaces.by_name(route.interface.name)
       expect(route.interface).to be(iface)
     end
 

--- a/test/y2network/interfaces_collection_test.rb
+++ b/test/y2network/interfaces_collection_test.rb
@@ -33,14 +33,6 @@ describe Y2Network::InterfacesCollection do
     end
   end
 
-  describe "#add" do
-    it "adds an interface with the given name" do
-      collection.add("eth1")
-      eth1 = collection.by_name("eth1")
-      expect(eth1.name).to eq("eth1")
-    end
-  end
-
   describe "#push" do
     let(:wlan1) { Y2Network::Interface.new("wlan1") }
 

--- a/test/y2network/interfaces_collection_test.rb
+++ b/test/y2network/interfaces_collection_test.rb
@@ -49,4 +49,22 @@ describe Y2Network::InterfacesCollection do
       expect(collection.find(wlan1.name)).to eq(wlan1)
     end
   end
+
+  describe "#==" do
+    context "when the given collection contains the same interfaces" do
+      let(:other) { described_class.new([wlan0, eth0]) }
+
+      it "returns true" do
+        expect(collection).to eq(other)
+      end
+    end
+
+    context "when the given collection does not contain the same interfaces" do
+      let(:other) { described_class.new([eth0]) }
+
+      it "returns false" do
+        expect(collection).to_not eq(other)
+      end
+    end
+  end
 end

--- a/test/y2network/interfaces_collection_test.rb
+++ b/test/y2network/interfaces_collection_test.rb
@@ -42,6 +42,19 @@ describe Y2Network::InterfacesCollection do
     end
   end
 
+  describe "#delete_if" do
+    it "deletes elements which meet a condition" do
+      expect(collection.by_name("eth0")).to eq(eth0)
+      collection.delete_if { |i| i.name == "eth0" }
+      expect(collection.by_name("eth0")).to be_nil
+    end
+
+    it "returns the collection" do
+      same_collection = collection.delete_if { |i| i.name == "eth0" }
+      expect(same_collection).to eq(collection)
+    end
+  end
+
   describe "#==" do
     context "when the given collection contains the same interfaces" do
       let(:other) { described_class.new([wlan0, eth0]) }

--- a/test/y2network/interfaces_collection_test.rb
+++ b/test/y2network/interfaces_collection_test.rb
@@ -1,0 +1,52 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2network/interfaces_collection"
+
+describe Y2Network::InterfacesCollection do
+  subject(:collection) { described_class.new(interfaces) }
+
+  let(:eth0) { Y2Network::Interface.new("eth0") }
+  let(:wlan0) { Y2Network::Interface.new("wlan0") }
+  let(:interfaces) { [eth0, wlan0] }
+
+  describe "#find" do
+    it "returns the interface with the given name" do
+      expect(collection.find("eth0")).to eq(eth0)
+    end
+  end
+
+  describe "#add" do
+    it "adds an interface with the given name" do
+      collection.add("eth1")
+      eth1 = collection.find("eth1")
+      expect(eth1.name).to eq("eth1")
+    end
+  end
+
+  describe "#push" do
+    let(:wlan1) { Y2Network::Interface.new("wlan1") }
+
+    it "adds an interface to the list" do
+      collection.push(wlan1)
+      expect(collection.find(wlan1.name)).to eq(wlan1)
+    end
+  end
+end

--- a/test/y2network/interfaces_collection_test.rb
+++ b/test/y2network/interfaces_collection_test.rb
@@ -27,16 +27,16 @@ describe Y2Network::InterfacesCollection do
   let(:wlan0) { Y2Network::Interface.new("wlan0") }
   let(:interfaces) { [eth0, wlan0] }
 
-  describe "#find" do
+  describe "#by_name" do
     it "returns the interface with the given name" do
-      expect(collection.find("eth0")).to eq(eth0)
+      expect(collection.by_name("eth0")).to eq(eth0)
     end
   end
 
   describe "#add" do
     it "adds an interface with the given name" do
       collection.add("eth1")
-      eth1 = collection.find("eth1")
+      eth1 = collection.by_name("eth1")
       expect(eth1.name).to eq("eth1")
     end
   end
@@ -46,7 +46,7 @@ describe Y2Network::InterfacesCollection do
 
     it "adds an interface to the list" do
       collection.push(wlan1)
-      expect(collection.find(wlan1.name)).to eq(wlan1)
+      expect(collection.by_name(wlan1.name)).to eq(wlan1)
     end
   end
 


### PR DESCRIPTION
* Taken from https://github.com/yast/yast-network/pull/796.
* Not intended to be merged until `Y2Network::Interface`provides a `#hardware` (or `#hwinfo`) method.