### PR TITLE
Move routes from slave to the new bridge

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jun 11 07:59:52 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- boo#903889
+  - When proposing a bridge configuration for virtualization, move
+    the routes from the enslaved interface to the new bridge.
+- 4.1.47
+
+-------------------------------------------------------------------
 Fri May  3 10:13:37 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1131588

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.46
+Version:        4.1.47
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -85,10 +85,9 @@ module Yast
       # Moreover virtual devices are not needed during first stage. So, it can
       # wait for rebooting into just installed target
       LanItems.write
-      if Routing.Modified
-        LanItems.update_routing_devices!
-        Routing.Write
-      end
+      return unless Routing.Modified
+      LanItems.update_routing_devices!
+      Routing.Write
     end
 
     # Propose DNS and Hostname setup

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -85,6 +85,10 @@ module Yast
       # Moreover virtual devices are not needed during first stage. So, it can
       # wait for rebooting into just installed target
       LanItems.write
+      if Routing.Modified
+        LanItems.update_routing_devices!
+        Routing.Write
+      end
     end
 
     # Propose DNS and Hostname setup

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -916,6 +916,7 @@ module Yast
         next unless configure_as_bridge!(ifcfg, bridge_name)
         # reconfigure existing device as newly created bridge's port
         configure_as_bridge_port(ifcfg)
+        Routing.move_routes(ifcfg, bridge_name)
         refresh_lan_items
       end
 

--- a/src/modules/Routing.rb
+++ b/src/modules/Routing.rb
@@ -519,6 +519,14 @@ module Yast
       "<ul>#{summary}</ul>"
     end
 
+    # Assigns all the routes from one interface to another
+    #
+    # @param from [String] interface belonging the routes to be moved
+    # @param to [String] target interface
+    def move_routes(from, to)
+      device_routes(from).each { |r| r["device"] = to }
+    end
+
     publish variable: :Routes, type: "list <map>"
     publish variable: :Forward_v4, type: "boolean"
     publish variable: :Forward_v6, type: "boolean"

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -272,4 +272,25 @@ describe Yast::Routing do
       expect(Yast::Routing.normalize_routes(input_routes)).to eql input_routes
     end
   end
+
+  describe "#move_routes" do
+    let(:routes) do
+      [
+        {
+          "destination" => "default",
+          "gateway"     => "192.168.122.1",
+          "netmask"     => "-",
+          "device"      => "eth0"
+        }
+      ]
+    end
+    before do
+      described_class.Import("routes" => routes)
+    end
+
+    it "assigns all the 'from' routes to the 'to' interface" do
+      expect { described_class.move_routes("eth0", "br0") }
+        .to change { described_class.device_routes("br0").size }.from(0).to(1)
+    end
+  end
 end


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=903889

When YaST proposes the a bridge configuration for Virtualization, it does not move the routes that belongs to the interface being enslaved to the bridge.

## Solution

- Move the routes to the bridge

## Tests

- Unit test added
- Tested manually (Leap 15.1)
