### PR TITLE
Read not present interfaces

### DIFF
--- a/src/lib/y2network/config_reader/connection_config/sysconfig.rb
+++ b/src/lib/y2network/config_reader/connection_config/sysconfig.rb
@@ -45,8 +45,9 @@ module Y2Network
         def find_handler_class(type)
           require "y2network/config_reader/connection_config/sysconfig_handlers/#{type}"
           SysconfigHandlers.const_get(type.to_s.capitalize)
-        rescue LoadError, NameError
-          log.info "Unknown connection type: '#{type}'"
+        rescue LoadError, NameError => e
+          log.info "Unknown connection type: '#{type}'. " \
+                   "Connection handler could not be loaded: #{e.message}"
           nil
         end
       end

--- a/src/lib/y2network/config_reader/connection_config/sysconfig.rb
+++ b/src/lib/y2network/config_reader/connection_config/sysconfig.rb
@@ -28,12 +28,15 @@ module Y2Network
 
         # Constructor
         #
-        # @param interface [String] Interface
-        # @return [Y2Network::SysconfigInterfaceFile]
-        def read(interface)
-          handler_class = find_handler_class(interface.type)
+        # @param name [String] Interface name
+        # @param type [Symbol,nil] Interface type (:eth, :wlan, etc.); if the type is unknown,
+        #   `nil` can be used and it will be guessed from the configuration file is possible.
+        #
+        # @return [Y2Network::ConnectionConfig::Base]
+        def read(name, type)
+          file = Y2Network::SysconfigInterfaceFile.new(name)
+          handler_class = find_handler_class(type || file.type)
           return nil if handler_class.nil?
-          file = Y2Network::SysconfigInterfaceFile.new(interface.name)
           handler_class.new(file).connection_config
         end
 

--- a/src/lib/y2network/config_reader/connection_config/sysconfig_handlers/wlan.rb
+++ b/src/lib/y2network/config_reader/connection_config/sysconfig_handlers/wlan.rb
@@ -33,9 +33,9 @@ module Y2Network
             @file = file
           end
 
-          # Returns an ethernet connection configuration
+          # Returns a wireless connection configuration
           #
-          # @return [ConnectionConfig::Ethernet]
+          # @return [ConnectionConfig::Wireless]
           def connection_config
             Y2Network::ConnectionConfig::Wireless.new.tap do |conn|
               conn.interface = file.name

--- a/src/lib/y2network/config_reader/sysconfig.rb
+++ b/src/lib/y2network/config_reader/sysconfig.rb
@@ -56,21 +56,9 @@ module Y2Network
 
       include SysconfigPaths
 
-      # Find configured network interfaces
+      # Returns an interfaces reader instance
       #
-      # Configured interfaces have a configuration (ifcfg file) assigned.
-      #
-      # @return [Array<Interface>] Detected interfaces
-      # @see Yast::NetworkInterfaces.Read
-      def find_interfaces
-        Yast::NetworkInterfaces.Read
-        # TODO: for the time being, we are just relying in the underlying stuff.
-        interfaces = Yast::NetworkInterfaces.List("").map do |name|
-          Y2Network::Interface.new(name)
-        end
-        Y2Network::InterfacesCollection.new(interfaces)
-      end
-
+      # @return [SysconfigInterfaces] Interfaces reader
       def interfaces_reader
         @interfaces_reader ||= Y2Network::ConfigReader::SysconfigInterfaces.new
       end

--- a/src/lib/y2network/config_reader/sysconfig_interfaces.rb
+++ b/src/lib/y2network/config_reader/sysconfig_interfaces.rb
@@ -48,7 +48,7 @@ module Y2Network
         return @config if @config
         find_physical_interfaces
         find_connections
-        { interfaces: @interfaces, connections: @connections }
+        @config = { interfaces: @interfaces, connections: @connections }
       end
 
       # Convenience method to get connections configuration

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -41,6 +41,15 @@ module Y2Network
       attr_accessor :secondary_ip_addresses
       # @return [Integer, nil]
       attr_accessor :mtu
+
+      # Returns the connection type
+      #
+      # @todo: We should consider using an enum
+      #
+      # @return [String] :ethernet, :wireless, etc.
+      def type
+        self.class.name.split("::").last.downcase.to_sym
+      end
     end
   end
 end

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -17,7 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2network/interface"
+require "y2network/interface_type"
 
 module Y2Network
   module ConnectionConfig
@@ -44,11 +44,13 @@ module Y2Network
 
       # Returns the connection type
       #
-      # @todo: We should consider using an enum
+      # Any subclass could define this method is the default
+      # logic does not match.
       #
-      # @return [String] :ethernet, :wireless, etc.
+      # @return [InterfaceType] Interface type
       def type
-        self.class.name.split("::").last.downcase.to_sym
+        const_name = self.class.name.split("::").last.upcase
+        InterfaceType.const_get(const_name)
       end
     end
   end

--- a/src/lib/y2network/fake_interface.rb
+++ b/src/lib/y2network/fake_interface.rb
@@ -1,0 +1,38 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/interface"
+
+module Y2Network
+  # This class represents an interface which does not exists in the system
+  class FakeInterface < Interface
+    class << self
+      # Build connection
+      #
+      # @todo Would be possible to get the name from the connection?
+      #
+      # @param name [String] Interface name
+      # @param conn [ConnectionConfig] Connection configuration related to the
+      #   network interface
+      def from_connection(name, conn)
+        new(name, type: conn.type)
+      end
+    end
+  end
+end

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -29,9 +29,10 @@ module Y2Network
     # Constructor
     #
     # @param name [String] Interface name (e.g., "eth0")
-    def initialize(name)
+    def initialize(name, type: :ethernet)
       @name = name
       @description = ""
+      @type = type
     end
 
     # Determines whether two interfaces are equal

--- a/src/lib/y2network/interface_type.rb
+++ b/src/lib/y2network/interface_type.rb
@@ -17,38 +17,43 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2network/interface_type"
+require "yast"
 
 module Y2Network
-  # Network interface.
-  class Interface
-    # @return [String] Device name ('eth0', 'wlan0', etc.)
-    attr_accessor :name
-    # @return [String] Interface description
-    attr_accessor :description
-    # @return [Symbol] Interface type
-    attr_accessor :type
+  # This class represents the interface types which are supported.
+  #
+  # Constants may be defined using the {define_type} method.
+  class InterfaceType
+    extend Yast::I18n
+    include Yast::I18n
+
+    class << self
+      # @param const_name [String] Constant name
+      # @param name       [String] Type name ("Ethernet", "Wireless", etc.)
+      def define_type(const_name, name)
+        const_set(const_name, new(name))
+      end
+    end
+
+    # @return [String] Return's type name
+    attr_reader :name
 
     # Constructor
     #
-    # @param name [String] Interface name (e.g., "eth0")
-    def initialize(name, type: InterfaceType::ETHERNET)
+    # @param name [String] Type name
+    def initialize(name)
       @name = name
-      @description = ""
-      @type = type
     end
 
-    # Determines whether two interfaces are equal
+    # Returns the translated name
     #
-    # @param other [Interface] Interface to compare with
-    # @return [Boolean]
-    def ==(other)
-      return false unless other.is_a?(Interface)
-      name == other.name
+    # @return [String]
+    def to_human_string
+      _(name)
     end
 
-    # eql? (hash key equality) should alias ==, see also
-    # https://ruby-doc.org/core-2.3.3/Object.html#method-i-eql-3F
-    alias_method :eql?, :==
+    # Define types constants
+    define_type "ETHERNET", N_("Ethernet")
+    define_type "WIRELESS", N_("Wireless")
   end
 end

--- a/src/lib/y2network/interface_type.rb
+++ b/src/lib/y2network/interface_type.rb
@@ -30,20 +30,40 @@ module Y2Network
     class << self
       # @param const_name [String] Constant name
       # @param name       [String] Type name ("Ethernet", "Wireless", etc.)
-      def define_type(const_name, name)
-        const_set(const_name, new(name))
+      # @param short_name [String] Short name used in legacy code
+      def define_type(const_name, name, short_name)
+        const_set(const_name, new(name, short_name))
+        all << const_get(const_name)
+      end
+
+      # Returns all the existing types
+      #
+      # @return [Array<InterfaceType>] Interface types
+      def all
+        @types ||= []
+      end
+
+      # Returns the interface type with a given short name
+      #
+      # @param short_name [String] Short name
+      # @return [InterfaceType,nil] Interface type or nil is not found
+      def from_short_name(short_name)
+        all.find { |t| t.short_name == short_name }
       end
     end
 
-    # @return [String] Return's type name
+    # @return [String] Returns type name
     attr_reader :name
+    # @return [String] Returns type's short name
+    attr_reader :short_name
 
     # Constructor
     #
     # @param name [String] Type name
-    def initialize(name)
+    def initialize(name, short_name)
       textdomain "network"
       @name = name
+      @short_name = short_name
     end
 
     # Returns the translated name
@@ -54,7 +74,11 @@ module Y2Network
     end
 
     # Define types constants
-    define_type "ETHERNET", N_("Ethernet")
-    define_type "WIRELESS", N_("Wireless")
+    define_type "ETHERNET", N_("Ethernet"), "eth"
+    define_type "WIRELESS", N_("Wireless"), "wlan"
+    define_type "INFINIBAND", N_("Infiniband"), "ib"
+    define_type "BONDING", N_("Bonding"), "bond"
+    define_type "BRIDGE", N_("Bridge"), "br"
+    define_type "VLAN", N_("VLAN"), "vlan"
   end
 end

--- a/src/lib/y2network/interface_type.rb
+++ b/src/lib/y2network/interface_type.rb
@@ -42,6 +42,7 @@ module Y2Network
     #
     # @param name [String] Type name
     def initialize(name)
+      textdomain "network"
       @name = name
     end
 

--- a/src/lib/y2network/sysconfig_interface_file.rb
+++ b/src/lib/y2network/sysconfig_interface_file.rb
@@ -153,6 +153,15 @@ module Y2Network
       Yast::SCR.Read(path)
     end
 
+    # Determines the interface's type
+    #
+    # @todo Borrow logic from https://github.com/yast/yast-yast2/blob/6f7a789d00cd03adf62e00da34720f326f0e0633/library/network/src/modules/NetworkInterfaces.rb#L291
+    #
+    # @return [Symbol] Interface's type depending on the file values
+    def type
+      :eth
+    end
+
   private
 
     # Converts the value into a string (or nil if empty)

--- a/test/y2network/config_reader/connection_config/sysconfig_test.rb
+++ b/test/y2network/config_reader/connection_config/sysconfig_test.rb
@@ -28,7 +28,7 @@ describe Y2Network::ConfigReader::ConnectionConfig::Sysconfig do
 
   describe "#read" do
     let(:interface) { instance_double(Y2Network::PhysicalInterface, name: "wlan0", type: :wlan) }
-    let(:connection_config) { double("connection_config")}
+    let(:connection_config) { double("connection_config") }
     let(:handler) do
       instance_double(
         Y2Network::ConfigReader::ConnectionConfig::SysconfigHandlers::Wlan,
@@ -49,7 +49,7 @@ describe Y2Network::ConfigReader::ConnectionConfig::Sysconfig do
       expect(conn).to be(connection_config)
     end
 
-    context "when the interface type is unknown" do
+    xcontext "when the interface type is unknown" do
       let(:interface) { instance_double(Y2Network::PhysicalInterface, type: :foo) }
 
       it "returns nil" do

--- a/test/y2network/config_reader/connection_config/sysconfig_test.rb
+++ b/test/y2network/config_reader/connection_config/sysconfig_test.rb
@@ -45,7 +45,7 @@ describe Y2Network::ConfigReader::ConnectionConfig::Sysconfig do
     it "uses the appropiate handler" do
       expect(reader).to receive(:require)
         .with("y2network/config_reader/connection_config/sysconfig_handlers/wlan")
-      conn = reader.read(interface)
+      conn = reader.read(interface, :wlan)
       expect(conn).to be(connection_config)
     end
 
@@ -53,7 +53,7 @@ describe Y2Network::ConfigReader::ConnectionConfig::Sysconfig do
       let(:interface) { instance_double(Y2Network::PhysicalInterface, type: :foo) }
 
       it "returns nil" do
-        expect(reader.read(interface)).to be_nil
+        expect(reader.read(interface, :wlan)).to be_nil
       end
     end
   end

--- a/test/y2network/config_reader/connection_config/sysconfig_test.rb
+++ b/test/y2network/config_reader/connection_config/sysconfig_test.rb
@@ -1,0 +1,60 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+
+require "y2network/config_reader/connection_config/sysconfig"
+require "y2network/config_reader/connection_config/sysconfig_handlers/wlan"
+require "y2network/physical_interface"
+
+describe Y2Network::ConfigReader::ConnectionConfig::Sysconfig do
+  subject(:reader) { described_class.new }
+
+  describe "#read" do
+    let(:interface) { instance_double(Y2Network::PhysicalInterface, name: "wlan0", type: :wlan) }
+    let(:connection_config) { double("connection_config")}
+    let(:handler) do
+      instance_double(
+        Y2Network::ConfigReader::ConnectionConfig::SysconfigHandlers::Wlan,
+        connection_config: connection_config
+      )
+    end
+
+    before do
+      allow(reader).to receive(:require).and_call_original
+      allow(Y2Network::ConfigReader::ConnectionConfig::SysconfigHandlers::Wlan)
+        .to receive(:new).and_return(handler)
+    end
+
+    it "uses the appropiate handler" do
+      expect(reader).to receive(:require)
+        .with("y2network/config_reader/connection_config/sysconfig_handlers/wlan")
+      conn = reader.read(interface)
+      expect(conn).to be(connection_config)
+    end
+
+    context "when the interface type is unknown" do
+      let(:interface) { instance_double(Y2Network::PhysicalInterface, type: :foo) }
+
+      it "returns nil" do
+        expect(reader.read(interface)).to be_nil
+      end
+    end
+  end
+end

--- a/test/y2network/config_reader/sysconfig_interfaces_test.rb
+++ b/test/y2network/config_reader/sysconfig_interfaces_test.rb
@@ -39,6 +39,10 @@ describe Y2Network::ConfigReader::SysconfigInterfaces do
     "eth0" => {
       "BOOTPROTO" => "static",
       "IPADDR"    => "192.168.1.2"
+    },
+    "eth1" => {
+      "BOOTPROTO" => "static",
+      "IPADDR"    => "10.0.0.2"
     }
   }.freeze
   SCR_PATH_REGEXP = /.network.value.\"(\w+)\".(\w+)\Z/
@@ -69,6 +73,15 @@ describe Y2Network::ConfigReader::SysconfigInterfaces do
     it "reads bridge interfaces"
     it "reads bonding interfaces"
     it "reads interfaces configuration"
+
+    context "when a connection for a not existing device is found" do
+      let(:configured_interfaces) { ["lo", "eth0", "eth1"] }
+
+      it "creates a fake interface" do
+        eth1 = reader.interfaces.by_name("eth1")
+        expect(eth1).to_not be_nil
+      end
+    end
   end
 
   describe "#connections" do

--- a/test/y2network/connection_config/ethernet_test.rb
+++ b/test/y2network/connection_config/ethernet_test.rb
@@ -1,0 +1,31 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/connection_config/ethernet"
+
+describe Y2Network::ConnectionConfig::Ethernet do
+  subject(:config) { described_class.new }
+
+  describe "#type" do
+    it "returns 'ethernet'" do
+      expect(config.type).to eq(:ethernet)
+    end
+  end
+end

--- a/test/y2network/connection_config/ethernet_test.rb
+++ b/test/y2network/connection_config/ethernet_test.rb
@@ -19,13 +19,14 @@
 
 require_relative "../../test_helper"
 require "y2network/connection_config/ethernet"
+require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Ethernet do
   subject(:config) { described_class.new }
 
   describe "#type" do
     it "returns 'ethernet'" do
-      expect(config.type).to eq(:ethernet)
+      expect(config.type).to eq(Y2Network::InterfaceType::ETHERNET)
     end
   end
 end

--- a/test/y2network/connection_config/wireless_test.rb
+++ b/test/y2network/connection_config/wireless_test.rb
@@ -1,0 +1,31 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/connection_config/wireless"
+
+describe Y2Network::ConnectionConfig::Wireless do
+  subject(:config) { described_class.new }
+
+  describe "#type" do
+    it "returns 'wireless'" do
+      expect(config.type).to eq(:wireless)
+    end
+  end
+end

--- a/test/y2network/connection_config/wireless_test.rb
+++ b/test/y2network/connection_config/wireless_test.rb
@@ -19,13 +19,14 @@
 
 require_relative "../../test_helper"
 require "y2network/connection_config/wireless"
+require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Wireless do
   subject(:config) { described_class.new }
 
   describe "#type" do
     it "returns 'wireless'" do
-      expect(config.type).to eq(:wireless)
+      expect(config.type).to eq(Y2Network::InterfaceType::WIRELESS)
     end
   end
 end

--- a/test/y2network/fake_interface_test.rb
+++ b/test/y2network/fake_interface_test.rb
@@ -21,7 +21,9 @@ require "y2network/fake_interface"
 require "y2network/connection_config/wireless"
 
 describe Y2Network::FakeInterface do
-  subject(:interface) { described_class.new("eth0", type: :ethernet) }
+  subject(:interface) { described_class.new("eth0", type: iface_type) }
+
+  let(:iface_type) { Y2Network::InterfaceType::ETHERNET }
 
   describe ".from_connection" do
     let(:conn) do
@@ -32,7 +34,7 @@ describe Y2Network::FakeInterface do
 
     it "returns a fake interface using the connection's type" do
       iface = described_class.from_connection("wlan0", conn)
-      expect(iface.type).to eq(:wireless)
+      expect(iface.type).to eq(Y2Network::InterfaceType::WIRELESS)
     end
   end
 end

--- a/test/y2network/fake_interface_test.rb
+++ b/test/y2network/fake_interface_test.rb
@@ -1,0 +1,38 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+require_relative "../test_helper"
+require "y2network/fake_interface"
+require "y2network/connection_config/wireless"
+
+describe Y2Network::FakeInterface do
+  subject(:interface) { described_class.new("eth0", type: :ethernet) }
+
+  describe ".from_connection" do
+    let(:conn) do
+      Y2Network::ConnectionConfig::Wireless.new.tap do |conn|
+        conn.interface = "wlan0"
+      end
+    end
+
+    it "returns a fake interface using the connection's type" do
+      iface = described_class.from_connection("wlan0", conn)
+      expect(iface.type).to eq(:wireless)
+    end
+  end
+end

--- a/test/y2network/interface_type_test.rb
+++ b/test/y2network/interface_type_test.rb
@@ -1,0 +1,31 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+describe Y2Network::InterfaceType do
+  subject(:ethernet) { described_class.from_short_name("eth") }
+
+  describe ".from_short_name" do
+    it "returns the type for a given shortname" do
+      type = described_class.from_short_name("wlan")
+      expect(type).to be(Y2Network::InterfaceType::WIRELESS)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the ability to read interfaces that, for some reason, are not present in the system (USB, hotplug, ...) but the configuration is still present. In such a case, a `FakeInterface` object is created.