### PR TITLE
Fix Enum comparisons

### DIFF
--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -28,6 +28,7 @@
 #
 require "y2firewall/helpers/interfaces"
 require "y2network/dialogs/edit_interface"
+require "y2network/boot_protocol"
 
 module Yast
   module NetworkLanAddressInclude
@@ -73,9 +74,9 @@ module Yast
 
         # IP is mandatory for static configuration. Makes no sense to write static
         # configuration without that.
-        return ret if bootproto == "static" && ipaddr.empty?
+        return ret if bootproto == Y2Network::BootProtocol::STATIC && ipaddr.empty?
 
-        if bootproto == "static"
+        if bootproto == Y2Network::BootProtocol::STATIC
           update_hostname(ipaddr, builder.hostname || "")
         elsif LanItems.isCurrentDHCP && !LanItems.isCurrentHotplug
           # fixed bug #73739 - if dhcp is used, dont set default gw statically

--- a/src/lib/y2network/boot_protocol.rb
+++ b/src/lib/y2network/boot_protocol.rb
@@ -56,6 +56,18 @@ module Y2Network
       [DHCP4, DHCP6, DHCP, DHCP_AUTOIP].include?(self)
     end
 
+    # Determines whether two objects are equivalent
+    #
+    # They are equal when they refer to the same boot protocol (through the name).
+    #
+    # @param other [BootProtocol] Boot protocol to compare with
+    # @return [Boolean]
+    def ==(other)
+      name == other.name
+    end
+
+    alias_method :eql?, :==
+
     # iBFT boot protocol
     IBFT = new("ibft")
     # statically assigned interface properties

--- a/src/lib/y2network/ipoib_mode.rb
+++ b/src/lib/y2network/ipoib_mode.rb
@@ -51,6 +51,18 @@ module Y2Network
       @name = name
     end
 
+    # Determines whether two objects are equivalent
+    #
+    # They are equal when they refer to the same IPoIB mode (through the name).
+    #
+    # @param other [IpoibMode] IPoIB mode to compare with
+    # @return [Boolean]
+    def ==(other)
+      name == other.name
+    end
+
+    alias_method :eql?, :==
+
     DATAGRAM = new("datagram")
     CONNECTED = new("connected")
     # Not a mode at all but the default value that will be choose by the IB

--- a/test/y2network/boot_protocol_test.rb
+++ b/test/y2network/boot_protocol_test.rb
@@ -22,7 +22,7 @@ require_relative "../test_helper"
 require "y2network/boot_protocol"
 
 describe Y2Network::BootProtocol do
-  subject { described_class.new("dhcp") }
+  subject(:protocol) { described_class.new("dhcp") }
 
   describe ".all" do
     it "returns all known boot protocols" do
@@ -46,6 +46,20 @@ describe Y2Network::BootProtocol do
       expect(Y2Network::BootProtocol::DHCP4.dhcp?).to eq true
       expect(Y2Network::BootProtocol::DHCP_AUTOIP.dhcp?).to eq true
       expect(Y2Network::BootProtocol::STATIC.dhcp?).to eq false
+    end
+  end
+
+  describe "#==" do
+    context "when the other object refers to the same boot protocol" do
+      it "returns true" do
+        expect(protocol).to eq(described_class.new("dhcp"))
+      end
+    end
+
+    context "when the other object refers to a different boot protocol" do
+      it "returns false" do
+        expect(protocol).to_not eq(described_class.new("static"))
+      end
     end
   end
 end

--- a/test/y2network/ipoib_mode_test.rb
+++ b/test/y2network/ipoib_mode_test.rb
@@ -1,0 +1,56 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2network/ipoib_mode"
+
+describe Y2Network::IpoibMode do
+  subject(:mode) { described_class.new("datagram") }
+
+  describe ".all" do
+    it "returns all know IPoIB modes" do
+      expect(described_class.all).to contain_exactly(
+        Y2Network::IpoibMode::CONNECTED,
+        Y2Network::IpoibMode::DATAGRAM,
+        Y2Network::IpoibMode::DEFAULT
+      )
+    end
+  end
+
+  describe ".from_name" do
+    it "returns the IPoIB mode with the given mode" do
+      expect(described_class.from_name("datagram")).to eq(Y2Network::IpoibMode::DATAGRAM)
+    end
+  end
+
+  describe "#==" do
+    context "when the other object refers to the same IPoIB mode" do
+      it "returns true" do
+        expect(mode).to eq(described_class.new("datagram"))
+      end
+    end
+
+    context "when the other object refers to a different IPoIB mode" do
+      it "returns false" do
+        expect(mode).to_not eq(described_class.new("connected"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implement `#==` to compare `BootProtocol` and `IpoibMode` objects.