### PR TITLE
Increased DHCP timeout when saving the network and with NM backend

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jun 17 15:47:45 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- bsc#1133442
+  - Increased the DHCP timeout when NetworkManager is in use to
+    its default (45 seconds).
+- 3.4.9
+
+-------------------------------------------------------------------
 Mon Jun 10 11:55:48 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - bsc#1136929

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        3.4.8
+Version:        3.4.9
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -616,7 +616,7 @@ module Yast
 
       if NetworkService.is_network_manager
         network = false
-        timeout = 15
+        timeout = 45
         while Ops.greater_than(timeout, 0)
           if NetworkService.isNetworkRunning
             network = true

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -478,6 +478,8 @@ module Yast
       nil
     end
 
+    NM_DHCP_TIMEOUT = 45
+
     # Update the SCR according to network settings
     # @return true on success
     def Write
@@ -616,7 +618,7 @@ module Yast
 
       if NetworkService.is_network_manager
         network = false
-        timeout = 45
+        timeout = NM_DHCP_TIMEOUT
         while Ops.greater_than(timeout, 0)
           if NetworkService.isNetworkRunning
             network = true


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1133442

Use NM default:

https://github.com/NetworkManager/NetworkManager/blob/1850dc495206e08a4bdb1adb62996fe2710fa071/src/dhcp/nm-dhcp-client.h#L27