### PR TITLE
network-ng: use new backend

### DIFF
--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -563,11 +563,16 @@ module Y2Network
     # method that allows easy change of backend for providing data
     # it also logs error if result differs
     # TODO: Only temporary method for testing switch of backends. Remove it from production
-    def select_backend(old, new)
-      log.error "Different value in backends. Old: #{old.inspect} New: #{new.inspect}" if new != old
+    #
+    # @param old_value [Object]
+    # @param new_value [Object]
+    def select_backend(old_value, new_value)
+      if new_value != old_value
+        log.error "Different value in backends. Old: #{old_value.inspect} New: #{new_value.inspect}"
+      end
 
       # XXX: to be removed when fully migrated to the new backend
-      ENV["Y2NETWORK_NEW_BACKEND"] == "1" ? new : old
+      ENV["Y2NETWORK_NEW_BACKEND"] == "1" ? new_value : old_value
     end
 
     # Returns the connection config class for a given type

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -566,7 +566,8 @@ module Y2Network
     def select_backend(old, new)
       log.error "Different value in backends. Old: #{old.inspect} New: #{new.inspect}" if new != old
 
-      old
+      # XXX: to be removed when fully migrated to the new backend
+      ENV["Y2NETWORK_NEW_BACKEND"] == "1" ? new : old
     end
 
     # Returns the connection config class for a given type

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -256,9 +256,9 @@ module Y2Network
 
       new_aliases = @connection_config.ip_aliases.map do |data|
         {
-          label:     data.label,
-          ip:        data.address.address,
-          prefixlen: data.address.prefix
+          label:     data.label.to_s,
+          ip:        data.address.address.to_s,
+          prefixlen: data.address.prefix.to_s,
           # NOTE: new API does not have netmask at all, we need to adapt UI to clearly mention only prefix
         }
       end
@@ -294,7 +294,7 @@ module Y2Network
 
       default = @connection_config.ip
       new_ = if default
-        default.address.address
+        default.address.address.to_s
       else
         ""
       end

--- a/src/lib/y2network/sysconfig/interface_file.rb
+++ b/src/lib/y2network/sysconfig/interface_file.rb
@@ -154,7 +154,7 @@ module Y2Network
 
       # !@attribute [r] labels
       #   @return [Hash] Label to assign to the address
-      define_collection_variable(:label, :symbol)
+      define_collection_variable(:label, :string)
 
       # !@attribute [r] remote_ipaddrs
       #   @return [Hash] Remote IP address of a point to point connection


### PR DESCRIPTION
This PR allows using the new backend when edition a connection configuration by setting an environment variable called `Y2NETWORK_NEW_BACKEND`. Please, do not rely on this variable too much, as it will be removed as soon as the migration to the new backend is finished.

Additionally, some fixes have been made to make it work. You can see the module working in the screencast below.

![new-backend](https://user-images.githubusercontent.com/15836/62303951-fc15bd80-b474-11e9-9169-ca0974ab123a.gif)
