### PR TITLE
packaging: Require hostname

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 30 11:14:04 UTC 2019 - Dominique Leuenberger <dimstar@opensuse.org>
+
+- Requires hostname: there are many places where the module calls
+  /bin/hostname (boo#1142595).
+- 4.2.11
+
+-------------------------------------------------------------------
 Fri Jul 19 08:10:14 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - avoid dependency on autoyast2-installation

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.10
+Version:        4.2.11
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only
@@ -57,6 +57,7 @@ Requires:       augeas-lenses
 Requires:       hwinfo         >= 21.35
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       yast2-xml
+Requires:       hostname
 
 # testsuite
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)


### PR DESCRIPTION
Since the code calls /bin/hostname in multiple places, we really ought
to ensure /bin/hostname is present.