### PR TITLE
Add a Y2Network::IPAddress class

### DIFF
--- a/src/lib/y2network/ip_address.rb
+++ b/src/lib/y2network/ip_address.rb
@@ -1,0 +1,73 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "ipaddr"
+require "forwardable"
+
+module Y2Network
+  # This class represents an IP address
+  #
+  # The problem with the IPAddr from the Ruby standard library, is that it drops
+  # the host part according to the netmask.
+  #
+  # @example IPAddr from standard library behavior
+  #  ip = IPAddr.new("192.168.122.1/24")
+  #  ip.to_s #=> "192.168.122.0/24"
+  #
+  # However, what we need is to be able to keep the host part
+  #
+  # @example IPAddress behaviour
+  #   ip = IPAddress.new("192.168.122.1/24")
+  #   ip.to_s #=> "192.168.122.1/24"
+  class IPAddress
+    extend Forwardable
+
+    # @return [IPAddr] IP address
+    attr_reader :address
+    # @return [Integer] Prefix
+    attr_reader :prefix
+
+    def_delegators :@address, :ipv4?, :ipv6?
+
+    class << self
+      def from_string(str)
+        address, prefix = str.split("/")
+        address = IPAddr.new(address)
+        prefix = prefix.to_i if prefix
+        new(address, prefix)
+      end
+    end
+
+    # @return [Integer] IPv4 address default prefix
+    IPV4_DEFAULT_PREFIX = 32
+    # @return [Integer] IPv6 address default prefix
+    IPV6_DEFAULT_PREFIX = 128
+
+    def initialize(address, prefix = nil)
+      @address = address
+      @prefix = prefix
+      @prefix ||= address.ipv4? ? IPV4_DEFAULT_PREFIX : IPV6_DEFAULT_PREFIX
+    end
+
+    # Returns a string representation of the address
+    def to_s
+      "#{@address}/#{@prefix}"
+    end
+  end
+end

--- a/src/lib/y2network/ip_address.rb
+++ b/src/lib/y2network/ip_address.rb
@@ -81,7 +81,7 @@ module Y2Network
     #
     # @return [Boolean]
     def host?
-      (ipv4? && prefix == IPV4_DEFAULT_PREFIX) && (ipv6? && prefix == IPV6_DEFAULT_PREFIX)
+      (ipv4? && prefix == IPV4_DEFAULT_PREFIX) || (ipv6? && prefix == IPV6_DEFAULT_PREFIX)
     end
   end
 end

--- a/src/lib/y2network/ip_address.rb
+++ b/src/lib/y2network/ip_address.rb
@@ -48,7 +48,6 @@ module Y2Network
     class << self
       def from_string(str)
         address, prefix = str.split("/")
-        address = IPAddr.new(address)
         prefix = prefix.to_i if prefix
         new(address, prefix)
       end
@@ -59,15 +58,29 @@ module Y2Network
     # @return [Integer] IPv6 address default prefix
     IPV6_DEFAULT_PREFIX = 128
 
+    # Constructor
+    #
+    # @param address [String] IP address without the prefix
+    # @param prefix [Integer] IP prefix (number of bits). If not specified, 32 will be used for IPv4
+    #   and 128 for IPv6.
     def initialize(address, prefix = nil)
-      @address = address
+      @address = IPAddr.new(address)
       @prefix = prefix
-      @prefix ||= address.ipv4? ? IPV4_DEFAULT_PREFIX : IPV6_DEFAULT_PREFIX
+      @prefix ||= @address.ipv4? ? IPV4_DEFAULT_PREFIX : IPV6_DEFAULT_PREFIX
     end
 
     # Returns a string representation of the address
     def to_s
-      "#{@address}/#{@prefix}"
+      host? ? @address.to_s : "#{@address}/#{@prefix}"
+    end
+
+  private
+
+    # Determines whether it is a host address
+    #
+    # @return [Boolean]
+    def host?
+      (ipv4? && prefix == IPV4_DEFAULT_PREFIX) && (ipv6? && prefix == IPV6_DEFAULT_PREFIX)
     end
   end
 end

--- a/src/lib/y2network/ip_address.rb
+++ b/src/lib/y2network/ip_address.rb
@@ -23,8 +23,9 @@ require "forwardable"
 module Y2Network
   # This class represents an IP address
   #
-  # The problem with the IPAddr from the Ruby standard library, is that it drops
-  # the host part according to the netmask.
+  # The IPAddr from the Ruby standard library drops the host part according to the netmask. The
+  # problem is that YaST uses a CIDR-like string, including the host part, to set IPADDR in ifcfg-*
+  # files (see man 5 ifcfg for further details).
   #
   # @example IPAddr from standard library behavior
   #  ip = IPAddr.new("192.168.122.1/24")

--- a/src/lib/y2network/sysconfig/interface_file.rb
+++ b/src/lib/y2network/sysconfig/interface_file.rb
@@ -19,7 +19,7 @@
 
 require "yast"
 require "pathname"
-require "ipaddr"
+require "y2network/ip_address"
 
 module Y2Network
   module Sysconfig
@@ -203,7 +203,7 @@ module Y2Network
       # @return [IPAddr,nil] IP address or nil if it is not defined
       def ip_address
         str = fetch("IPADDR")
-        str.nil? || str.empty? ? nil : IPAddr.new(str)
+        str.nil? || str.empty? ? nil : IPAddress.new(str)
       end
       alias_method :ip_address, :ipaddr
 

--- a/test/y2network/ip_address_test.rb
+++ b/test/y2network/ip_address_test.rb
@@ -62,4 +62,20 @@ describe Y2Network::IPAddress do
       end
     end
   end
+
+  describe "#to_s" do
+    subject(:ip) { described_class.new("192.168.122.1", 24) }
+
+    it "returns a string CIDR based representation" do
+      expect(ip.to_s).to eq("192.168.122.1/24")
+    end
+
+    context "when it is a host address" do
+      subject(:ip) { described_class.new("192.168.122.1") }
+
+      it "omits the prefix" do
+        expect(ip.to_s).to eq("192.168.122.1")
+      end
+    end
+  end
 end

--- a/test/y2network/ip_address_test.rb
+++ b/test/y2network/ip_address_test.rb
@@ -1,0 +1,65 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2network/ip_address"
+
+describe Y2Network::IPAddress do
+  describe ".from_string" do
+    context "when a string representing an IPv4 is given" do
+      let(:ip_address) { "192.168.122.1/24" }
+
+      it "creates an IPAddress object" do
+        ip = described_class.from_string(ip_address)
+        expect(ip.address).to eq(IPAddr.new("192.168.122.1"))
+        expect(ip.prefix).to eq(24)
+      end
+
+      context "when no prefix is given" do
+        let(:ip_address) { "192.168.122.1" }
+
+        it "sets a 32 bits prefix" do
+          ip = described_class.from_string(ip_address)
+          expect(ip.address).to eq(IPAddr.new("192.168.122.1"))
+          expect(ip.prefix).to eq(32)
+        end
+      end
+    end
+
+    context "when a string representing an IPv6 is given" do
+      let(:ip_address) { "2001:db8:1234:ffff:ffff:ffff:ffff:fff1/48" }
+
+      it "creates an IPAddress object" do
+        ip = described_class.from_string(ip_address)
+        expect(ip.address).to eq(IPAddr.new("2001:db8:1234:ffff:ffff:ffff:ffff:fff1"))
+        expect(ip.prefix).to eq(48)
+      end
+
+      context "when no prefix is given" do
+        let(:ip_address) { "2001:db8:1234:ffff:ffff:ffff:ffff:fff1" }
+
+        it "sets a 128 bits prefix" do
+          ip = described_class.from_string(ip_address)
+          expect(ip.address).to eq(IPAddr.new(ip_address))
+          expect(ip.prefix).to eq(128)
+        end
+      end
+    end
+  end
+end

--- a/test/y2network/sysconfig/interface_file_test.rb
+++ b/test/y2network/sysconfig/interface_file_test.rb
@@ -143,13 +143,13 @@ describe Y2Network::Sysconfig::InterfaceFile do
     subject(:file) { described_class.new("eth0") }
 
     it "writes the changes to the file" do
-      file.ipaddr = IPAddr.new("192.168.122.1")
+      file.ipaddr = Y2Network::IPAddress.from_string("192.168.122.1/24")
       file.bootproto = :static
       file.save
 
       content = file_content(scr_root, file)
       expect(content).to include("BOOTPROTO='static'")
-      expect(content).to include("IPADDR='192.168.122.1'")
+      expect(content).to include("IPADDR='192.168.122.1/24'")
     end
 
     describe "when multiple wireless keys are specified" do


### PR DESCRIPTION
This class should solve a problem we have with Ruby stdlib IPAddr class. Details are documented in the class description.