### PR TITLE
Fix the stubbing

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,18 +52,17 @@ DATA_PATH = File.join(File.expand_path(File.dirname(__FILE__)), "data")
 # stub module to prevent its Import
 # Useful for modules from different yast packages, to avoid build dependencies
 def stub_module(name)
-  Yast.const_set name.to_sym, Class.new do
+  stubbed_class = Class.new do
     # fake respond_to? to avoid failure of partial doubles
-    # rubocop:disable Lint/NestedMethodDefinition
-    def self.respond_to?(_m, _a = nil)
+    singleton_class.define_method(:respond_to?) do |_mname, _include_all = nil|
       true
     end
 
     # needed to fake at least one class method to avoid Yast.import
-    def self.fake_method
+    singleton_class.define_method(:fake_method) do
     end
-    # rubocop:enable Lint/NestedMethodDefinition
   end
+  Yast.const_set(name.to_sym, stubbed_class)
 end
 
 # stub classes from other modules to speed up a build


### PR DESCRIPTION
Without the fix, the block gets passed to const_new, not to Class.new.

It's a design flaw in Ruby that unwanted blocks cannot be forbidden :-(
https://stackoverflow.com/questions/39221847/how-to-prohibit-a-block-require-that-no-block-argument-is-given-in-ruby