### PR TITLE
Improve and update network-ng.md document

### DIFF
--- a/doc/network-ng.md
+++ b/doc/network-ng.md
@@ -3,7 +3,9 @@
 This document tries to describe the details of the network-ng data model and how all the pieces are
 combined.
 
-## Overall Approach
+## Data Model
+
+### Overall Approach
 
 {Y2Network::Config} and other associated classes represent the network configuration in a backend
 agnostic way. It should not matter whether you are using `sysconfig` files, NetworkManager or
@@ -25,7 +27,7 @@ filesystem by using a *configuration writer*.
 Obviously, we should implement configuration readers and writers for whathever backend we would like
 to support. At this point of time, only `Sysconfig` and `Autoinst` are supported.
 
-## The Configuration Classes
+### The Configuration Classes
 
 {Y2Network::Config} offers and API to deal with network configuration, but it collaborates with
 other classes.
@@ -38,31 +40,77 @@ other classes.
   Currently it is bound to an interface name, but we plan to provide more advanced matchers.
 * {Y2Network::Routing}: holds routing information, including IP forwarding settings, routing tables, etc.
 
-## Backend Support
+### Multi-Backend Support
 
-In order to support a new backend, we need to implement a configuration readers and writers. The
-{Y2Network::Sysconfig} module implements support to deal with `sysconfig` files.
+As mentioned above, Y2Network is designed to support different backends. It is expected to implement
+a reader and a writer for each backend (except for AutoYaST, which is an special case). The reader
+will be responsible for checking the system's configuration and building a {Y2Network::Config}
+object, containing interfaces, configurations, routes, etc. On the other hand, the writer will be
+responsible for updating the system using that configuration object.
+
+As a developer, you rarely will need to access to readers/writers because `Yast::Lan` already offers
+an API to read and write the configuration. See the [Accessing the
+Configuration](#accessing-the-configuration) section for further details.
+
+#### Sysconfig
+
+The sysconfig backend support is composed by these files:
 
     src/lib/y2network/sysconfig
     ├── config_reader.rb <- READER
     ├── config_writer.rb <- WRITER
-    ├── connection_config_reader_handlers
-    │   ├── eth.rb
-    │   ├── wlan.rb
-    │   └── ...
     ├── connection_config_reader.rb
+    ├── connection_config_readers
+    │   ├── eth.rb
+    │   ├── wlan.rb
+    │   └── ...
+    ├── connection_config_writer.rb
+    ├── connection_config_writers
+    │   ├── eth.rb
+    │   ├── wlan.rb
+    │   └── ...
     ├── dns_reader.rb
     ├── dns_writer.rb
     ├── interface_file.rb
     ├── interfaces_reader.rb
-    ├── interfaces_writer.rb
     └── routes_file.rb
 
-As you can see, there are many classes, but the relevant ones are just `ConfigReader` and `ConfigWriter`.
+{Y2Network::Sysconfig::ConfigReader} and {Y2Network::Sysconfig::ConfigWriter} are the reader and
+writer classes. Each of them cooperates with a set of ancillary classes in order to get the job
+done.
 
-## Accessing the Configuration
+{Y2Network::Sysconfig::DNSReader}, {Y2Network::Sysconfig::InterfacesReader} and
+{Y2Network::Sysconfig::ConnectionConfigReader} are involved in reading the configuration. The logic
+to read the configuration for a connection (e.g., `ifcfg-eth0`, `ifcfg-wlan0`, etc.) is implemented
+in a set of smaller classes (one for each time of connection) under
+{Y2Network::Sysconfig::ConnectionConfigReaders}.
 
-The `Yast::Lan` module is still the entry point to read and write the network configuration. Basically, it keeps two configuration objects, one for the running system and another want for the wanted configuration.
+{Y2Network::Sysconfig::DNSWriter} and {Y2Network::Sysconfig::ConnectionConfigWriter}, including
+smaller classes under {Y2Network::Sysconfig::ConnectionConfigWriters}, are involved in writing the
+configuration. In this case, it does not exist a `InterfacesWriter` class, because when it comes to
+interfaces the configuration is handled through connection configuration files.
+
+Last but not least, there are additional classes like {Y2Network::Sysconfig::RoutesFile} and
+{Y2Network::Sysconfig::InterfaceFile} which abstract the details of reading/writing `ifcfg` files.
+
+#### AutoYaST
+
+AutoYaST is a special case in the sense that it reads the information from a profile, instead of
+using the running system as reference. Additionally, it does not implement a writer because the
+configuration will be written using a different backend (like sysconfig).
+
+    src/lib/y2network/autoinst/
+    ├── config_reader.rb
+    ├── dns_reader.rb
+    └── routing_reader.rb
+
+For the time being, it only implements support to read DNS and routing information.
+
+### Accessing the Configuration
+
+The `Yast::Lan` module is still the entry point to read and write the network configuration.
+Basically, it keeps two configuration objects, one for the running system and another want for the
+wanted configuration.
 
     Yast.import "Lan"
     Yast::Lan.read(:cache)
@@ -78,11 +126,32 @@ The `Yast::Lan` module is still the entry point to read and write the network co
 Any change you want to apply to the running system should be performed by modifying the
 `yast_config` and writing the changes.
 
-## AutoYaST Support
+## New UI layer
 
-AutoYaST is somehow and special case, as the configuration is read from the profile instead of the
-running system. So in this scenario, YaST2 Network will read the configuration using the `Autoinst`
-reader and will write it to the final system using the one corresponding to the wanted backend.
+### Interface Configuration Builders
+
+In the old code, there was no clear separation between UI and business logic. In order to improve
+the situation, we introduced the concept of [interface configuration
+builders](https://github.com/yast/yast-network/blob/network-ng/src/lib/y2network/interface_config_builder.rb).
+
+We already have implemented support for several interface types. You can find them under the
+[Y2Network::InterfaceConfigBuilders
+namespace](https://github.com/yast/yast-network/tree/843f75bfdb71d4026b3f97facf18eece479b8a0e/src/lib/y2network/interface_config_builders).
+
+### Widgets
+
+The user interaction is driven by a set of sequences, which determine which dialogs are shown to the
+user. Each of those dialogs contain a set of widgets, usually grouped in tabs. The content of the
+dialog depends on the interface type.
+
+Below you can find some pointers to relevant sequences, dialogs and widgets:
+
+* Sequences:
+  *  [Sequences::Interface](https://github.com/yast/yast-network/blob/358bcd13b4e92e7c4e9c0e477c83196ca67b578e/src/lib/y2network/sequences/interface.rb)
+* Dialogs:
+  * [Dialogs::AddInterface](https://github.com/yast/yast-network/blob/358bcd13b4e92e7c4e9c0e477c83196ca67b578e/src/lib/y2network/dialogs/add_interface.rb)
+  * [Dialogs::EditInterface](https://github.com/yast/yast-network/blob/358bcd13b4e92e7c4e9c0e477c83196ca67b578e/src/lib/y2network/dialogs/edit_interface.rb)
+* [Y2Network::Widgets](https://github.com/yast/yast-network/tree/358bcd13b4e92e7c4e9c0e477c83196ca67b578e/src/lib/y2network/widgets)
 
 ## Current Status
 
@@ -90,8 +159,8 @@ reader and will write it to the final system using the one corresponding to the 
 
 | Interface type  | read | write |
 |-----------------|------|-------|
-| Ethernet        |  ✓  |   ⌛   |
-| Wireless        |  ✓  |   ⌛   |
+| Ethernet        |  ✓  |   ✓   |
+| Wireless        |  ✓  |   ✓   |
 | InfiniBand      |  ⌛   |       |
 | Bridge          |  ⌛   |       |
 | Bonding         |      |       |
@@ -101,3 +170,9 @@ reader and will write it to the final system using the one corresponding to the 
 | USB             |      |       |
 | Dummy           |      |       |
 | s390 types      |      |       |
+
+## (Short Term) Plan
+
+- [ ] Finish reading/writing interfaces
+- [ ] Move missing UI logic to interface configuration builders
+- [ ] Replace LanItems with the new data model


### PR DESCRIPTION
Merge after #28 

It updates and improves the `network-ng.md` document.

* Update current status.
* Add a plan.
* Add information about the UI layer and interface builders.