### PR TITLE
network-ng: split IP configurations into #ip and #ip_aliases

### DIFF
--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -81,7 +81,7 @@ module Y2Network
       # Returns all IP configurations
       #
       # @return [Array<IPConfig>]
-      def ip_configs
+      def all_ips
         ([ip] + ip_aliases).compact
       end
     end

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -35,11 +35,12 @@ module Y2Network
       #
       # @return [String] Connection name
       attr_accessor :name
-      # #FIXME: Maybe in the future it could be a matcher. By now we will use
-      #   the interface name
-      #
-      # @return [String, nil]
+
+      # @return [String, nil] Interface to apply the configuration to
+      # FIXME: Maybe in the future it could be a matcher. By now we will use
+      #   the interface's name.
       attr_accessor :interface
+
       # @return [BootProtocol] Bootproto
       attr_accessor :bootproto
       # @return [IPConfig] Primary IP configuration

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -42,8 +42,10 @@ module Y2Network
       attr_accessor :interface
       # @return [BootProtocol] Bootproto
       attr_accessor :bootproto
-      # @return [Array<IPConfig>]
-      attr_accessor :ip_configs
+      # @return [IPConfig] Primary IP configuration
+      attr_accessor :ip
+      # @return [Array<IPConfig>] Additional IP configurations (also known as 'aliases')
+      attr_accessor :ip_aliases
       # @return [Integer, nil]
       attr_accessor :mtu
       # @return [Startmode, nil]
@@ -53,7 +55,7 @@ module Y2Network
 
       # Constructor
       def initialize
-        @ip_configs = []
+        @ip_aliases = []
         @bootproto = BootProtocol::STATIC
         @startmode = Startmode.create("manual")
       end
@@ -74,6 +76,13 @@ module Y2Network
       # @return [Boolean]
       def virtual?
         false
+      end
+
+      # Returns all IP configurations
+      #
+      # @return [Array<IPConfig>]
+      def ip_configs
+        ([ip] + ip_aliases).compact
       end
     end
   end

--- a/src/lib/y2network/connection_config/bonding.rb
+++ b/src/lib/y2network/connection_config/bonding.rb
@@ -31,6 +31,7 @@ module Y2Network
       attr_accessor :options
 
       def initialize
+        super()
         @slaves = []
         @options = ""
       end

--- a/src/lib/y2network/connection_config/bridge.rb
+++ b/src/lib/y2network/connection_config/bridge.rb
@@ -33,6 +33,7 @@ module Y2Network
       attr_accessor :forward_delay
 
       def initialize
+        super()
         @ports = []
         @stp = false
         @forward_delay = 0

--- a/src/lib/y2network/connection_config/tap.rb
+++ b/src/lib/y2network/connection_config/tap.rb
@@ -29,6 +29,7 @@ module Y2Network
       attr_accessor :group
 
       def initialize
+        super()
         @owner = ""
         @group = ""
       end

--- a/src/lib/y2network/connection_config/tun.rb
+++ b/src/lib/y2network/connection_config/tun.rb
@@ -29,6 +29,7 @@ module Y2Network
       attr_accessor :group
 
       def initialize
+        super()
         @owner = ""
         @group = ""
       end

--- a/src/lib/y2network/sysconfig/connection_config_readers/base.rb
+++ b/src/lib/y2network/sysconfig/connection_config_readers/base.rb
@@ -83,10 +83,10 @@ module Y2Network
         # @return [Array<Y2Network::ConnectionConfig::IPAdress>] IP addresses configuration
         # @see Y2Network::ConnectionConfig::IPConfig
         def all_ips
-          @all_ips ||= file.ipaddrs.map do |id, ip|
+          @all_ips ||= file.ipaddrs.each_with_object([]) do |(id, ip), all|
             next unless ip.is_a?(Y2Network::IPAddress)
             ip_address = build_ip(ip, file.prefixlens[id], file.netmasks[id])
-            Y2Network::ConnectionConfig::IPConfig.new(
+            all << Y2Network::ConnectionConfig::IPConfig.new(
               ip_address,
               id:             id,
               label:          file.labels[id],

--- a/src/lib/y2network/sysconfig/connection_config_readers/base.rb
+++ b/src/lib/y2network/sysconfig/connection_config_readers/base.rb
@@ -48,8 +48,8 @@ module Y2Network
             conn.bootproto = BootProtocol.from_name(file.bootproto || "static")
             conn.description = file.name
             conn.interface = file.interface
-            conn.ip = ip_configs.find { |i| i.id.empty? }
-            conn.ip_aliases = ip_configs.reject { |i| i.id.empty? }
+            conn.ip = all_ips.find { |i| i.id.empty? }
+            conn.ip_aliases = all_ips.reject { |i| i.id.empty? }
             conn.name = file.interface
             conn.startmode = Startmode.create(file.startmode || "manual")
             conn.startmode.priority = file.ifplugd_priority if conn.startmode.name == "ifplugd"
@@ -82,8 +82,8 @@ module Y2Network
         #
         # @return [Array<Y2Network::ConnectionConfig::IPAdress>] IP addresses configuration
         # @see Y2Network::ConnectionConfig::IPConfig
-        def ip_configs
-          @ip_configs ||= configs = file.ipaddrs.map do |id, ip|
+        def all_ips
+          @all_ips ||= file.ipaddrs.map do |id, ip|
             next unless ip.is_a?(Y2Network::IPAddress)
             ip_address = build_ip(ip, file.prefixlens[id], file.netmasks[id])
             Y2Network::ConnectionConfig::IPConfig.new(

--- a/src/lib/y2network/sysconfig/connection_config_writers/base.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writers/base.rb
@@ -44,7 +44,7 @@ module Y2Network
           file.name = conn.description
           file.startmode = conn.startmode.to_s
           file.ifplugd_priority = conn.startmode.priority if conn.startmode.name == "ifplugd"
-          write_all_ips(conn.all_ips)
+          add_ips(conn)
           update_file(conn)
         end
 
@@ -59,16 +59,24 @@ module Y2Network
           raise NotImplementedError
         end
 
-        # Write IP configuration
+        # Adds IP addresses
         #
-        # @param all_ips [Array<Y2Network::ConnectionConfig::IPConfig>] IPs configuration
-        def write_all_ips(all_ips)
-          all_ips.each do |ip_config|
-            file.ipaddrs[ip_config.id] = ip_config.address
-            file.labels[ip_config.id] = ip_config.label
-            file.remote_ipaddrs[ip_config.id] = ip_config.remote_address
-            file.broadcasts.merge!(ip_config.id => ip_config.broadcast)
-          end
+        # @param conn [Y2Network::ConnectionConfig::Base] Connection to take settings from
+        def add_ips(conn)
+          file.ipaddrs.clear
+          ips_to_add = conn.ip_aliases.clone
+          ips_to_add << conn.ip if conn.ip && !conn.bootproto.dhcp?
+          ips_to_add.each { |i| add_ip(i) }
+        end
+
+        # Adds a single IP to the file
+        #
+        # @param ip [Y2Network::IPAddress] IP address to add
+        def add_ip(ip)
+          file.ipaddrs[ip.id] = ip.address
+          file.labels[ip.id] = ip.label
+          file.remote_ipaddrs[ip.id] = ip.remote_address
+          file.broadcasts[ip.id] = ip.broadcast
         end
       end
     end

--- a/src/lib/y2network/sysconfig/connection_config_writers/base.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writers/base.rb
@@ -44,7 +44,7 @@ module Y2Network
           file.name = conn.description
           file.startmode = conn.startmode.to_s
           file.ifplugd_priority = conn.startmode.priority if conn.startmode.name == "ifplugd"
-          write_ip_configs(conn.ip_configs)
+          write_all_ips(conn.all_ips)
           update_file(conn)
         end
 
@@ -61,9 +61,9 @@ module Y2Network
 
         # Write IP configuration
         #
-        # @param ip_configs [Array<Y2Network::ConnectionConfig::IPConfig>] IPs configuration
-        def write_ip_configs(ip_configs)
-          ip_configs.each do |ip_config|
+        # @param all_ips [Array<Y2Network::ConnectionConfig::IPConfig>] IPs configuration
+        def write_all_ips(all_ips)
+          all_ips.each do |ip_config|
             file.ipaddrs[ip_config.id] = ip_config.address
             file.labels[ip_config.id] = ip_config.label
             file.remote_ipaddrs[ip_config.id] = ip_config.remote_address

--- a/test/y2network/sysconfig/config_writer_test.rb
+++ b/test/y2network/sysconfig/config_writer_test.rb
@@ -40,13 +40,13 @@ describe Y2Network::Sysconfig::ConfigWriter do
       )
     end
     let(:old_config) { instance_double(Y2Network::Config, dns: double("dns"), interfaces: nil) }
-    let(:ip_config) { Y2Network::ConnectionConfig::IPConfig.new(address: IPAddr.new("192.168.122.2")) }
+    let(:ip) { Y2Network::ConnectionConfig::IPConfig.new(address: IPAddr.new("192.168.122.2")) }
     let(:eth0) { Y2Network::Interface.new("eth0") }
     let(:eth0_conn) do
       Y2Network::ConnectionConfig::Ethernet.new.tap do |conn|
         conn.interface = "eth0"
         conn.bootproto = :static
-        conn.ip_configs = [ip_config]
+        conn.ip = ip
       end
     end
     let(:route) do

--- a/test/y2network/sysconfig/connection_config_readers/dummy_test.rb
+++ b/test/y2network/sysconfig/connection_config_readers/dummy_test.rb
@@ -41,7 +41,7 @@ describe Y2Network::Sysconfig::ConnectionConfigReaders::Dummy do
     it "returns a dummy connection config object" do
       dummy_conn = handler.connection_config
       expect(dummy_conn.interface).to eq("dummy0")
-      expect(dummy_conn.ip_configs.map(&:address)).to eq([ip_address])
+      expect(dummy_conn.ip.address).to eq(ip_address)
       expect(dummy_conn.bootproto).to eq(Y2Network::BootProtocol::STATIC)
     end
   end

--- a/test/y2network/sysconfig/connection_config_readers/ethernet_test.rb
+++ b/test/y2network/sysconfig/connection_config_readers/ethernet_test.rb
@@ -40,7 +40,7 @@ describe Y2Network::Sysconfig::ConnectionConfigReaders::Ethernet do
     it "returns an ethernet connection config object" do
       eth = handler.connection_config
       expect(eth.interface).to eq("eth0")
-      expect(eth.ip_configs.map(&:address)).to eq([Y2Network::IPAddress.from_string("192.168.123.1/24")])
+      expect(eth.ip.address).to eq(Y2Network::IPAddress.from_string("192.168.123.1/24"))
       expect(eth.bootproto).to eq(Y2Network::BootProtocol::STATIC)
     end
 
@@ -49,7 +49,7 @@ describe Y2Network::Sysconfig::ConnectionConfigReaders::Ethernet do
 
       it "uses the prefixlen as the address prefix" do
         eth = handler.connection_config
-        expect(eth.ip_configs.map(&:address)).to eq([Y2Network::IPAddress.from_string("172.16.0.1/12")])
+        expect(eth.ip.address).to eq(Y2Network::IPAddress.from_string("172.16.0.1/12"))
       end
     end
 
@@ -58,7 +58,7 @@ describe Y2Network::Sysconfig::ConnectionConfigReaders::Ethernet do
 
       it "uses the netmask to set the address prefix" do
         eth = handler.connection_config
-        expect(eth.ip_configs.map(&:address)).to eq([Y2Network::IPAddress.from_string("10.0.0.1/8")])
+        expect(eth.ip.address).to eq(Y2Network::IPAddress.from_string("10.0.0.1/8"))
       end
     end
   end

--- a/test/y2network/sysconfig/connection_config_readers/infiniband_test.rb
+++ b/test/y2network/sysconfig/connection_config_readers/infiniband_test.rb
@@ -42,7 +42,7 @@ describe Y2Network::Sysconfig::ConnectionConfigReaders::Infiniband do
       infiniband_conn = handler.connection_config
       expect(infiniband_conn.interface).to eq("ib0")
       expect(infiniband_conn.ipoib_mode).to eq(Y2Network::IpoibMode::DATAGRAM)
-      expect(infiniband_conn.ip_configs.map(&:address)).to eq([ip_address])
+      expect(infiniband_conn.all_ips.map(&:address)).to eq([ip_address])
       expect(infiniband_conn.bootproto).to eq(Y2Network::BootProtocol::STATIC)
     end
   end

--- a/test/y2network/sysconfig/connection_config_writers/bonding_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/bonding_test.rb
@@ -28,17 +28,15 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Bonding do
   subject(:handler) { described_class.new(file) }
 
   let(:conn) do
-    instance_double(
-      Y2Network::ConnectionConfig::Bonding,
-      name:        "bond0",
-      interface:   "bond0",
-      description: "",
-      ip_configs:  [],
-      startmode:   Y2Network::Startmode.create("auto"),
-      bootproto:   Y2Network::BootProtocol::DHCP,
-      slaves:      ["eth0", "eth1"],
-      options:     "mode=active-backup miimon=100"
-    )
+    Y2Network::ConnectionConfig::Bonding.new.tap do |c|
+      c.name = "bond0"
+      c.interface = "bond0"
+      c.description = ""
+      c.startmode = Y2Network::Startmode.create("auto")
+      c.bootproto = Y2Network::BootProtocol::DHCP
+      c.slaves = ["eth0", "eth1"]
+      c.options = "mode=active-backup miimon=100"
+    end
   end
 
   let(:file) { Y2Network::Sysconfig::InterfaceFile.new(conn.name) }

--- a/test/y2network/sysconfig/connection_config_writers/bridge_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/bridge_test.rb
@@ -29,18 +29,16 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Bridge do
   subject(:handler) { described_class.new(file) }
 
   let(:conn) do
-    instance_double(
-      Y2Network::ConnectionConfig::Bridge,
-      name:          "br1",
-      interface:     "br1",
-      description:   "",
-      startmode:     Y2Network::Startmode.create("auto"),
-      bootproto:     Y2Network::BootProtocol::DHCP,
-      ip_configs:    [],
-      ports:         ["eth0", "eth1"],
-      stp:           false,
-      forward_delay: 5
-    )
+    Y2Network::ConnectionConfig::Bridge.new.tap do |c|
+      c.name = "br1"
+      c.interface = "br1"
+      c.description = ""
+      c.startmode = Y2Network::Startmode.create("auto")
+      c.bootproto = Y2Network::BootProtocol::DHCP
+      c.ports = ["eth0", "eth1"]
+      c.stp = false
+      c.forward_delay = 5
+    end
   end
 
   let(:file) { Y2Network::Sysconfig::InterfaceFile.new(conn.name) }

--- a/test/y2network/sysconfig/connection_config_writers/dummy_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/dummy_test.rb
@@ -44,15 +44,14 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Dummy do
   end
 
   let(:conn) do
-    instance_double(
-      Y2Network::ConnectionConfig::Dummy,
-      name:        "dummy1",
-      interface:   "dummy1",
-      description: "",
-      bootproto:   Y2Network::BootProtocol::STATIC,
-      all_ips:     [ip],
-      startmode:   Y2Network::Startmode.create("auto")
-    )
+    Y2Network::ConnectionConfig::Dummy.new.tap do |c|
+      c.name = "dummy1"
+      c.interface = "dummy1"
+      c.description = ""
+      c.ip = ip
+      c.bootproto = Y2Network::BootProtocol::STATIC
+      c.startmode = Y2Network::Startmode.create("auto")
+    end
   end
 
   let(:file) { Y2Network::Sysconfig::InterfaceFile.new(conn.name) }

--- a/test/y2network/sysconfig/connection_config_writers/dummy_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/dummy_test.rb
@@ -39,12 +39,8 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Dummy do
     end
   end
 
-  let(:ip_configs) do
-    [
-      Y2Network::ConnectionConfig::IPConfig.new(
-        Y2Network::IPAddress.from_string("10.0.0.100/24")
-      )
-    ]
+  let(:ip) do
+    Y2Network::ConnectionConfig::IPConfig.new(Y2Network::IPAddress.from_string("10.0.0.100/24"))
   end
 
   let(:conn) do
@@ -54,7 +50,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Dummy do
       interface:   "dummy1",
       description: "",
       bootproto:   Y2Network::BootProtocol::STATIC,
-      ip_configs:  ip_configs,
+      ip_configs:  [ip],
       startmode:   Y2Network::Startmode.create("auto")
     )
   end

--- a/test/y2network/sysconfig/connection_config_writers/dummy_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/dummy_test.rb
@@ -50,7 +50,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Dummy do
       interface:   "dummy1",
       description: "",
       bootproto:   Y2Network::BootProtocol::STATIC,
-      ip_configs:  [ip],
+      all_ips:     [ip],
       startmode:   Y2Network::Startmode.create("auto")
     )
   end

--- a/test/y2network/sysconfig/connection_config_writers/ethernet_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/ethernet_test.rb
@@ -40,18 +40,21 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Ethernet do
     end
   end
 
-  let(:ip_configs) do
-    [
-      Y2Network::ConnectionConfig::IPConfig.new(
-        Y2Network::IPAddress.from_string("192.168.122.1/24"),
-        id: "", broadcast: Y2Network::IPAddress.from_string("192.168.122.255")
-      ),
-      Y2Network::ConnectionConfig::IPConfig.new(
-        Y2Network::IPAddress.from_string("10.0.0.1/8"),
-        id: "_0", label: "my-label", remote_address: Y2Network::IPAddress.from_string("10.0.0.2")
-      )
-    ]
+  let(:ip) do
+    Y2Network::ConnectionConfig::IPConfig.new(
+      Y2Network::IPAddress.from_string("192.168.122.1/24"),
+      id: "", broadcast: Y2Network::IPAddress.from_string("192.168.122.255")
+    )
   end
+
+  let(:ip_alias) do
+    Y2Network::ConnectionConfig::IPConfig.new(
+      Y2Network::IPAddress.from_string("10.0.0.1/8"),
+      id: "_0", label: "my-label", remote_address: Y2Network::IPAddress.from_string("10.0.0.2")
+    )
+  end
+
+  let(:all_ips) { [ip, ip_alias] }
 
   let(:conn) do
     instance_double(
@@ -60,7 +63,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Ethernet do
       interface:   "eth0",
       description: "Ethernet Card 0",
       bootproto:   Y2Network::BootProtocol::STATIC,
-      ip_configs:  ip_configs,
+      all_ips:     all_ips,
       startmode:   Y2Network::Startmode.create("auto")
     )
   end
@@ -80,9 +83,9 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Ethernet do
     it "sets IP configuration attributes" do
       handler.write(conn)
       expect(file).to have_attributes(
-        ipaddrs:        { "" => ip_configs[0].address, "_0" => ip_configs[1].address },
-        broadcasts:     { "" => ip_configs[0].broadcast, "_0" => nil },
-        remote_ipaddrs: { "" => nil, "_0" => ip_configs[1].remote_address },
+        ipaddrs:        { "" => ip.address, "_0" => ip_alias.address },
+        broadcasts:     { "" => ip.broadcast, "_0" => nil },
+        remote_ipaddrs: { "" => nil, "_0" => ip_alias.remote_address },
         labels:         { "" => nil, "_0" => "my-label" }
       )
     end

--- a/test/y2network/sysconfig/connection_config_writers/infiniband_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/infiniband_test.rb
@@ -40,12 +40,8 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Infiniband do
     end
   end
 
-  let(:ip_configs) do
-    [
-      Y2Network::ConnectionConfig::IPConfig.new(
-        Y2Network::IPAddress.from_string("192.168.20.1/24")
-      )
-    ]
+  let(:ip) do
+    Y2Network::ConnectionConfig::IPConfig.new(Y2Network::IPAddress.from_string("192.168.20.1/24"))
   end
 
   let(:conn) do
@@ -55,7 +51,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Infiniband do
       interface:   "ib0",
       description: "",
       ipoib_mode:  Y2Network::IpoibMode::CONNECTED,
-      ip_configs:  ip_configs,
+      ip_configs:  [ip],
       startmode:   Y2Network::Startmode.create("auto"),
       bootproto:   Y2Network::BootProtocol::STATIC
     )

--- a/test/y2network/sysconfig/connection_config_writers/infiniband_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/infiniband_test.rb
@@ -51,7 +51,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Infiniband do
       interface:   "ib0",
       description: "",
       ipoib_mode:  Y2Network::IpoibMode::CONNECTED,
-      ip_configs:  [ip],
+      all_ips:     [ip],
       startmode:   Y2Network::Startmode.create("auto"),
       bootproto:   Y2Network::BootProtocol::STATIC
     )

--- a/test/y2network/sysconfig/connection_config_writers/infiniband_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/infiniband_test.rb
@@ -45,16 +45,15 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Infiniband do
   end
 
   let(:conn) do
-    instance_double(
-      Y2Network::ConnectionConfig::Infiniband,
-      name:        "ib0",
-      interface:   "ib0",
-      description: "",
-      ipoib_mode:  Y2Network::IpoibMode::CONNECTED,
-      all_ips:     [ip],
-      startmode:   Y2Network::Startmode.create("auto"),
-      bootproto:   Y2Network::BootProtocol::STATIC
-    )
+    Y2Network::ConnectionConfig::Infiniband.new.tap do |c|
+      c.name = "ib0"
+      c.interface = "ib0"
+      c.description = ""
+      c.ipoib_mode =  Y2Network::IpoibMode::CONNECTED
+      c.ip = ip
+      c.startmode = Y2Network::Startmode.create("auto")
+      c.bootproto = Y2Network::BootProtocol::STATIC
+    end
   end
 
   let(:file) { Y2Network::Sysconfig::InterfaceFile.new(conn.name) }

--- a/test/y2network/sysconfig/connection_config_writers/tap_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/tap_test.rb
@@ -45,17 +45,15 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Tap do
   end
 
   let(:conn) do
-    instance_double(
-      Y2Network::ConnectionConfig::Tap,
-      name:        "tap1",
-      interface:   "tap1",
-      owner:       "nobody",
-      group:       "nobody",
-      description: "",
-      bootproto:   Y2Network::BootProtocol::STATIC,
-      ip_configs:  [],
-      startmode:   Y2Network::Startmode.create("auto")
-    )
+    Y2Network::ConnectionConfig::Tap.new.tap do |c|
+      c.name = "tap1"
+      c.interface = "tap1"
+      c.owner = "nobody"
+      c.group = "nobody"
+      c.description = ""
+      c.bootproto = Y2Network::BootProtocol::STATIC
+      c.startmode = Y2Network::Startmode.create("auto")
+    end
   end
 
   let(:file) { Y2Network::Sysconfig::InterfaceFile.new(conn.name) }

--- a/test/y2network/sysconfig/connection_config_writers/tun_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/tun_test.rb
@@ -45,17 +45,15 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Tun do
   end
 
   let(:conn) do
-    instance_double(
-      Y2Network::ConnectionConfig::Tun,
-      name:        "tun1",
-      interface:   "tun1",
-      owner:       "nobody",
-      group:       "nobody",
-      description: "",
-      bootproto:   Y2Network::BootProtocol::STATIC,
-      ip_configs:  [],
-      startmode:   Y2Network::Startmode.create("auto")
-    )
+    Y2Network::ConnectionConfig::Tun.new.tap do |c|
+      c.name = "tun1"
+      c.interface = "tun1"
+      c.owner = "nobody"
+      c.group = "nobody"
+      c.description = ""
+      c.bootproto = Y2Network::BootProtocol::STATIC
+      c.startmode = Y2Network::Startmode.create("auto")
+    end
   end
 
   let(:file) { Y2Network::Sysconfig::InterfaceFile.new(conn.name) }

--- a/test/y2network/sysconfig/connection_config_writers/vlan_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/vlan_test.rb
@@ -37,7 +37,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Vlan do
       description:   "",
       parent_device: "eth0",
       vlan_id:       100,
-      ip_configs:    [],
+      all_ips:       [],
       startmode:     Y2Network::Startmode.create("auto"),
       bootproto:     Y2Network::BootProtocol::DHCP
     )

--- a/test/y2network/sysconfig/connection_config_writers/vlan_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/vlan_test.rb
@@ -30,17 +30,15 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Vlan do
   subject(:handler) { described_class.new(file) }
 
   let(:conn) do
-    instance_double(
-      Y2Network::ConnectionConfig::Vlan,
-      name:          "eth0.100",
-      interface:     "eth0.100",
-      description:   "",
-      parent_device: "eth0",
-      vlan_id:       100,
-      all_ips:       [],
-      startmode:     Y2Network::Startmode.create("auto"),
-      bootproto:     Y2Network::BootProtocol::DHCP
-    )
+    Y2Network::ConnectionConfig::Vlan.new.tap do |c|
+      c.name = "eth0.100"
+      c.interface = "eth0.100"
+      c.description = ""
+      c.parent_device = "eth0"
+      c.vlan_id = 100
+      c.startmode = Y2Network::Startmode.create("auto")
+      c.bootproto = Y2Network::BootProtocol::DHCP
+    end
   end
 
   let(:file) { Y2Network::Sysconfig::InterfaceFile.new(conn.name) }

--- a/test/y2network/sysconfig/connection_config_writers/wireless_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/wireless_test.rb
@@ -35,7 +35,8 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Wireless do
       conn.description = "Wireless Card 0"
       conn.startmode = Y2Network::Startmode.create("auto")
       conn.bootproto = Y2Network::BootProtocol::STATIC
-      conn.ip_configs = ip_configs
+      conn.ip = ip
+      conn.ip_aliases = [ip_alias]
       conn.mode = "managed"
       conn.essid = "example_essid"
       conn.auth_mode = :open
@@ -44,17 +45,18 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Wireless do
     end
   end
 
-  let(:ip_configs) do
-    [
-      Y2Network::ConnectionConfig::IPConfig.new(
-        Y2Network::IPAddress.from_string("192.168.122.1/24"),
-        id: "", broadcast: Y2Network::IPAddress.from_string("192.168.122.255")
-      ),
-      Y2Network::ConnectionConfig::IPConfig.new(
-        Y2Network::IPAddress.from_string("10.0.0.1/8"),
-        id: "_0", label: "my-label", remote_address: Y2Network::IPAddress.from_string("10.0.0.2")
-      )
-    ]
+  let(:ip) do
+    Y2Network::ConnectionConfig::IPConfig.new(
+      Y2Network::IPAddress.from_string("192.168.122.1/24"),
+      id: "", broadcast: Y2Network::IPAddress.from_string("192.168.122.255")
+    )
+  end
+
+  let(:ip_alias) do
+    Y2Network::ConnectionConfig::IPConfig.new(
+      Y2Network::IPAddress.from_string("10.0.0.1/8"),
+      id: "_0", label: "my-label", remote_address: Y2Network::IPAddress.from_string("10.0.0.2")
+    )
   end
 
   it "sets relevant attributes" do
@@ -73,9 +75,9 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Wireless do
   it "sets IP configuration attributes" do
     handler.write(conn)
     expect(file).to have_attributes(
-      ipaddrs:        { "" => ip_configs[0].address, "_0" => ip_configs[1].address },
-      broadcasts:     { "" => ip_configs[0].broadcast, "_0" => nil },
-      remote_ipaddrs: { "" => nil, "_0" => ip_configs[1].remote_address },
+      ipaddrs:        { "" => ip.address, "_0" => ip_alias.address },
+      broadcasts:     { "" => ip.broadcast, "_0" => nil },
+      remote_ipaddrs: { "" => nil, "_0" => ip_alias.remote_address },
       labels:         { "" => nil, "_0" => "my-label" }
     )
   end

--- a/test/y2network/sysconfig/connection_config_writers/wireless_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/wireless_test.rb
@@ -30,18 +30,18 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Wireless do
   let(:file) { Y2Network::Sysconfig::InterfaceFile.new("wlan0") }
 
   let(:conn) do
-    Y2Network::ConnectionConfig::Wireless.new.tap do |conn|
-      conn.interface = "wlan0"
-      conn.description = "Wireless Card 0"
-      conn.startmode = Y2Network::Startmode.create("auto")
-      conn.bootproto = Y2Network::BootProtocol::STATIC
-      conn.ip = ip
-      conn.ip_aliases = [ip_alias]
-      conn.mode = "managed"
-      conn.essid = "example_essid"
-      conn.auth_mode = :open
-      conn.ap = "00:11:22:33:44:55"
-      conn.ap_scanmode = "1"
+    Y2Network::ConnectionConfig::Wireless.new.tap do |c|
+      c.interface = "wlan0"
+      c.description = "Wireless Card 0"
+      c.startmode = Y2Network::Startmode.create("auto")
+      c.bootproto = Y2Network::BootProtocol::STATIC
+      c.ip = ip
+      c.ip_aliases = [ip_alias]
+      c.mode = "managed"
+      c.essid = "example_essid"
+      c.auth_mode = :open
+      c.ap = "00:11:22:33:44:55"
+      c.ap_scanmode = "1"
     end
   end
 
@@ -84,15 +84,15 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Wireless do
 
   context "WPA-EAP network configuration" do
     let(:conn) do
-      Y2Network::ConnectionConfig::Wireless.new.tap do |conn|
-        conn.startmode = Y2Network::Startmode.create("auto")
-        conn.bootproto = Y2Network::BootProtocol::STATIC
-        conn.mode = "managed"
-        conn.essid = "example_essid"
-        conn.auth_mode = "eap"
-        conn.eap_mode = "PEAP"
-        conn.essid = "example_essid"
-        conn.wpa_password = "example_passwd"
+      Y2Network::ConnectionConfig::Wireless.new.tap do |c|
+        c.startmode = Y2Network::Startmode.create("auto")
+        c.bootproto = Y2Network::BootProtocol::STATIC
+        c.mode = "managed"
+        c.essid = "example_essid"
+        c.auth_mode = "eap"
+        c.eap_mode = "PEAP"
+        c.essid = "example_essid"
+        c.wpa_password = "example_passwd"
       end
     end
 
@@ -109,12 +109,12 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Wireless do
 
   context "WPA-PSK network configuration" do
     let(:conn) do
-      Y2Network::ConnectionConfig::Wireless.new.tap do |conn|
-        conn.startmode = Y2Network::Startmode.create("auto")
-        conn.bootproto = Y2Network::BootProtocol::STATIC
-        conn.mode = "managed"
-        conn.auth_mode = "psk"
-        conn.wpa_psk = "example_psk"
+      Y2Network::ConnectionConfig::Wireless.new.tap do |c|
+        c.startmode = Y2Network::Startmode.create("auto")
+        c.bootproto = Y2Network::BootProtocol::STATIC
+        c.mode = "managed"
+        c.auth_mode = "psk"
+        c.wpa_psk = "example_psk"
       end
     end
 
@@ -129,14 +129,14 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Wireless do
 
   context "WEP network configuration" do
     let(:conn) do
-      Y2Network::ConnectionConfig::Wireless.new.tap do |conn|
-        conn.startmode = Y2Network::Startmode.create("auto")
-        conn.bootproto = Y2Network::BootProtocol::STATIC
-        conn.mode = "managed"
-        conn.auth_mode = "shared"
-        conn.keys = ["123456", "abcdef"]
-        conn.key_length = 128
-        conn.default_key = 1
+      Y2Network::ConnectionConfig::Wireless.new.tap do |c|
+        c.startmode = Y2Network::Startmode.create("auto")
+        c.bootproto = Y2Network::BootProtocol::STATIC
+        c.mode = "managed"
+        c.auth_mode = "shared"
+        c.keys = ["123456", "abcdef"]
+        c.key_length = 128
+        c.default_key = 1
       end
     end
 


### PR DESCRIPTION
Separate `ConnectionConfig::Base#ip_configs` into different methods: `#ip` and `#ip_aliases`.