### PR TITLE
AY: Use current sysconfig readers and infer type from config

### DIFF
--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -247,13 +247,15 @@ module Yast
     # It creates a proposal in case of common installation. In case of AY
     # installation it does full import of <networking> section
     def configure_lan
-      NetworkAutoconfiguration.instance.configure_virtuals
+      NetworkAutoYast.instance.configure_lan if Mode.autoinst
 
-      if Mode.autoinst
-        NetworkAutoYast.instance.configure_lan
-      else
-        NetworkAutoconfiguration.instance.configure_dns
-      end
+      # FIXME: Really make sense to configure it in autoinst mode? At least the
+      # proposal should be done and checked after lan configuration and in case
+      # that a bridge configuratio is present in the profile it should be
+      # skipped or even only done in case of missing `networking -> interfaces`
+      # section
+      NetworkAutoconfiguration.instance.configure_virtuals
+      NetworkAutoconfiguration.instance.configure_dns unless Mode.autoinst
 
       # this depends on DNS configuration
       configure_hosts

--- a/src/lib/y2network/autoinst/config_reader.rb
+++ b/src/lib/y2network/autoinst/config_reader.rb
@@ -44,7 +44,7 @@ module Y2Network
       # @return [Y2Network::Config] Network configuration
       def config
         attrs = { source: :sysconfig }
-        # FIXME: implement prper readers for AutoYaST
+        # FIXME: implement proper readers for AutoYaST
         attrs[:interfaces] =  interfaces_reader.interfaces
         attrs[:connections] = interfaces_reader.connections
         attrs[:routing] = RoutingReader.new(section.routing).config if section.routing

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -681,7 +681,7 @@ module Yast
       Builtins.foreach(interfaces) do |devname, if_data|
         # devname can be in old-style fashion (eth-bus-<pci_id>). So, convert it
         devname = LanItems.getDeviceName(devname)
-        type = NetworkInterfaces.GetType(devname)
+        type = NetworkInterfaces.GetTypeFromIfcfgOrName(devname, if_data)
         d = Ops.get(devices, type, {})
         Ops.set(d, devname, if_data)
         Ops.set(devices, type, d)


### PR DESCRIPTION
## Problem

1. In case of an Autoinstallation, the configuration is imported and converted by `Lan.FromAY`. The main problem here is that, in case of virtual interfaces, as them are still not present in the system the interface type cannot be inferred from the sysfs. Once the detection from the name was removed recently, at least the interface configuration should be given in order to try to determine the type from them. Otherwise `NetworkInterfaces` imported will be indexed by 'eth' instead of the virtual interface type ('bond', 'br', 'vlan', 'dummy'...)

2. When xen, qemu or kvm packages are installed (and not in a s390 machine), save_network propose a network configuration for virtualization. That is, it creates a bridge when not exist. The problem is that normally the network configuration is done during the second stage and in the moment of proposed is even not importer yet. (Currently a crash when checking the current yast_config.interfaces which does not exist)

## Solution

1. Use the interface type detection passing the ifcfg data.
2. Initialize the list of Config interfaces from sysconfig at least to have a proper InterfacesCollection and not an array.
3. Propose the virtualization configuration after configurin the lan in case of autoinst.
