### PR TITLE
Update current udev rule if not exist or the key in use is not the :bus_id

### DIFF
--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -309,8 +309,9 @@ module Yast
         case LanItems.GetDeviceType(current)
         when "bond"
           LanItems.startmode = "hotplug"
-
-          LanItems.update_item_udev_rule!(:bus_id)
+          if LanItems.current_udev_rule.empty? || LanItems.GetItemUdev("KERNELS").empty?
+            LanItems.update_item_udev_rule!(:bus_id)
+          end
         when "br"
           LanItems.ipaddr = ""
         end


### PR DESCRIPTION
When testing #829 I found an scenario not covered by #825. 

As the SR has not been created yet, would like to merge this PR as complement of #825 and before merging #829  