### PR TITLE
Add aliases to the builder sysconfig devmap

### DIFF
--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -184,7 +184,7 @@ module Y2Network
       config.delete_if { |k, _| k == "INTERFACE" } if type != "dummy"
       config.delete_if { |k, _| k == "IFPLUGD_PRIORITY" } if config["STARTMODE"] != "ifplugd"
 
-      config
+      aliases.empty? ? config : config.merge("_aliases" => lan_items_format_aliases)
     end
 
     # Updates itself according to the given sysconfig configuration
@@ -288,8 +288,8 @@ module Y2Network
       @hwinfo ||= Hwinfo.new(name: name)
     end
 
-    def save_aliases
-      lan_items_format = aliases.each_with_index.each_with_object({}) do |(a, i), res|
+    def lan_items_format_aliases
+      aliases.each_with_index.each_with_object({}) do |(a, i), res|
         res[i] = {
           "IPADDR"    => a[:ip],
           "LABEL"     => a[:label],
@@ -298,10 +298,13 @@ module Y2Network
 
         }
       end
-      log.info "setting new aliases #{lan_items_format.inspect}"
+    end
+
+    def save_aliases
+      log.info "setting new aliases #{lan_items_format_aliases.inspect}"
       aliases_to_delete = Yast::LanItems.aliases.dup # #48191
-      Yast::NetworkInterfaces.Current["_aliases"] = lan_items_format
-      Yast::LanItems.aliases = lan_items_format
+      Yast::NetworkInterfaces.Current["_aliases"] = lan_items_format_aliases
+      Yast::LanItems.aliases = lan_items_format_aliases
       aliases_to_delete.each_pair do |a, v|
         Yast::NetworkInterfaces.DeleteAlias(Yast::NetworkInterfaces.Name, a) if v
       end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -184,7 +184,7 @@ module Y2Network
       config.delete_if { |k, _| k == "INTERFACE" } if type != "dummy"
       config.delete_if { |k, _| k == "IFPLUGD_PRIORITY" } if config["STARTMODE"] != "ifplugd"
 
-      aliases.empty? ? config : config.merge("_aliases" => lan_items_format_aliases)
+      config.merge("_aliases" => lan_items_format_aliases)
     end
 
     # Updates itself according to the given sysconfig configuration

--- a/src/lib/y2network/widgets/additional_addresses.rb
+++ b/src/lib/y2network/widgets/additional_addresses.rb
@@ -86,6 +86,16 @@ module Y2Network
         end
 
         Yast::UI.ChangeWidget(Id(:address_table), :Items, table_items)
+        Yast::UI.ChangeWidget(
+          Id(:edit_address),
+          :Enabled,
+          !@settings.aliases.empty?
+        )
+        Yast::UI.ChangeWidget(
+          Id(:delete_address),
+          :Enabled,
+          !@settings.aliases.empty?
+        )
       end
 
       # @return [Symbol, nil] dialog result
@@ -116,17 +126,6 @@ module Y2Network
           @settings.aliases.delete_at(cur)
           refresh_table
         end
-
-        Yast::UI.ChangeWidget(
-          Id(:edit_address),
-          :Enabled,
-          !@settings.aliases.empty?
-        )
-        Yast::UI.ChangeWidget(
-          Id(:delete_address),
-          :Enabled,
-          !@settings.aliases.empty?
-        )
 
         nil
       end


### PR DESCRIPTION
## Problem

When modified the list of aliases through the builder, the new devmap is overwritten by the device_sysconfig which is not exporting the aliases.

- https://github.com/yast/yast-network/blob/network-ng/src/modules/LanItems.rb#L1723
- https://github.com/yast/yast-network/blob/network-ng/src/lib/y2network/interface_config_builder.rb#L170

Previously save has updated the NetworkInterfaces.Current and LanItems with the set of aliases but that is not enough while we still uses the newdev to modify the changes

## Solution

Export also the aliases by device_sysconfig.