### PR TITLE
Do not raise an exception when no interface type is provided

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,7 +2,7 @@
 Wed Jul  3 13:18:05 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - bsc#1137346
-  - CLI: Report an error isntead of raise an exception when the
+  - CLI: Report an error instead of raising an exception when the
     device type is not provided and there is no way to infer it
     from the given options.
 - 4.1.50

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,8 +2,9 @@
 Wed Jul  3 13:18:05 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - bsc#1137346
-  - CLI: Do not raise an exception when the device type is not
-    provided but report an error instead.
+  - CLI: Report an error isntead of raise an exception when the
+    device type is not provided and there is no way to infer it
+    from the given options.
 - 4.1.50
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul  3 13:18:05 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- bsc#1137346
+  - CLI: Do not raise an exception when the device type is not
+    provided but report an error instead.
+- 4.1.50
+
+-------------------------------------------------------------------
 Fri Jun 14 13:14:05 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - boo#1138297

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.49
+Version:        4.1.50
 Release:        0
 BuildArch:      noarch
 

--- a/src/clients/lan.rb
+++ b/src/clients/lan.rb
@@ -90,9 +90,10 @@ module Yast
               "boolean (map <string, string>)"
             ),
             "example" => [
-              "yast lan add type=vlan name=vlan50 ethdevice=eth0 bootproto=dhcp",
-              "yast lan add type=br name=br0 bridge_ports=eth0 eth1 bootproot=dhcp",
-              "yast lan add type=bond name=bond0 slaves=eth0 eth1 bootproto=dhcp"
+              "yast lan add name=vlan50 ethdevice=eth0 bootproto=dhcp",
+              "yast lan add name=br0 bridge_ports=eth0 eth1 bootproot=dhcp",
+              "yast lan add name=bond0 slaves=eth0 eth1 bootproto=dhcp",
+              "yast lan add name=dummy0 type=dummy ip=10.0.0.100"
             ]
           },
           "edit"   => {

--- a/src/clients/lan.rb
+++ b/src/clients/lan.rb
@@ -90,9 +90,9 @@ module Yast
               "boolean (map <string, string>)"
             ),
             "example" => [
-              "yast lan add name=vlan50 ethdevice=eth0 bootproto=dhcp",
-              "yast lan add name=br0 bridge_ports=eth0 eth1 bootproot=dhcp",
-              "yast lan add name=bond0 slaves=eth0 eth1 bootproto=dhcp"
+              "yast lan add type=vlan name=vlan50 ethdevice=eth0 bootproto=dhcp",
+              "yast lan add type=br name=br0 bridge_ports=eth0 eth1 bootproot=dhcp",
+              "yast lan add type=bond name=bond0 slaves=eth0 eth1 bootproto=dhcp"
             ]
           },
           "edit"   => {

--- a/src/include/network/lan/cmdline.rb
+++ b/src/include/network/lan/cmdline.rb
@@ -185,7 +185,7 @@ module Yast
       LanItems.AddNew
       Lan.Add
       LanItems.Items[LanItems.current]["ifcfg"] = options.fetch("name", "")
-      LanItems.type = options.fetch("type", "")
+      LanItems.type = options.fetch("type", infered_type(options))
       if LanItems.type.empty?
         Report.Error(_("The device type is mandatory."))
         return false
@@ -311,6 +311,21 @@ module Yast
       end
 
       true
+    end
+
+  private
+
+    # Return the infered type from the given options or an empty string if no
+    # one infered.
+    #
+    # @param options [Hash{String => String}] action options
+    # @return [String] infered device type; an empty string if not infered
+    def infered_type(options)
+      return "bond" if options.include? "slaves"
+      return "vlan" if options.include? "ethdevice"
+      return "br"   if options.include? "bridge_ports"
+
+      ""
     end
   end
 end

--- a/test/cmdline_test.rb
+++ b/test/cmdline_test.rb
@@ -21,4 +21,58 @@ describe "NetworkLanCmdlineInclude" do
       expect(subject.ShowHandler("id" => "0")).to eq true
     end
   end
+
+  describe "AddHandler" do
+    let(:vlan_config) { { "name" => "vlan0", "type" => "vlan", "bootproto" => "dhcp" } }
+
+    before do
+      allow(Yast::Report).to receive(:Error)
+      allow(Yast::LanItems).to receive(:Commit)
+    end
+
+    context "when called without type" do
+      it "reports an error" do
+        expect(Yast::Report).to receive(:Error)
+        subject.AddHandler(vlan_config.reject { |k| k == "type" })
+      end
+
+      it "returns false" do
+        expect(subject.AddHandler(vlan_config.reject { |k| k == "type" })).to eq false
+      end
+    end
+
+    context "when startmode is given" do
+      context "but with an invalid option" do
+        it "reports an error" do
+          expect(Yast::Report).to receive(:Error)
+          subject.AddHandler(vlan_config.merge("startmode" => "wrong"))
+        end
+
+        it "returns false" do
+          expect(subject.AddHandler(vlan_config.merge("startmode" => "wrong"))).to eq false
+        end
+      end
+    end
+
+    context "when a valid configuration is providen" do
+      before do
+        allow(subject).to receive(:ListHandler)
+      end
+
+      it "commits the new configuration" do
+        expect(Yast::LanItems).to receive(:Commit)
+        subject.AddHandler(vlan_config)
+      end
+
+      it "lists the final configuration" do
+        expect(subject).to receive(:ListHandler)
+        subject.AddHandler(vlan_config)
+      end
+
+      it "returns true" do
+        expect(Yast::Report).to_not receive(:Error)
+        expect(subject.AddHandler(vlan_config)).to eq true
+      end
+    end
+  end
 end

--- a/test/cmdline_test.rb
+++ b/test/cmdline_test.rb
@@ -31,14 +31,16 @@ describe "NetworkLanCmdlineInclude" do
     end
 
     context "when called without type" do
+      let(:no_type_options) { options.reject { |k| k == "ethdevice" } }
+
       context "and it cannot be infered from the given options" do
         it "reports an error" do
           expect(Yast::Report).to receive(:Error)
-          subject.AddHandler(options.reject { |k| k == "ethdevice" })
+          subject.AddHandler(no_type_options)
         end
 
         it "returns false" do
-          expect(subject.AddHandler(options.reject { |k| k == "ethdevice" })).to eq false
+          expect(subject.AddHandler(no_type_options)).to eq false
         end
       end
     end

--- a/test/cmdline_test.rb
+++ b/test/cmdline_test.rb
@@ -23,7 +23,7 @@ describe "NetworkLanCmdlineInclude" do
   end
 
   describe "AddHandler" do
-    let(:vlan_config) { { "name" => "vlan0", "type" => "vlan", "bootproto" => "dhcp" } }
+    let(:options) { { "name" => "vlan0", "ethdevice" => "eth0", "bootproto" => "dhcp" } }
 
     before do
       allow(Yast::Report).to receive(:Error)
@@ -31,13 +31,15 @@ describe "NetworkLanCmdlineInclude" do
     end
 
     context "when called without type" do
-      it "reports an error" do
-        expect(Yast::Report).to receive(:Error)
-        subject.AddHandler(vlan_config.reject { |k| k == "type" })
-      end
+      context "and it cannot be infered from the given options" do
+        it "reports an error" do
+          expect(Yast::Report).to receive(:Error)
+          subject.AddHandler(options.reject { |k| k == "ethdevice" })
+        end
 
-      it "returns false" do
-        expect(subject.AddHandler(vlan_config.reject { |k| k == "type" })).to eq false
+        it "returns false" do
+          expect(subject.AddHandler(options.reject { |k| k == "ethdevice" })).to eq false
+        end
       end
     end
 
@@ -45,11 +47,11 @@ describe "NetworkLanCmdlineInclude" do
       context "but with an invalid option" do
         it "reports an error" do
           expect(Yast::Report).to receive(:Error)
-          subject.AddHandler(vlan_config.merge("startmode" => "wrong"))
+          subject.AddHandler(options.merge("startmode" => "wrong"))
         end
 
         it "returns false" do
-          expect(subject.AddHandler(vlan_config.merge("startmode" => "wrong"))).to eq false
+          expect(subject.AddHandler(options.merge("startmode" => "wrong"))).to eq false
         end
       end
     end
@@ -61,17 +63,17 @@ describe "NetworkLanCmdlineInclude" do
 
       it "commits the new configuration" do
         expect(Yast::LanItems).to receive(:Commit)
-        subject.AddHandler(vlan_config)
+        subject.AddHandler(options)
       end
 
       it "lists the final configuration" do
         expect(subject).to receive(:ListHandler)
-        subject.AddHandler(vlan_config)
+        subject.AddHandler(options)
       end
 
       it "returns true" do
         expect(Yast::Report).to_not receive(:Error)
-        expect(subject.AddHandler(vlan_config)).to eq true
+        expect(subject.AddHandler(options)).to eq true
       end
     end
   end

--- a/test/lib/y2network/proposal_settings_test.rb
+++ b/test/lib/y2network/proposal_settings_test.rb
@@ -17,6 +17,8 @@ describe Y2Network::ProposalSettings do
   def stub_features(features)
     Yast.import "ProductFeatures"
     Yast::ProductFeatures.Import(features)
+    # Prevent to Restore or Init
+    allow(Yast::ProductFeatures).to receive(:InitIfNeeded)
   end
 
   describe ".instance" do

--- a/test/new_device_startmode_test.rb
+++ b/test/new_device_startmode_test.rb
@@ -8,6 +8,11 @@ Yast.import "ProductFeatures"
 Yast.import "LanItems"
 
 describe "LanItemsClass#new_device_startmode" do
+  before do
+    allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+    allow(Yast::LanItems).to receive(:type) { "eth" }
+  end
+
   DEVMAP_STARTMODE_INVALID = {
     "STARTMODE" => "invalid"
   }.freeze
@@ -53,9 +58,11 @@ describe "LanItemsClass#new_device_startmode" do
         expect(result).to be_eql expected_startmode
       end
 
-      it "results to ifplugd when running on laptop" do
+      it "results to ifplugd when running on laptop with wicked and not virtual device" do
         expect(Yast::Arch)
           .to receive(:is_laptop) { true }
+        allow(Yast::NetworkService)
+          .to receive(:is_network_manager) { false }
 
         result = Yast::LanItems.new_device_startmode
         expect(result).to be_eql "ifplugd"

--- a/test/new_device_startmode_test.rb
+++ b/test/new_device_startmode_test.rb
@@ -58,16 +58,6 @@ describe "LanItemsClass#new_device_startmode" do
         expect(result).to be_eql expected_startmode
       end
 
-      it "results to ifplugd when running on laptop with wicked and not virtual device" do
-        expect(Yast::Arch)
-          .to receive(:is_laptop) { true }
-        allow(Yast::NetworkService)
-          .to receive(:is_network_manager) { false }
-
-        result = Yast::LanItems.new_device_startmode
-        expect(result).to be_eql "ifplugd"
-      end
-
       it "results to #{expected_startmode} when running NetworkManager" do
         expect(Yast::NetworkService)
           .to receive(:is_network_manager) { true }
@@ -84,6 +74,18 @@ describe "LanItemsClass#new_device_startmode" do
 
         result = Yast::LanItems.new_device_startmode
         expect(result).to be_eql expected_startmode
+      end
+
+      context "and running on a laptop without NetworkManager" do
+        it "returns ifplugd is the device is not a virtual one" do
+          expect(Yast::Arch)
+            .to receive(:is_laptop) { true }
+          allow(Yast::NetworkService)
+            .to receive(:is_network_manager) { false }
+
+          result = Yast::LanItems.new_device_startmode
+          expect(result).to be_eql "ifplugd"
+        end
       end
     end
 


### PR DESCRIPTION
## Problem

Since https://github.com/yast/yast-network/pull/661 the device type is mandatory, but the help has not been updated and a exception is raised instead of an error reported.
```
$ yast lan add name=vlan50 ethdevice=eth0

# Reports
Error: Internal error. Please report a bug report with logs.
Run save_y2logs to get complete logs.

Caller:  /usr/share/YaST2/include/network/lan/cmdline.rb:194:in `AddHandler'
Details: Device type is mandatory.
```
https://bugzilla.suse.com/show_bug.cgi?id=1137346

## Solution

- Try to infer the device type when able to.
- Update the examples adding the new mandatory device 'type'.
- Report an error instead of raise an exception when no type is provided and there is no way to infer it from the given options.

## Tests

- New unit test created.
- Tested manually