### PR TITLE
network-ng: use connection config writers

### DIFF
--- a/src/include/network/lan/cmdline.rb
+++ b/src/include/network/lan/cmdline.rb
@@ -215,7 +215,7 @@ module Yast
       LanItems.current = getItem(options, config)
 
       config = Lan.yast_config.copy
-      connection_config = config.connections.find { |c| c.name == LanItems.GetCurrentName }
+      connection_config = config.connections.by_name(LanItems.GetCurrentName)
       builder = Y2Network::InterfaceConfigBuilder.for(LanItems.GetCurrentType(), config: connection_config)
       builder.name = LanItems.GetCurrentName()
       LanItems.SetItem(builder: builder)

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -310,14 +310,14 @@ module Yast
 
       current = LanItems.current
       config = Lan.yast_config.copy
-      connection_config = config.connections.find { |c| c.name == LanItems.GetCurrentName }
+      connection_config = config.connections.by_name(LanItems.GetCurrentName)
       Yast.y2milestone("update slaves for #{current}:#{LanItems.GetCurrentName}:#{LanItems.GetCurrentType}")
       master_builder = Y2Network::InterfaceConfigBuilder.for(LanItems.GetCurrentType(), config: connection_config)
       master_builder.name = LanItems.GetCurrentName()
 
       Lan.autoconf_slaves.each do |dev|
         if LanItems.FindAndSelect(dev)
-          connection_config = config.connections.find { |c| c.name == LanItems.GetCurrentName }
+          connection_config = config.connections.by_name(LanItems.GetCurrentName)
           builder = Y2Network::InterfaceConfigBuilder.for(LanItems.GetCurrentType(), config: connection_config)
           builder.name = LanItems.GetCurrentName()
           LanItems.SetItem(builder: builder)
@@ -415,7 +415,7 @@ module Yast
         when :edit
           if LanItems.IsCurrentConfigured
             config = Lan.yast_config.copy
-            connection_config = config.connections.find { |c| c.name == LanItems.GetCurrentName }
+            connection_config = config.connections.by_name(LanItems.GetCurrentName)
             builder = Y2Network::InterfaceConfigBuilder.for(LanItems.GetCurrentType(), config: connection_config)
             builder.name = LanItems.GetCurrentName()
             LanItems.SetItem(builder: builder)

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -21,6 +21,7 @@ require "y2network/config_reader"
 require "y2network/routing"
 require "y2network/dns"
 require "y2network/interfaces_collection"
+require "y2network/connection_configs_collection"
 
 module Y2Network
   # This class represents the current network configuration including interfaces,
@@ -38,7 +39,7 @@ module Y2Network
   class Config
     # @return [InterfacesCollection]
     attr_accessor :interfaces
-    # @return [Array<ConnectionConfig>]
+    # @return [ConnectionConfigsCollection]
     attr_accessor :connections
     # @return [Routing] Routing configuration
     attr_accessor :routing
@@ -87,11 +88,13 @@ module Y2Network
 
     # Constructor
     #
-    # @param interfaces [InterfacesCollection] List of interfaces
-    # @param routing    [Routing] Object with routing configuration
-    # @param dns        [DNS] Object with DNS configuration
-    # @param source     [Symbol] Configuration source
-    def initialize(interfaces: InterfacesCollection.new, connections: [], routing: Routing.new, dns: DNS.new, source:)
+    # @param interfaces  [InterfacesCollection] List of interfaces
+    # @param connections [ConnectionConfigsCollection] List of connection configurations
+    # @param routing     [Routing] Object with routing configuration
+    # @param dns         [DNS] Object with DNS configuration
+    # @param source      [Symbol] Configuration source
+    def initialize(interfaces: InterfacesCollection.new, connections: ConnectionConfigsCollection.new,
+      routing: Routing.new, dns: DNS.new, source:)
       @interfaces = interfaces
       @connections = connections
       @routing = routing

--- a/src/lib/y2network/connection_config.rb
+++ b/src/lib/y2network/connection_config.rb
@@ -1,0 +1,27 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/connection_config/base"
+require "y2network/connection_config/bonding"
+require "y2network/connection_config/dummy"
+require "y2network/connection_config/ethernet"
+require "y2network/connection_config/infiniband"
+require "y2network/connection_config/ip_config"
+require "y2network/connection_config/vlan"
+require "y2network/connection_config/wireless"

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -18,6 +18,8 @@
 # find current contact information at www.suse.com.
 
 require "y2network/interface_type"
+require "y2network/boot_protocol"
+require "y2network/startmode"
 
 module Y2Network
   module ConnectionConfig
@@ -52,6 +54,8 @@ module Y2Network
       # Constructor
       def initialize
         @ip_configs = []
+        @bootproto = BootProtocol::STATIC
+        @startmode = Startmode.create("manual")
       end
 
       # Returns the connection type

--- a/src/lib/y2network/connection_configs_collection.rb
+++ b/src/lib/y2network/connection_configs_collection.rb
@@ -52,5 +52,15 @@ module Y2Network
     def by_name(name)
       connection_configs.find { |c| c.name == name }
     end
+
+    # Updates a connection configuration
+    #
+    # @note It uses the name to do the matching.
+    #
+    # @param connection_config [ConnectionConfig::Base] New connection configuration object
+    def update(connection_config)
+      idx = connection_configs.find_index { |c| c.name == connection_config.name }
+      connection_configs[idx] = connection_config if idx
+    end
   end
 end

--- a/src/lib/y2network/connection_configs_collection.rb
+++ b/src/lib/y2network/connection_configs_collection.rb
@@ -36,7 +36,7 @@ module Y2Network
     attr_reader :connection_configs
     alias_method :to_a, :connection_configs
 
-    def_delegators :@connection_configs, :each, :push, :<<, :reject!, :map, :flat_map, :any?
+    def_delegators :@connection_configs, :each, :push, :<<, :reject!, :map, :flat_map, :any?, :size
 
     # Constructor
     #
@@ -53,14 +53,28 @@ module Y2Network
       connection_configs.find { |c| c.name == name }
     end
 
-    # Updates a connection configuration
+    # Adds or updates a connection configuration
     #
     # @note It uses the name to do the matching.
     #
     # @param connection_config [ConnectionConfig::Base] New connection configuration object
-    def update(connection_config)
+    def add_or_update(connection_config)
       idx = connection_configs.find_index { |c| c.name == connection_config.name }
-      connection_configs[idx] = connection_config if idx
+      if idx
+        connection_configs[idx] = connection_config
+      else
+        connection_configs << connection_config
+      end
+    end
+
+    # Removes a connection configuration
+    #
+    # @note It uses the name to do the matching.
+    #
+    # @param connection_config [ConnectionConfig::Base,String] Connection configuration object or name
+    def remove(connection_config)
+      name = connection_config.respond_to?(:name) ? connection_config.name : connection_config
+      connection_configs.reject! { |c| c.name == name }
     end
   end
 end

--- a/src/lib/y2network/connection_configs_collection.rb
+++ b/src/lib/y2network/connection_configs_collection.rb
@@ -1,0 +1,56 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "forwardable"
+
+module Y2Network
+  # A container for connection configurations objects.
+  #
+  # @example Create a new collection
+  #   eth0 = Y2Network::ConnectionConfig::Ethernet.new
+  #   collection = Y2Network::ConnectionConfigsCollection.new([eth0])
+  #
+  # @example Find a connection config using its name
+  #   config = collection.by_name("eth0") #=> #<Y2Network::ConnectionConfig::Ethernet:0x...>
+  class ConnectionConfigsCollection
+    extend Forwardable
+    include Yast::Logger
+
+    attr_reader :connection_configs
+    alias_method :to_a, :connection_configs
+
+    def_delegators :@connection_configs, :each, :push, :<<, :reject!, :map, :flat_map, :any?
+
+    # Constructor
+    #
+    # @param connection_configs [Array<ConnectionConfig>] List of connection configurations
+    def initialize(connection_configs = [])
+      @connection_configs = connection_configs
+    end
+
+    # Returns a connection configuration with the given name if present
+    #
+    # @param name [String] Connection name
+    # @return [ConnectionConfig::Base,nil] Connection config with the given name or nil if not found
+    def by_name(name)
+      connection_configs.find { |c| c.name == name }
+    end
+  end
+end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -308,7 +308,8 @@ module Y2Network
     def ip_address
       old = @config["IPADDR"]
 
-      default = @connection_config.ip_configs.find { |c| c.id == "" }
+      # FIXME: workaround to remove when primary ip config is separated from the rest
+      default = (@connection_config.ip_configs || []).find { |c| c.id == "" }
       new_ = if default
         default.address.address
       else
@@ -337,7 +338,7 @@ module Y2Network
       else
         @config["NETMASK"] || ""
       end
-      default = @connection_config.ip_configs.find { |c| c.id == "" }
+      default = (@connection_config.ip_configs || []).find { |c| c.id == "" }
       new_ = if default
         "/" + default.address.prefix.to_s
       else

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -92,7 +92,7 @@ module Y2Network
         Yast::LanItems.driver_options[driver] = driver_options
       end
 
-      Yast::Lan.yast_config.connections.update(@connection_config)
+      Yast::Lan.yast_config.connections.add_or_update(@connection_config)
 
       # create new instance as name can change
       firewall_interface = Y2Firewall::Firewalld::Interface.new(name)

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -92,6 +92,8 @@ module Y2Network
         Yast::LanItems.driver_options[driver] = driver_options
       end
 
+      Yast::Lan.yast_config.connections.update(@connection_config)
+
       # create new instance as name can change
       firewall_interface = Y2Firewall::Firewalld::Interface.new(name)
       if Y2Firewall::Firewalld.instance.installed?

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -17,31 +17,28 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast"
 require "y2network/interface"
 require "forwardable"
 
 module Y2Network
-  # A container for network devices. In the end should implement methods for mass operations over
-  # network interfaces like old LanItems::find_dhcp_ifaces.
+  # A container for network devices.
   #
-  # @example Create a new collection
-  #   eth0 = Y2Network::Interface.new("eth0")
-  #   collection = Y2Network::InterfacesCollection.new(eth0)
+  # Objects of this class are able to keep a list of interfaces and perform simple queries
+  # on such a list. In the end should implement methods for mass operations over network
+  # interfaces like old LanItems::find_dhcp_ifaces.
+  #
+  # @example Finding an interface by its name
+  #   interfaces = Y2Network::InterfacesCollection.new([eth0, wlan0])
+  #   interfaces.by_name("wlan0") # => wlan0
   #
   # @example Find an interface using its name
   #   iface = collection.by_name("eth0") #=> #<Y2Network::Interface:0x...>
+  #
+  # @example FIXME (not implemented yet). For the future, we are aiming at this kind of API.
+  #   interfaces = Y2Network::InterfacesCollection.new([eth0, wlan0])
+  #   interfaces.of_type(:eth).to_a # => [eth0]
   class InterfacesCollection
-    # Objects of this class are able to keep a list of interfaces and perform simple queries
-    # on such a list.
-    #
-    # @example Finding an interface by its name
-    #   interfaces = Y2Network::InterfacesCollection.new([eth0, wlan0])
-    #   interfaces.by_name("wlan0") # => wlan0
-    #
-    # @example FIXME (not implemented yet). For the future, we are aiming at this kind of API.
-    #   interfaces = Y2Network::InterfacesCollection.new([eth0, wlan0])
-    #   interfaces.of_type(:eth).to_a # => [eth0]
-
     extend Forwardable
     include Yast::Logger
 
@@ -60,7 +57,7 @@ module Y2Network
 
     # Returns an interface with the given name if present
     #
-    # @todo It uses the hardware's name as a fallback if interface's name is not set
+    # @note It uses the hardware's name as a fallback if interface's name is not set
     #
     # @param name [String] interface name ("eth0", "br1", ...)
     # @return [Interface,nil] Interface with the given name or nil if not found

--- a/src/lib/y2network/sysconfig/interface_file.rb
+++ b/src/lib/y2network/sysconfig/interface_file.rb
@@ -328,7 +328,7 @@ module Y2Network
       #
       # @return [Array<String>] name of keys that are included in the file
       def defined_variables
-        @defined_variables ||= Yast::SCR.Dir(Yast::Path.new(".network.value.\"#{interface}\""))
+        @defined_variables ||= Yast::SCR.Dir(Yast::Path.new(".network.value.\"#{interface}\"")) || []
       end
 
       # Fetches the value for a given key

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -24,6 +24,8 @@ require "y2network/virtual_interface"
 require "y2network/physical_interface"
 require "y2network/fake_interface"
 require "y2network/sysconfig/connection_config_reader"
+require "y2network/interfaces_collection"
+require "y2network/connection_configs_collection"
 
 Yast.import "LanItems"
 Yast.import "NetworkInterfaces"
@@ -81,7 +83,7 @@ module Y2Network
       # Finds the connections configurations
       def find_connections
         @connections ||=
-          configured_devices.each_with_object([]) do |name, conns|
+          configured_devices.each_with_object(ConnectionConfigsCollection.new([])) do |name, conns|
             interface = @interfaces.by_name(name)
             connection = ConnectionConfigReader.new.read(
               name,

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -736,10 +736,6 @@ module Yast
       end
 
       LanItems.WriteUdevRules if !Stage.cont && InstallInfConvertor.instance.AllowUdevModify
-
-      # FIXME: remove this code
-      # FIXME: hack: no "netcard" filter as biosdevname names it diferently (bnc#712232)
-      # NetworkInterfaces.Write("")
     end
 
     # Exports configuration for use in AY profile

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -737,8 +737,9 @@ module Yast
 
       LanItems.WriteUdevRules if !Stage.cont && InstallInfConvertor.instance.AllowUdevModify
 
+      # FIXME: remove this code
       # FIXME: hack: no "netcard" filter as biosdevname names it diferently (bnc#712232)
-      NetworkInterfaces.Write("")
+      # NetworkInterfaces.Write("")
     end
 
     # Exports configuration for use in AY profile

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -2388,7 +2388,7 @@ module Yast
       return unless config && config.routing
       routing = config.routing
       add_device_to_routing(to)
-      target_interface = config.interfaces.find { |i| i.name == to }
+      target_interface = config.interfaces.by_name(to)
       return unless target_interface
       routing.routes.select { |r| r.interface && r.interface.name == from }
              .each { |r| r.interface = target_interface }

--- a/test/default_route_test.rb
+++ b/test/default_route_test.rb
@@ -5,8 +5,16 @@ require_relative "test_helper"
 require "network/install_inf_convertor"
 require "y2network/interface_config_builder"
 
+Yast.import "Lan"
+
 describe "Yast::LanItemsClass" do
   subject { Yast::LanItems }
+
+  let(:config) { Y2Network::Config.new(source: :sysconfig) }
+
+  before do
+    allow(Yast::Lan).to receive(:yast_config).and_return(config)
+  end
 
   before do
     Yast.import "LanItems"

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -761,8 +761,9 @@ describe "LanItems renaming methods" do
     end
     let(:eth0) { Y2Network::Interface.new("eth0") }
     let(:br0) { Y2Network::Interface.new("br0") }
+    let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, br0]) }
     let(:yast_config) do
-      instance_double(Y2Network::Config, interfaces: [eth0, br0], routing: routing)
+      instance_double(Y2Network::Config, interfaces: interfaces, routing: routing)
     end
 
     before do

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -9,7 +9,6 @@ require "y2network/routing_table"
 require "y2network/route"
 
 Yast.import "NetworkInterfaces"
-Yast.import "Lan"
 
 # @return one item for a .probe.netcard list
 def probe_netcard_factory(num)
@@ -52,8 +51,8 @@ describe Yast::NetworkAutoconfiguration do
   let(:system_config) { yast_config.copy }
 
   before do
-    Yast::Lan.add_config(:yast, yast_config)
-    Yast::Lan.add_config(:system, system_config)
+    Y2Network::Config.add(:yast, yast_config)
+    Y2Network::Config.add(:system, system_config)
   end
 
   describe "it sets DHCLIENT_SET_DEFAULT_ROUTE properly" do

--- a/test/y2network/connection_configs_collection_test.rb
+++ b/test/y2network/connection_configs_collection_test.rb
@@ -40,4 +40,13 @@ describe Y2Network::ConnectionConfigsCollection do
       end
     end
   end
+
+  describe "#update" do
+    let(:eth0_1) { Y2Network::ConnectionConfig::Ethernet.new.tap { |c| c.name = "eth0" } }
+
+    it "replaces the connection configuration having the same name with the given object" do
+      collection.update(eth0_1)
+      expect(collection.by_name("eth0")).to be(eth0_1)
+    end
+  end
 end

--- a/test/y2network/connection_configs_collection_test.rb
+++ b/test/y2network/connection_configs_collection_test.rb
@@ -1,0 +1,43 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2network/connection_configs_collection"
+require "y2network/connection_config/ethernet"
+require "y2network/connection_config/wireless"
+
+describe Y2Network::ConnectionConfigsCollection do
+  subject(:collection) { described_class.new(connections) }
+
+  let(:connections) { [eth0, wlan0] }
+  let(:eth0) { Y2Network::ConnectionConfig::Ethernet.new.tap { |c| c.name = "eth0" } }
+  let(:wlan0) { Y2Network::ConnectionConfig::Wireless.new.tap { |c| c.name = "wlan0" } }
+
+  describe "#by_name" do
+    it "returns the connection configuration with the given name" do
+      expect(collection.by_name("eth0")).to eq(eth0)
+    end
+
+    context "when name is not defined" do
+      it "returns nil" do
+        expect(collection.by_name("eth1")).to be_nil
+      end
+    end
+  end
+end

--- a/test/y2network/connection_configs_collection_test.rb
+++ b/test/y2network/connection_configs_collection_test.rb
@@ -41,12 +41,52 @@ describe Y2Network::ConnectionConfigsCollection do
     end
   end
 
-  describe "#update" do
+  describe "#add_or_update" do
     let(:eth0_1) { Y2Network::ConnectionConfig::Ethernet.new.tap { |c| c.name = "eth0" } }
 
-    it "replaces the connection configuration having the same name with the given object" do
-      collection.update(eth0_1)
-      expect(collection.by_name("eth0")).to be(eth0_1)
+    context "when a connection configuration having the same name exists" do
+      it "replaces the existing configuration with the new one" do
+        collection.add_or_update(eth0_1)
+        expect(collection.by_name("eth0")).to be(eth0_1)
+        expect(collection.size).to eq(2)
+      end
+    end
+
+    context "if a connection configuration having the same name does not exist" do
+      let(:wlan1) { Y2Network::ConnectionConfig::Wireless.new.tap { |c| c.name = "wlan1" } }
+
+      it "adds the configuration to the collection" do
+        collection.add_or_update(wlan1)
+        expect(collection.by_name("wlan1")).to be(wlan1)
+        expect(collection.size).to eq(3)
+      end
+    end
+  end
+
+  describe "#remove" do
+    context "when a connection configuration having the same name exists" do
+      it "removes the configuration from the collection" do
+        collection.remove(eth0)
+        expect(collection.by_name("eth0")).to be_nil
+        expect(collection.size).to eq(1)
+      end
+    end
+
+    context "when a name is given, instead of a connection configuration" do
+      it "removes the configuration with the given name" do
+        collection.remove("eth0")
+        expect(collection.by_name("eth0")).to be_nil
+        expect(collection.size).to eq(1)
+      end
+    end
+
+
+    context "when a connection configuration having the same name does not exists" do
+      let(:wlan1) { Y2Network::ConnectionConfig::Wireless.new.tap { |c| c.name = "wlan1" } }
+
+      it "does not modify the collection" do
+        expect { collection.remove("wlan1") }.to_not change { collection.size }
+      end
     end
   end
 end

--- a/test/y2network/connection_configs_collection_test.rb
+++ b/test/y2network/connection_configs_collection_test.rb
@@ -80,7 +80,6 @@ describe Y2Network::ConnectionConfigsCollection do
       end
     end
 
-
     context "when a connection configuration having the same name does not exists" do
       let(:wlan1) { Y2Network::ConnectionConfig::Wireless.new.tap { |c| c.name = "wlan1" } }
 

--- a/test/y2network/interface_config_builder_test.rb
+++ b/test/y2network/interface_config_builder_test.rb
@@ -55,6 +55,11 @@ describe Y2Network::InterfaceConfigBuilder do
       expect(Yast::LanItems.driver_options["e1000e"]).to eq "test"
     end
 
+    it "saves connection config" do
+      expect(config.connections).to receive(:update).with(Y2Network::ConnectionConfig::Base)
+      subject.save
+    end
+
     it "stores aliases" do
       # Avoid deleting old aliases as it can break other tests, due to singleton NetworkInterfaces
       allow(Yast::NetworkInterfaces).to receive(:DeleteAlias)

--- a/test/y2network/interface_config_builder_test.rb
+++ b/test/y2network/interface_config_builder_test.rb
@@ -56,7 +56,7 @@ describe Y2Network::InterfaceConfigBuilder do
     end
 
     it "saves connection config" do
-      expect(config.connections).to receive(:update).with(Y2Network::ConnectionConfig::Base)
+      expect(config.connections).to receive(:add_or_update).with(Y2Network::ConnectionConfig::Base)
       subject.save
     end
 

--- a/test/y2network/interface_config_builder_test.rb
+++ b/test/y2network/interface_config_builder_test.rb
@@ -5,11 +5,19 @@ require_relative "../test_helper"
 require "yast"
 require "y2network/interface_config_builder"
 
+Yast.import "Lan"
+
 describe Y2Network::InterfaceConfigBuilder do
   subject(:config_builder) do
     res = Y2Network::InterfaceConfigBuilder.for("eth")
     res.name = "eth0"
     res
+  end
+
+  let(:config) { Y2Network::Config.new(source: :sysconfig) }
+
+  before do
+    allow(Yast::Lan).to receive(:yast_config).and_return(config)
   end
 
   describe ".for" do

--- a/test/y2network/interface_config_builders/infiniband_test.rb
+++ b/test/y2network/interface_config_builders/infiniband_test.rb
@@ -12,6 +12,12 @@ describe Y2Network::InterfaceConfigBuilders::Infiniband do
     res
   end
 
+  let(:config) { Y2Network::Config.new(source: :sysconfig) }
+
+  before do
+    allow(Yast::Lan).to receive(:yast_config).and_return(config)
+  end
+
   describe "#type" do
     it "returns infiniband interface type" do
       expect(subject.type).to eq Y2Network::InterfaceType::INFINIBAND

--- a/test/y2network/sysconfig/interfaces_reader_test.rb
+++ b/test/y2network/sysconfig/interfaces_reader_test.rb
@@ -80,7 +80,7 @@ describe Y2Network::Sysconfig::InterfacesReader do
   describe "#connections" do
     it "reads ethernet connections" do
       connections = reader.connections
-      conn = connections.find { |i| i.interface == "eth0" }
+      conn = connections.by_name("eth0")
       expect(conn.interface).to eq("eth0")
     end
   end


### PR DESCRIPTION
This PR replaces `NetworkInterfaces.Write` with `Y2Network::Config#write`. `Yast::NetworkAutoconfiguration` is out of scope.