### PR TITLE
Replace deprecated operator

### DIFF
--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -69,14 +69,14 @@ module Yast
 
       if ret != :back && ret != :abort
         bootproto = builder.boot_protocol
-        ipaddr = builder["IPADDR"]
+        ipaddr = builder.ip_address
 
         # IP is mandatory for static configuration. Makes no sense to write static
         # configuration without that.
         return ret if bootproto == "static" && ipaddr.empty?
 
         if bootproto == "static"
-          update_hostname(ipaddr, builder["HOSTNAME"] || "")
+          update_hostname(ipaddr, builder.hostname || "")
         elsif LanItems.isCurrentDHCP && !LanItems.isCurrentHotplug
           # fixed bug #73739 - if dhcp is used, dont set default gw statically
           # but also: reset default gw only if DHCP* is used, this branch covers

--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -68,7 +68,7 @@ module Yast
       log.info "ShowAndRun: #{ret}"
 
       if ret != :back && ret != :abort
-        bootproto = builder["BOOTPROTO"]
+        bootproto = builder.boot_protocol
         ipaddr = builder["IPADDR"]
 
         # IP is mandatory for static configuration. Makes no sense to write static

--- a/src/include/network/lan/cmdline.rb
+++ b/src/include/network/lan/cmdline.rb
@@ -272,19 +272,19 @@ module Yast
     # @param builder [Y2Network::InterfaceConfigBuilder]
     # @return [Boolean] true when the options are valid; false otherwise
     def validate_config(builder)
-      if Y2Network::BootProtocol.all.none? { |bp| bp.name == builder["BOOTPROTO"] }
+      if builder.boot_protocol.nil?
         Report.Error(_("Impossible value for bootproto."))
         return false
       end
 
-      if builder["BOOTPROTO"] == "static" && builder["IPADDR"].empty?
+      if builder.boot_protocol.name == "static" && builder["IPADDR"].empty?
         Report.Error(
           _("For static configuration, the \"ip\" option is needed.")
         )
         return false
       end
 
-      unless ["auto", "ifplugd", "nfsroot"].include? builder["STARTMODE"]
+      unless ["auto", "ifplugd", "nfsroot"].include?(builder.startmode.name)
         Report.Error(_("Impossible value for startmode."))
         return false
       end
@@ -302,14 +302,14 @@ module Yast
       when "bond"
         builder.slaves = options.fetch("slaves", "").split(" ")
       when "vlan"
-        builder["ETHERDEVICE"] = options.fetch("ethdevice", "")
+        builder.etherdevice = options.fetch("ethdevice", "")
       when "br"
-        builder["BRIDGE_PORTS"] = options.fetch("bridge_ports", "")
+        builder.ports = options.fetch("bridge_ports", "")
       end
 
       default_bootproto = options.keys.include?("ip") ? "static" : "none"
-      builder["BOOTPROTO"] = options.fetch("bootproto", default_bootproto)
-      if builder["BOOTPROTO"] == "static"
+      builder.boot_protocol = options.fetch("bootproto", default_bootproto)
+      if builder.boot_protocol.name == "static"
         builder["IPADDR"] = options.fetch("ip", "")
         builder["PREFIX"] = options.fetch("prefix", "")
         builder["NETMASK"] = options.fetch("netmask", "255.255.255.0") if builder["PREFIX"].empty?
@@ -317,7 +317,7 @@ module Yast
         builder["IPADDR"] = ""
         builder["NETMASK"] = ""
       end
-      builder["STARTMODE"] = options.fetch("startmode", "auto")
+      builder.startmode = options.fetch("startmode", "auto")
     end
   end
 end

--- a/src/include/network/lan/cmdline.rb
+++ b/src/include/network/lan/cmdline.rb
@@ -300,7 +300,7 @@ module Yast
     def update_builder_from_options!(builder, options)
       case builder.type.short_name
       when "bond"
-        builder["BOND_SLAVES"] = options.fetch("slaves", "").split(" ")
+        builder.slaves = options.fetch("slaves", "").split(" ")
       when "vlan"
         builder["ETHERDEVICE"] = options.fetch("ethdevice", "")
       when "br"

--- a/src/include/network/lan/cmdline.rb
+++ b/src/include/network/lan/cmdline.rb
@@ -277,14 +277,14 @@ module Yast
         return false
       end
 
-      if builder.boot_protocol.name == "static" && builder["IPADDR"].empty?
+      if builder.boot_protocol.name == "static" && builder.ip_address.empty?
         Report.Error(
           _("For static configuration, the \"ip\" option is needed.")
         )
         return false
       end
 
-      unless ["auto", "ifplugd", "nfsroot"].include?(builder.startmode.name)
+      unless builder.startmode
         Report.Error(_("Impossible value for startmode."))
         return false
       end
@@ -310,12 +310,11 @@ module Yast
       default_bootproto = options.keys.include?("ip") ? "static" : "none"
       builder.boot_protocol = options.fetch("bootproto", default_bootproto)
       if builder.boot_protocol.name == "static"
-        builder["IPADDR"] = options.fetch("ip", "")
-        builder["PREFIX"] = options.fetch("prefix", "")
-        builder["NETMASK"] = options.fetch("netmask", "255.255.255.0") if builder["PREFIX"].empty?
+        builder.ip_address = options.fetch("ip", "")
+        builder.subnet_prefix = options.fetch("prefix", options.fetch("netmask", "255.255.255.0"))
       else
-        builder["IPADDR"] = ""
-        builder["NETMASK"] = ""
+        builder.ip_address = ""
+        builder.subnet_prefix = ""
       end
       builder.startmode = options.fetch("startmode", "auto")
     end

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -328,7 +328,7 @@ module Yast
         end
         # clear defaults, some defaults are invalid for slaves and can cause troubles
         # in related sysconfig scripts or makes no sence for slaves (e.g. ip configuration).
-        builder["NETMASK"] = ""
+        builder.subnet_prefix = ""
         builder.boot_protocol = "none"
         case master_builder.type.short_name
         when "bond"
@@ -338,7 +338,7 @@ module Yast
             LanItems.update_item_udev_rule!(:bus_id)
           end
         when "br"
-          builder["IPADDR"] = ""
+          builder.ip_address = ""
         else
           raise "Adapting slaves for wrong type #{master_builder.type.inspect}"
         end

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -329,7 +329,7 @@ module Yast
         # clear defaults, some defaults are invalid for slaves and can cause troubles
         # in related sysconfig scripts or makes no sence for slaves (e.g. ip configuration).
         builder["NETMASK"] = ""
-        builder["BOOTPROTO"] = "none"
+        builder.boot_protocol = "none"
         case master_builder.type.short_name
         when "bond"
           LanItems.startmode = "hotplug"

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -141,8 +141,8 @@ module Yast
         current["ifcfg"] = card
       end
 
-      builder["BOOTPROTO"] = "dhcp"
-      builder["STARTMODE"] = "auto"
+      builder.boot_protocol = "dhcp"
+      builder.startmode = "auto"
 
       LanItems.Commit(builder)
     end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -240,6 +240,16 @@ module Y2Network
       @config["ETHTOOL_OPTIONS"] = value
     end
 
+    # @return [String]
+    def ip_address
+      @config["IPADDR"]
+    end
+
+    # @param [String] value
+    def ip_address=(value)
+      @config["IPADDR"] = value
+    end
+
     # Provides stored configuration in sysconfig format
     #
     # @return [Hash<String, String>] where key is sysconfig option and value is the option's value

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -250,6 +250,18 @@ module Y2Network
       @config["IPADDR"] = value
     end
 
+    # Gets Maximum Transition Unit
+    # @return [String]
+    def mtu
+      @config["MTU"]
+    end
+
+    # Sets Maximum Transition Unit
+    # @param [String] value
+    def mtu=(value)
+      @config["MTU"] = value
+    end
+
     # Provides stored configuration in sysconfig format
     #
     # @return [Hash<String, String>] where key is sysconfig option and value is the option's value

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -229,6 +229,17 @@ module Y2Network
       Yast::LanItems.current_udev_name
     end
 
+    # TODO: eth only?
+    # @return [String]
+    def ethtool_options
+      @config["ETHTOOL_OPTIONS"]
+    end
+
+    # @param [String] value
+    def ethtool_options=(value)
+      @config["ETHTOOL_OPTIONS"] = value
+    end
+
     # Provides stored configuration in sysconfig format
     #
     # @return [Hash<String, String>] where key is sysconfig option and value is the option's value

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -270,6 +270,17 @@ module Y2Network
       end
     end
 
+    # sets remote ip for ptp connections
+    # @return [String]
+    def remote_ip
+      @config["REMOTEIP"]
+    end
+
+    # @param [String] value
+    def remote_ip=(value)
+      @config["REMOTEIP"] = value
+    end
+
     # Gets Maximum Transition Unit
     # @return [String]
     def mtu

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -170,9 +170,10 @@ module Y2Network
       startmode
     end
 
-    # @param [String] name startmode name used to create Startmode object
+    # @param [String,Y2Network::Startmode] name startmode name used to create Startmode object
+    #   or object itself
     def startmode=(name)
-      mode = Startmode.create(name)
+      mode = name.is_a?(Startmode) ? name : Startmode.create(name)
       # assign only if it is not already this value. This helps with ordering of ifplugd_priority
       @connection_config.startmode = mode if @connection_config.startmode.name != mode.name
       @config["STARTMODE"] = mode.name

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -21,6 +21,7 @@ require "yast"
 require "y2network/connection_config/base"
 require "y2network/hwinfo"
 require "y2network/startmode"
+require "y2network/boot_protocol"
 require "y2firewall/firewalld"
 require "y2firewall/firewalld/interface"
 
@@ -148,6 +149,17 @@ module Y2Network
     # sets assigned firewall zone
     def firewall_zone=(value)
       @firewall_zone = value
+    end
+
+    # @return [Y2Network::BootProtocol]
+    def boot_protocol
+      Y2Network::BootProtocol.from_name(@config["BOOTPROTO"])
+    end
+
+    # @param[String, Y2Network::BootProtocol]
+    def boot_protocol=(value)
+      value = value.name if value.is_a?(Y2Network::BootProtocol)
+      @config["BOOTPROTO"] = value
     end
 
     # @return [Startmode]

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -70,18 +70,6 @@ module Y2Network
       Yast::LanItems.operation == :add
     end
 
-    # changes internal config keys.
-    # @note always prefer specialized method if available
-    def []=(key, value)
-      @config[key] = value
-    end
-
-    # gets internal config keys.
-    # @note always prefer specialized method if available
-    def [](key)
-      @config[key]
-    end
-
     # saves builder content to backend
     # @ TODO now still LanItems actively query config attribute and write it
     #   down, so here mainly workarounds, but ideally this save should change

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -293,6 +293,16 @@ module Y2Network
       @config["MTU"] = value
     end
 
+    # @return [Array(2)<String,String>] user and group of tunnel
+    def tunnel_user_group
+      [@config["TUNNEL_SET_OWNER"], @config["TUNNEL_SET_GROUP"]]
+    end
+
+    def assign_tunnel_user_group(user, group)
+      @config["TUNNEL_SET_OWNER"] = user
+      @config["TUNNEL_SET_GROUP"] = group
+    end
+
     # Provides stored configuration in sysconfig format
     #
     # @return [Hash<String, String>] where key is sysconfig option and value is the option's value

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -342,7 +342,7 @@ module Y2Network
       return true if !Yast::Arch.is_laptop
       return true if Yast::NetworkService.is_network_manager
       # virtual devices cannot expect any event from ifplugd
-      return true if ["bond", "vlan", "br"].include? type
+      return true if ["bond", "vlan", "br"].include? type.short_name
 
       false
     end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -26,6 +26,7 @@ require "y2firewall/firewalld/interface"
 
 Yast.import "LanItems"
 Yast.import "NetworkInterfaces"
+Yast.import "Netmask"
 
 module Y2Network
   # Collects data from the UI until we have enough of it to create a {Y2Network::Interface}.
@@ -248,6 +249,25 @@ module Y2Network
     # @param [String] value
     def ip_address=(value)
       @config["IPADDR"] = value
+    end
+
+    # @return [String] returns prefix or netmask. prefix in format "/<prefix>"
+    def subnet_prefix
+      if @config["PREFIXLEN"] && !@config["PREFIXLEN"].empty?
+        "/#{@config["PREFIXLEN"]}"
+      else
+        @config["NETMASK"] || ""
+      end
+    end
+
+    # @param [String] value prefix or netmask is accepted. prefix in format "/<prefix>"
+    def subnet_prefix=(value)
+      if value.start_with?("/")
+        @settings["PREFIXLEN"] = value[1..-1]
+      else
+        param = Yast::Netmask.Check6(value) ? "PREFIXLEN" : "NETMASK"
+        @settings[param] = value
+      end
     end
 
     # Gets Maximum Transition Unit

--- a/src/lib/y2network/interface_config_builders/bonding.rb
+++ b/src/lib/y2network/interface_config_builders/bonding.rb
@@ -11,7 +11,7 @@ module Y2Network
         super(type: InterfaceType::BONDING)
 
         # fill mandatory bond option
-        @config["BOND_SLAVES"] = []
+        @slaves = []
       end
 
       # @return [Array<Interface>] list of interfaces usable for the bond device
@@ -32,11 +32,19 @@ module Y2Network
         @bond_options
       end
 
+      def slaves
+        @slaves
+      end
+
+      def slaves=(value)
+        @slaves = value
+      end
+
       # (see Y2Network::InterfaceConfigBuilder#save)
       def save
         super
 
-        Yast::LanItems.bond_slaves = @config["BOND_SLAVES"]
+        Yast::LanItems.bond_slaves = @slaves
         Yast::LanItems.bond_option = bond_options
       end
 

--- a/src/lib/y2network/interface_config_builders/bridge.rb
+++ b/src/lib/y2network/interface_config_builders/bridge.rb
@@ -26,6 +26,16 @@ module Y2Network
         interfaces.all.select { |i| bridgeable?(i) }
       end
 
+      # @return [Array<String>]
+      def ports
+        @config["BRIDGE_PORTS"].split
+      end
+
+      # @param [Array<String>] value
+      def ports=(value)
+        @config["BRIDGE_PORTS"] = value.join(" ")
+      end
+
     private
 
       def interfaces

--- a/src/lib/y2network/interface_config_builders/vlan.rb
+++ b/src/lib/y2network/interface_config_builders/vlan.rb
@@ -11,10 +11,22 @@ module Y2Network
         super(type: InterfaceType::VLAN)
       end
 
+      # @return [Integer]
+      def vlan_id
+        (@config["VLAN_ID"] || "0").to_i
+      end
+
+      # @param [Integer] value
+      def vlan_id=(value)
+        @config["VLAN_ID"] = value.to_s
+      end
+
+      # @return [String]
       def etherdevice
         @config["ETHERDEVICE"]
       end
 
+      # @param [String] value
       def etherdevice=(value)
         @config["ETHERDEVICE"] = value
       end

--- a/src/lib/y2network/startmode.rb
+++ b/src/lib/y2network/startmode.rb
@@ -17,11 +17,15 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast"
+
 module Y2Network
   # Base class for startmode. It allows to create new one according to name or anlist all.
   # Its child have to define `to_human_string` method and possibly its own specialized attributes.
   # TODO: as backends differs, we probably also need to have flag there to which backends mode exists
   class Startmode
+    include Yast::Logger
+
     attr_reader :name
     alias_method :to_s, :name
 
@@ -34,6 +38,9 @@ module Y2Network
       # avoid circular dependencies
       require "y2network/startmodes"
       Startmodes.const_get(name.capitalize).new
+    rescue NameError => e
+      log.error "Invalid startmode #{e.inspect}"
+      nil
     end
 
     def self.all

--- a/src/lib/y2network/widgets/bond_slave.rb
+++ b/src/lib/y2network/widgets/bond_slave.rb
@@ -68,7 +68,7 @@ module Y2Network
 
       # Default function to init the value of slave devices box for bonding.
       def init
-        slaves = @settings["BOND_SLAVES"] || []
+        slaves = @settings.slaves
         # TODO: use def items, but problem now is that slave_items returns term and not array
         items = slave_items_from(
           @settings.bondable_interfaces.map(&:name),
@@ -95,7 +95,7 @@ module Y2Network
 
       # Default function to store the value of slave devices box.
       def store
-        @settings["BOND_SLAVES"] = selected_items
+        @settings.slaves = selected_items
       end
 
       # Validates created bonding. Currently just prevent the user to create a

--- a/src/lib/y2network/widgets/boot_protocol.rb
+++ b/src/lib/y2network/widgets/boot_protocol.rb
@@ -106,25 +106,17 @@ module Y2Network
           Yast::UI.ChangeWidget(
             Id(:bootproto_ipaddr),
             :Value,
-            @settings["IPADDR"] || ""
+            @settings.ip_address
           )
-          if @settings["PREFIXLEN"] && !@settings["PREFIXLEN"].empty?
-            Yast::UI.ChangeWidget(
-              Id(:bootproto_netmask),
-              :Value,
-              "/#{@settings["PREFIXLEN"]}"
-            )
-          else
-            Yast::UI.ChangeWidget(
-              Id(:bootproto_netmask),
-              :Value,
-              @settings["NETMASK"] || ""
-            )
-          end
+          Yast::UI.ChangeWidget(
+            Id(:bootproto_netmask),
+            :Value,
+            @settings.subnet_prefix
+          )
           Yast::UI.ChangeWidget(
             Id(:bootproto_hostname),
             :Value,
-            @settings["HOSTNAME"]
+            @settings.hostname
           )
         when Y2Network::BootProtocol::DHCP
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_dynamic)
@@ -186,7 +178,8 @@ module Y2Network
 
       def store
         # FIXME: this value reset should be in backend in general not Yast::UI responsibility
-        @settings["IPADDR"] = @settings["NETMASK"] = @settings["PREFIXLEN"] = ""
+        @settings.ip_address = ""
+        @settings.subnet_prefix = ""
         case value
         when :bootproto_none
           bootproto = "none"
@@ -196,15 +189,9 @@ module Y2Network
           @settings.boot_protocol = bootproto
         when :bootproto_static
           @settings.boot_protocol = "static"
-          @settings["IPADDR"] = Yast::UI.QueryWidget(:bootproto_ipaddr, :Value)
-          mask = Yast::UI.QueryWidget(:bootproto_netmask, :Value)
-          if mask.start_with?("/")
-            @settings["PREFIXLEN"] = mask[1..-1]
-          else
-            param = Yast::Netmask.Check6(mask) ? "PREFIXLEN" : "NETMASK"
-            @settings[param] = mask
-          end
-          @settings["HOSTNAME"] = Yast::UI.QueryWidget(:bootproto_hostname, :Value)
+          @settings.ip_address = Yast::UI.QueryWidget(:bootproto_ipaddr, :Value)
+          @settings.subnet_prefix = Yast::UI.QueryWidget(:bootproto_netmask, :Value)
+          @settings.hostname = Yast::UI.QueryWidget(:bootproto_hostname, :Value)
         when :bootproto_dynamic
           case Yast::UI.QueryWidget(:bootproto_dyn, :Value)
           when :bootproto_dhcp

--- a/src/lib/y2network/widgets/boot_protocol.rb
+++ b/src/lib/y2network/widgets/boot_protocol.rb
@@ -1,7 +1,7 @@
 require "yast"
 require "cwm/custom_widget"
 
-require "y2network/interface_type"
+require "y2network/boot_protocol"
 
 Yast.import "DNS"
 Yast.import "Hostname"
@@ -100,8 +100,8 @@ module Y2Network
           )
         end
 
-        case @settings["BOOTPROTO"]
-        when "static"
+        case @settings.boot_protocol
+        when Y2Network::BootProtocol::STATIC
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_static)
           Yast::UI.ChangeWidget(
             Id(:bootproto_ipaddr),
@@ -126,27 +126,27 @@ module Y2Network
             :Value,
             @settings["HOSTNAME"]
           )
-        when "dhcp"
+        when Y2Network::BootProtocol::DHCP
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_dynamic)
           Yast::UI.ChangeWidget(Id(:bootproto_dhcp_mode), :Value, :bootproto_dhcp_both)
           Yast::UI.ChangeWidget(Id(:bootproto_dyn), :Value, :bootproto_dhcp)
-        when "dhcp4"
+        when Y2Network::BootProtocol::DHCP4
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_dynamic)
           Yast::UI.ChangeWidget(Id(:bootproto_dhcp_mode), :Value, :bootproto_dhcp_v4)
           Yast::UI.ChangeWidget(Id(:bootproto_dyn), :Value, :bootproto_dhcp)
-        when "dhcp6"
+        when Y2Network::BootProtocol::DHCP6
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_dynamic)
           Yast::UI.ChangeWidget(Id(:bootproto_dhcp_mode), :Value, :bootproto_dhcp_v6)
           Yast::UI.ChangeWidget(Id(:bootproto_dyn), :Value, :bootproto_dhcp)
-        when "dhcp+autoip"
+        when Y2Network::BootProtocol::DHCP_AUTOIP
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_dynamic)
           Yast::UI.ChangeWidget(Id(:bootproto_dyn), :Value, :bootproto_dhcp_auto)
-        when "autoip"
+        when Y2Network::BootProtocol::AUTOIP
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_dynamic)
           Yast::UI.ChangeWidget(Id(:bootproto_dyn), :Value, :bootproto_auto)
-        when "none"
+        when Y2Network::BootProtocol::NONE
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_none)
-        when "ibft"
+        when Y2Network::BootProtocol::IBFT
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_none)
           Yast::UI.ChangeWidget(Id(:bootproto_ibft), :Value, true)
         end
@@ -193,9 +193,9 @@ module Y2Network
           if ibft_available?
             bootproto = Yast::UI.QueryWidget(Id(:bootproto_ibft), :Value) ? "ibft" : "none"
           end
-          @settings["BOOTPROTO"] = bootproto
+          @settings.boot_protocol = bootproto
         when :bootproto_static
-          @settings["BOOTPROTO"] = "static"
+          @settings.boot_protocol = "static"
           @settings["IPADDR"] = Yast::UI.QueryWidget(:bootproto_ipaddr, :Value)
           mask = Yast::UI.QueryWidget(:bootproto_netmask, :Value)
           if mask.start_with?("/")
@@ -210,18 +210,18 @@ module Y2Network
           when :bootproto_dhcp
             case Yast::UI.QueryWidget(:bootproto_dhcp_mode, :Value)
             when :bootproto_dhcp_both
-              @settings["BOOTPROTO"] = "dhcp"
+              @settings.boot_protocol = "dhcp"
             when :bootproto_dhcp_v4
-              @settings["BOOTPROTO"] = "dhcp4"
+              @settings.boot_protocol = "dhcp4"
             when :bootproto_dhcp_v6
-              @settings["BOOTPROTO"] = "dhcp6"
+              @settings.boot_protocol = "dhcp6"
             else
               raise "Unexpected dhcp mode value #{Yast::UI.QueryWidget(:bootproto_dhcp_mode, :Value).inspect}"
             end
           when :bootproto_dhcp_auto
-            @settings["BOOTPROTO"] = "dhcp+autoip"
+            @settings.boot_protocol = "dhcp+autoip"
           when :bootproto_auto
-            @settings["BOOTPROTO"] = "autoip"
+            @settings.boot_protocol = "autoip"
           else
             raise "Unexpected dynamic mode value #{Yast::UI.QueryWidget(:bootproto_dyn, :Value).inspect}"
           end

--- a/src/lib/y2network/widgets/bridge_ports.rb
+++ b/src/lib/y2network/widgets/bridge_ports.rb
@@ -11,6 +11,7 @@ module Y2Network
     class BridgePorts < CWM::MultiSelectionBox
       include SlaveItems
 
+      # @param [Y2Network::InterfaceConfigBuilders::Bridge] settings
       def initialize(settings)
         textdomain "network"
         @settings = settings
@@ -27,7 +28,7 @@ module Y2Network
 
       # Default function to init the value of slave devices box for bridging.
       def init
-        br_ports = @settings["BRIDGE_PORTS"].split
+        br_ports = @settings.ports
         items = slave_items_from(
           @settings.bridgeable_interfaces.map(&:name),
           br_ports
@@ -39,8 +40,7 @@ module Y2Network
 
       # Default function to store the value of slave devices box.
       def store
-        # TODO: fix it in builder to use array and not space separated string
-        @settings["BRIDGE_PORTS"] = value.join(" ")
+        @settings.ports = value
       end
 
       # Validates created bridge. Currently just prevent the user to create a

--- a/src/lib/y2network/widgets/ethtools_options.rb
+++ b/src/lib/y2network/widgets/ethtools_options.rb
@@ -25,11 +25,11 @@ module Y2Network
       end
 
       def init
-        self.value = @settings["ETHTOOL_OPTIONS"]
+        self.value = @settings.ethtool_options
       end
 
       def store
-        @settings["ETHTOOL_OPTIONS"] = value
+        @settings.ethtool_options = value
       end
     end
   end

--- a/src/lib/y2network/widgets/ip_address.rb
+++ b/src/lib/y2network/widgets/ip_address.rb
@@ -27,11 +27,11 @@ module Y2Network
       end
 
       def init
-        self.value = @settings["IPADDR"]
+        self.value = @settings.ip_address
       end
 
       def store
-        @settings["IPADDR"] = value
+        @settings.ip_address = value
       end
 
       def validate

--- a/src/lib/y2network/widgets/mtu.rb
+++ b/src/lib/y2network/widgets/mtu.rb
@@ -34,16 +34,16 @@ module Y2Network
       end
 
       def items
-        @settings["IFCFGTYPE"] == "ib" ? ipoib_items : default_items
+        @settings.type.infiniband? ? ipoib_items : default_items
       end
 
       def init
         change_items(items)
-        self.value = @settings["MTU"]
+        self.value = @settings.mtu
       end
 
       def store
-        @settings["MTU"] = value
+        @settings.mtu = value
       end
     end
   end

--- a/src/lib/y2network/widgets/netmask.rb
+++ b/src/lib/y2network/widgets/netmask.rb
@@ -28,21 +28,11 @@ module Y2Network
       end
 
       def init
-        self.value = if @settings["PREFIXLEN"] && !@settings["PREFIXLEN"].empty?
-          "/#{@settings["PREFIXLEN"]}"
-        else
-          @settings["NETMASK"] || ""
-        end
+        self.value = @settings.subnet_prefix
       end
 
       def store
-        mask = value
-        if mask.start_with?("/")
-          @settings["PREFIXLEN"] = mask[1..-1]
-        else
-          param = Yast::Netmask.Check6(mask) ? "PREFIXLEN" : "NETMASK"
-          @settings[param] = mask
-        end
+        @settings.subnet_prefix = value
       end
 
       def validate

--- a/src/lib/y2network/widgets/remote_ip.rb
+++ b/src/lib/y2network/widgets/remote_ip.rb
@@ -25,11 +25,11 @@ module Y2Network
       end
 
       def init
-        self.value = @settings["REMOTEIP"]
+        self.value = @settings.remote_ip
       end
 
       def store
-        @settings["REMOTEIP"] = value
+        @settings.remote_ip = value
       end
 
       def validate

--- a/src/lib/y2network/widgets/tunnel.rb
+++ b/src/lib/y2network/widgets/tunnel.rb
@@ -26,14 +26,17 @@ module Y2Network
 
       def init
         log.info "init tunnel with #{@settings.inspect}"
+        owner, group = @settings.tunnel_user_group
 
-        Yast::UI.ChangeWidget(:tunnel_owner, :Value, @settings["TUNNEL_SET_OWNER"] || "")
-        Yast::UI.ChangeWidget(:tunnel_group, :Value, @settings["TUNNEL_SET_GROUP"] || "")
+        Yast::UI.ChangeWidget(:tunnel_owner, :Value, owner || "")
+        Yast::UI.ChangeWidget(:tunnel_group, :Value, group || "")
       end
 
       def store
-        @settings["TUNNEL_SET_OWNER"] = Yast::UI.QueryWidget(:tunnel_owner, :Value)
-        @settings["TUNNEL_SET_GROUP"] = Yast::UI.QueryWidget(:tunnel_group, :Value)
+        @settings.assign_tunnel_user_group(
+          Yast::UI.QueryWidget(:tunnel_owner, :Value),
+          Yast::UI.QueryWidget(:tunnel_group, :Value)
+        )
       end
     end
   end

--- a/src/lib/y2network/widgets/udev_rules.rb
+++ b/src/lib/y2network/widgets/udev_rules.rb
@@ -23,7 +23,6 @@ module Y2Network
       end
 
       def init
-        # TODO: get it from settings
         self.value = @settings.udev_name
       end
 

--- a/src/lib/y2network/widgets/vlan_id.rb
+++ b/src/lib/y2network/widgets/vlan_id.rb
@@ -19,11 +19,11 @@ module Y2Network
       end
 
       def init
-        self.value = (@config["VLAN_ID"] || "0").to_i
+        self.value = @config.vlan_id
       end
 
       def store
-        @config["VLAN_ID"] = value.to_s
+        @config.vlan_id = value.to_s
       end
 
       def minimum

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -1866,10 +1866,10 @@ module Yast
         Builtins.y2debug("%1", NetworkInterfaces.ConcealSecrets1(newdev))
 
         # configure bridge ports
-        bridge_ports = builder["BRIDGE_PORTS"]
-        if bridge_ports
+        if builder.type.bridge?
+          bridge_ports = builder.ports
           log.info "Configuring bridge ports #{bridge_ports} for: #{ifcfg_name}"
-          bridge_ports.split.each { |bp| configure_as_bridge_port(bp) }
+          bridge_ports.each { |bp| configure_as_bridge_port(bp) }
         end
 
         SetModified()
@@ -1979,8 +1979,8 @@ module Yast
       builder = Y2Network::InterfaceConfigBuilder.for(type)
 
       builder.mtu = "1492" if Arch.s390 && Builtins.contains(["lcs", "eth"], type)
-      builder["IPADDR"] = ""
-      builder["NETMASK"] = ""
+      builder.ip_address = ""
+      builder.subnet_prefix = ""
       builder.boot_protocol = Y2Network::BootProtocol::DHCP
 
       # see bsc#176804

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -1978,15 +1978,15 @@ module Yast
       type = Items().fetch(item_id, {}).fetch("hwinfo", {})[type]
       builder = Y2Network::InterfaceConfigBuilder.for(type)
 
-      builder["MTU"] = "1492" if Arch.s390 && Builtins.contains(["lcs", "eth"], type)
+      builder.mtu = "1492" if Arch.s390 && Builtins.contains(["lcs", "eth"], type)
       builder["IPADDR"] = ""
       builder["NETMASK"] = ""
-      builder["BOOTPROTO"] = "dhcp"
+      builder.boot_protocol = Y2Network::BootProtocol::DHCP
 
       # see bsc#176804
       devicegraph = Y2Storage::StorageManager.instance.staging
       if devicegraph.filesystem_in_network?("/")
-        builder["STARTMODE"] = "nfsroot"
+        builder.startmode = "nfsroot"
         Builtins.y2milestone("startmode nfsroot")
       end
 

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -1970,7 +1970,7 @@ module Yast
       nil
     end
 
-    PROPOSED_PPPOE_MTU = "1492" # suggested value for PPPoE
+    PROPOSED_PPPOE_MTU = "1492".freeze # suggested value for PPPoE
     # A default configuration for device when installer needs to configure it
     def ProposeItem(item_id)
       Builtins.y2milestone("Propose configuration for %1", GetDeviceName(item_id))

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -1970,6 +1970,7 @@ module Yast
       nil
     end
 
+    PROPOSED_PPPOE_MTU = "1492" # suggested value for PPPoE
     # A default configuration for device when installer needs to configure it
     def ProposeItem(item_id)
       Builtins.y2milestone("Propose configuration for %1", GetDeviceName(item_id))
@@ -1978,7 +1979,7 @@ module Yast
       type = Items().fetch(item_id, {}).fetch("hwinfo", {})[type]
       builder = Y2Network::InterfaceConfigBuilder.for(type)
 
-      builder.mtu = "1492" if Arch.s390 && Builtins.contains(["lcs", "eth"], type)
+      builder.mtu = PROPOSED_PPPOE_MTU if Arch.s390 && Builtins.contains(["lcs", "eth"], type)
       builder.ip_address = ""
       builder.subnet_prefix = ""
       builder.boot_protocol = Y2Network::BootProtocol::DHCP

--- a/test/y2network/interface_config_builder_test.rb
+++ b/test/y2network/interface_config_builder_test.rb
@@ -124,7 +124,7 @@ describe Y2Network::InterfaceConfigBuilder do
           # check for virtual device type is done via Builtins.contains. I don't
           # want to stub it because it requires default stub value definition for
           # other calls of the function. It might have unexpected inpacts.
-          allow(config_builder).to receive(:type) { "bond" }
+          allow(config_builder).to receive(:type).and_return(Y2Network::InterfaceType::BONDING)
 
           result = config_builder.device_sysconfig["STARTMODE"]
           expect(result).to be_eql expected_startmode

--- a/test/y2network/widgets/bond_options_test.rb
+++ b/test/y2network/widgets/bond_options_test.rb
@@ -21,9 +21,11 @@ require_relative "../../test_helper"
 require "cwm/rspec"
 
 require "y2network/widgets/bond_options"
+require "y2network/interface_config_builder"
 
 describe Y2Network::Widgets::BondOptions do
-  subject { described_class.new({}) }
+  let(:builder) { Y2Network::InterfaceConfigBuilder.for("bond") }
+  subject { described_class.new(builder) }
 
   include_examples "CWM::ComboBox"
 end

--- a/test/y2network/widgets/boot_protocol_test.rb
+++ b/test/y2network/widgets/boot_protocol_test.rb
@@ -51,10 +51,10 @@ describe Y2Network::Widgets::BootProtocol do
 
     context "static configuration" do
       before do
-        builder["BOOTPROTO"] = "static"
-        builder["IPADDR"] = "10.5.0.6"
-        builder["PREFIXLEN"] = "24"
-        builder["HOSTNAME"] = "pepa"
+        builder.boot_protocol = "static"
+        builder.ip_address = "10.5.0.6"
+        builder.subnet_prefix = "24"
+        builder.hostname = "pepa"
         allow(subject).to receive(:value).and_return(:bootproto_static)
         allow(Yast::UI).to receive(:QueryWidget).and_return("pepa")
       end
@@ -86,7 +86,7 @@ describe Y2Network::Widgets::BootProtocol do
 
     context "dhcp configuration" do
       before do
-        builder["BOOTPROTO"] = "dhcp"
+        builder.boot_protocol = "dhcp"
         allow(subject).to receive(:value).and_return(:bootproto_dynamic)
       end
 
@@ -97,7 +97,7 @@ describe Y2Network::Widgets::BootProtocol do
 
     context "dhcp4 configuration" do
       before do
-        builder["BOOTPROTO"] = "dhcp4"
+        builder.boot_protocol = "dhcp4"
         allow(subject).to receive(:value).and_return(:bootproto_dynamic)
       end
 
@@ -108,7 +108,7 @@ describe Y2Network::Widgets::BootProtocol do
 
     context "dhcp6 configuration" do
       before do
-        builder["BOOTPROTO"] = "dhcp6"
+        builder.boot_protocol = "dhcp6"
         allow(subject).to receive(:value).and_return(:bootproto_dynamic)
       end
 
@@ -119,7 +119,7 @@ describe Y2Network::Widgets::BootProtocol do
 
     context "dhcp+autoip configuration" do
       before do
-        builder["BOOTPROTO"] = "dhcp+autoip"
+        builder.boot_protocol = "dhcp+autoip"
         allow(subject).to receive(:value).and_return(:bootproto_dynamic)
       end
 
@@ -130,7 +130,7 @@ describe Y2Network::Widgets::BootProtocol do
 
     context "autoip configuration" do
       before do
-        builder["BOOTPROTO"] = "autoip"
+        builder.boot_protocol = "autoip"
         allow(subject).to receive(:value).and_return(:bootproto_dynamic)
       end
 
@@ -141,7 +141,7 @@ describe Y2Network::Widgets::BootProtocol do
 
     context "none configuration" do
       before do
-        builder["BOOTPROTO"] = "none"
+        builder.boot_protocol = "none"
       end
 
       it "does not crash" do
@@ -151,7 +151,7 @@ describe Y2Network::Widgets::BootProtocol do
 
     context "ibft configuration" do
       before do
-        builder["BOOTPROTO"] = "ibft"
+        builder.boot_protocol = "ibft"
       end
 
       it "does not crash" do
@@ -173,7 +173,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["BOOTPROTO"]).to eq "ibft"
+        expect(builder.boot_protocol.name).to eq "ibft"
       end
 
       it "sets bootproto to none if ibft is not selected" do
@@ -181,7 +181,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["BOOTPROTO"]).to eq "none"
+        expect(builder.boot_protocol.name).to eq "none"
       end
     end
 
@@ -195,7 +195,7 @@ describe Y2Network::Widgets::BootProtocol do
       it "sets bootproto to static" do
         subject.store
 
-        expect(builder["BOOTPROTO"]).to eq "static"
+        expect(builder.boot_protocol.name).to eq "static"
       end
 
       it "sets ipaddr to value of ip address widget" do
@@ -203,7 +203,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["IPADDR"]).to eq "10.100.0.1"
+        expect(builder.ip_address).to eq "10.100.0.1"
       end
 
       it "sets hostname to value of hostname widget" do
@@ -211,7 +211,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["HOSTNAME"]).to eq "test.suse.cz"
+        expect(builder.hostname).to eq "test.suse.cz"
       end
 
       it "sets prefixlen when value of netmast start with '/'" do
@@ -219,7 +219,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["PREFIXLEN"]).to eq "24"
+        expect(builder.subnet_prefix).to eq "/24"
       end
 
       it "sets prefixlen for ipv6" do
@@ -227,7 +227,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["PREFIXLEN"]).to eq "124"
+        expect(builder.subnet_prefix).to eq "/124"
       end
 
       it "sets netmask for ipv4 netmask value" do
@@ -235,7 +235,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["NETMASK"]).to eq "255.255.0.0"
+        expect(builder.subnet_prefix).to eq "255.255.0.0"
       end
     end
 
@@ -255,7 +255,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["BOOTPROTO"]).to eq "dhcp"
+        expect(builder.boot_protocol.name).to eq "dhcp"
       end
 
       it "sets bootproto to dhcp4 when dhcp for ipv4 only is selected" do
@@ -266,7 +266,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["BOOTPROTO"]).to eq "dhcp4"
+        expect(builder.boot_protocol.name).to eq "dhcp4"
       end
 
       it "sets bootproto to dhcp6 when dhcp for ipv6 only is selected" do
@@ -277,7 +277,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["BOOTPROTO"]).to eq "dhcp6"
+        expect(builder.boot_protocol.name).to eq "dhcp6"
       end
 
       it "sets bootproto to dhcp+autoip when dhcp and zeroconf is selected" do
@@ -286,7 +286,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["BOOTPROTO"]).to eq "dhcp+autoip"
+        expect(builder.boot_protocol.name).to eq "dhcp+autoip"
       end
 
       it "sets bootproto to autoip when zeroconf is selected" do
@@ -295,7 +295,7 @@ describe Y2Network::Widgets::BootProtocol do
 
         subject.store
 
-        expect(builder["BOOTPROTO"]).to eq "autoip"
+        expect(builder.boot_protocol.name).to eq "autoip"
       end
     end
   end

--- a/test/y2network/widgets/ifplugd_priority_test.rb
+++ b/test/y2network/widgets/ifplugd_priority_test.rb
@@ -26,7 +26,7 @@ require "y2network/interface_config_builder"
 describe Y2Network::Widgets::IfplugdPriority do
   let(:builder) do
     res = Y2Network::InterfaceConfigBuilder.for("eth")
-    res["IFPLUGD_PRIORITY"] = "50"
+    res.ifplugd_priority = 50
     res
   end
   subject { described_class.new(builder) }
@@ -59,7 +59,7 @@ describe Y2Network::Widgets::IfplugdPriority do
 
       subject.store
 
-      expect(builder["IFPLUGD_PRIORITY"]).to eq "20"
+      expect(builder.ifplugd_priority).to eq 20
     end
   end
 end

--- a/test/y2network/widgets/mtu_test.rb
+++ b/test/y2network/widgets/mtu_test.rb
@@ -21,9 +21,11 @@ require_relative "../../test_helper"
 require "cwm/rspec"
 
 require "y2network/widgets/mtu"
+require "y2network/interface_config_builder"
 
 describe Y2Network::Widgets::MTU do
-  subject { described_class.new({}) }
+  let(:builder) { Y2Network::InterfaceConfigBuilder.for("eth") }
+  subject { described_class.new(builder) }
 
   include_examples "CWM::ComboBox"
 end


### PR DESCRIPTION
goal of this pull request is to remove direct access to `@config` in InterfaceConfigBuilder. This will allow to modify InterfaceConfigBuilder to try e.g. store to both ConnectionConfig and LanItems in easier way.