### PR TITLE
Do not create duplicate udev attributes

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Sun Jun  9 21:40:34 UTC 2019 - kanderssen@suse.com
+
+- bsc#1137324
+  - Do not create duplicate udev rule attributes when editing an
+    interface name.
+- 3.4.7
+
+-------------------------------------------------------------------
 Mon May 20 14:08:23 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1123102, bnc#1134784, bnc#1136103

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.4.6
+Version:        3.4.7
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/network/edit_nic_name.rb
+++ b/src/lib/network/edit_nic_name.rb
@@ -15,9 +15,9 @@ module Yast
     include I18n
 
     # @return [String] current udev name before modifying it
-    attr_accessor :old_name
+    attr_reader :old_name
     # @return [String] current udev match criteria
-    attr_accessor :old_key
+    attr_reader :old_key
 
     # udev rule attribute for MAC address
     MAC_UDEV_ATTR   = "ATTR{address}".freeze

--- a/src/lib/network/edit_nic_name.rb
+++ b/src/lib/network/edit_nic_name.rb
@@ -31,10 +31,13 @@ module Yast
       Yast.include self, "network/routines.rb"
 
       current_item = LanItems.getCurrentItem
+      current_rule = LanItems.current_udev_rule
 
       @old_name = LanItems.current_udev_name
-      @old_key = :mac unless LanItems.GetItemUdev(MAC_UDEV_ATTR).empty?
-      @old_key = :bus_id unless LanItems.GetItemUdev(BUSID_UDEV_ATTR).empty?
+      unless current_rule.empty?
+        @old_key = :mac unless LanItems.GetItemUdev(MAC_UDEV_ATTR).empty?
+        @old_key = :bus_id unless LanItems.GetItemUdev(BUSID_UDEV_ATTR).empty?
+      end
 
       if current_item["hwinfo"]
         @mac = current_item["hwinfo"]["mac"]

--- a/src/lib/network/edit_nic_name.rb
+++ b/src/lib/network/edit_nic_name.rb
@@ -14,6 +14,11 @@ module Yast
     include UIShortcuts
     include I18n
 
+    # @return [String] current udev name before modifying it
+    attr_accessor :old_name
+    # @return [String] current udev match criteria
+    attr_accessor :old_key
+
     # udev rule attribute for MAC address
     MAC_UDEV_ATTR   = "ATTR{address}".freeze
 
@@ -28,8 +33,8 @@ module Yast
       current_item = LanItems.getCurrentItem
 
       @old_name = LanItems.current_udev_name
-      @old_key = MAC_UDEV_ATTR unless LanItems.GetItemUdev(MAC_UDEV_ATTR).empty?
-      @old_key = BUSID_UDEV_ATTR unless LanItems.GetItemUdev(BUSID_UDEV_ATTR).empty?
+      @old_key = :mac unless LanItems.GetItemUdev(MAC_UDEV_ATTR).empty?
+      @old_key = :bus_id unless LanItems.GetItemUdev(BUSID_UDEV_ATTR).empty?
 
       if current_item["hwinfo"]
         @mac = current_item["hwinfo"]["mac"]
@@ -67,12 +72,12 @@ module Yast
 
         # FIXME: it changes udev key used for device identification
         #  and / or its value only, name is changed elsewhere
-        LanItems.update_item_udev_rule!(udev_type)
+        LanItems.update_item_udev_rule!(udev_type) if udev_type && (old_key != udev_type)
       end
 
       close
 
-      new_name || @old_name
+      new_name || old_name
     end
 
   private
@@ -118,11 +123,8 @@ module Yast
         )
       )
 
-      case @old_key
-      when MAC_UDEV_ATTR
-        UI.ChangeWidget(Id(:udev_type), :CurrentButton, :mac)
-      when BUSID_UDEV_ATTR
-        UI.ChangeWidget(Id(:udev_type), :CurrentButton, :bus_id)
+      if old_key
+        UI.ChangeWidget(Id(:udev_type), :CurrentButton, old_key)
       else
         Builtins.y2error("Unknown udev rule.")
       end

--- a/test/edit_nic_name_test.rb
+++ b/test/edit_nic_name_test.rb
@@ -58,6 +58,10 @@ module Yast
 
         expect(@edit_name_dlg.run).to be_equal CURRENT_NAME
       end
+
+      it "does not touch the current udev rule" do
+        expect(Yast::LanItems).to_not receive(:update_item_udev_rule!)
+      end
     end
 
     context "when closed after name change" do
@@ -104,6 +108,32 @@ module Yast
           .with(NEW_NAME)
 
         expect(@edit_name_dlg.run).to eql NEW_NAME
+      end
+
+      context "but used the same matching udev key" do
+        it "does not touch the current udev rule" do
+          expect(Yast::LanItems).to_not receive(:update_item_udev_rule!)
+        end
+      end
+    end
+
+    context "when closed without changing the match selection" do
+      before(:each) do
+        # emulate UI work
+        allow(UI).to receive(:QueryWidget).with(:dev_name, :Value) { CURRENT_NAME }
+        allow(UI).to receive(:QueryWidget).with(:udev_type, :CurrentButton) { :mac }
+      end
+    end
+
+    context "when modified the matching udev key" do
+      before(:each) do
+        # emulate UI work
+        allow(UI).to receive(:QueryWidget).with(:dev_name, :Value) { CURRENT_NAME }
+        allow(UI).to receive(:QueryWidget).with(:udev_type, :CurrentButton) { :bus_id }
+      end
+
+      it "updates the current udev rule with the key used" do
+        expect(Yast::LanItems).to_not receive(:update_item_udev_rule!).with(:bus_id)
       end
     end
   end

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -242,6 +242,22 @@ describe "LanItems#RemoveItemUdev" do
   end
 end
 
+describe "#current_udev_rule" do
+  let(:busid) { "0000:08:00.0" }
+  let(:hwinfo) { { "dev_name" => "test0", "busid" => busid, "mac" => "24:be:05:ce:1e:91" } }
+  let(:udev_net) { ["KERNELS==\"#{busid}\"", "NAME=\"test0\""] }
+  let(:rule) { { 0 => { "hwinfo" => hwinfo, "udev" => { "net" => udev_net } } } }
+
+  before do
+    Yast::LanItems.Items = rule
+    Yast::LanItems.current = 0
+  end
+
+  it "returns the current item udev rule" do
+    expect(Yast::LanItems.current_udev_rule).to contain_exactly("KERNELS==\"#{busid}\"", "NAME=\"test0\"")
+  end
+end
+
 describe "#update_item_udev_rule!" do
   let(:hwinfo) { { "dev_name" => "test0", "busid" => "0000:08:00.0", "mac" => "24:be:05:ce:1e:91" } }
   let(:udev_net) { ["ATTR{address}==\"24:be:05:ce:1e:91\"", "KERNEL==\"eth*\"", "NAME=\"test0\""] }


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1137324

When editing an interface name. 

If no previous udev rule exist and the udev rule to be written is based on the interface :mac, then it generates a duplicate attribute:

![edit_nic_name](https://user-images.githubusercontent.com/7056681/58941639-17fe2b00-8774-11e9-88ec-eab7fa007599.png)

Something like:

```ruby
SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="9c:eb:e8:1a:d2:2f", ATTR{dev_id}=="0x0", ATTR{type}=="1", ATTR{address}=="9c:eb:e8:1a:d2:2f", NAME="eth1"
```

That also happens with an existent rule and pressing 'OK' without modifying the key attribute.


In combination with this another [bug](https://bugzilla.suse.com/show_bug.cgi?id=1136929) the situation is even worworst because there could be two different mac addresses, the current and the permanent one.

## Solution

When editing an interface name:

1.- The rule only will be updated if the matching attribute or value from the original differs.
2.- The update_item_udev_rule! method will check if a rule already exist and if not will initialize it. As the default rule is based on :mac, we will return after initialization in case the update rule is based on :mac.

## Testing

- *Added a new unit test for the new current udev rule method*
- *Tested manually*



