### PR TITLE
network-ng: Added LCS connection config.

### DIFF
--- a/src/lib/y2network/connection_config/ctc.rb
+++ b/src/lib/y2network/connection_config/ctc.rb
@@ -26,19 +26,24 @@ module Y2Network
     # @note The use of this connection is deprecated or not recommended as it
     #   will not be officially supported in future SLE versions.
     class Ctc < Base
-      # For CCW devices and CCW group devices, this device ID is the device
-      # bus-ID.
+      # Most I/O devices on a s390 system are typically driven through the
+      # channel I/O mechanism.
+      #
+      # The s390-tools provides a set of commands for working with CCW devices
+      # and CCW group devices, these commands use a device ID which is the
+      # device bus-ID
       #
       # The device bus-ID is of the format 0.<subchannel_set_ID>.<devno>,
       # for example, 0.0.8000.
       #
+      # @see https://www.ibm.com/developerworks/linux/linux390/documentation_suse.html
+      #
       # The CTCM device driver requires two I/O subchannels for each interface,
       # a read subchannel and a write subchannel
       #
-      # @see https://www.ibm.com/developerworks/linux/linux390/index.html
-      # @return [String] read bus id
+      # @return [String] read device bus id
       attr_accessor :read_channel
-      # @return [String] write bus id
+      # @return [String] write device bus id
       attr_accessor :write_channel
       # @return [Integer] connection protocol (0, 1, 3, or 4)
       #   0 Compatibility with peers other than OS/390®.

--- a/src/lib/y2network/connection_config/lcs.rb
+++ b/src/lib/y2network/connection_config/lcs.rb
@@ -23,13 +23,40 @@ module Y2Network
   module ConnectionConfig
     # Configuration for lcs connections
     class Lcs < Base
-      # @return [String] read bus id
+      # Most I/O devices on a s390 system are typically driven through the
+      # channel I/O mechanism.
+      #
+      # The s390-tools provides a set of commands for working with CCW devices
+      # and CCW group devices, these commands use a device ID which is the
+      # device bus-ID
+      #
+      # The device bus-ID is of the format 0.<subchannel_set_ID>.<devno>,
+      # for example, 0.0.8000.
+      #
+      # @see https://www.ibm.com/developerworks/linux/linux390/documentation_suse.html
+      #
+      # The LCS devices drivers requires two I/O subchannels for each interface,
+      # a read subchannel and a write subchannel and is very similar to the
+      # S390 CTC interface.
+      #
+      # @return [String] read device bus id
       attr_accessor :read_channel
-      # @return [String] write bus id
+      # @return [String] write device bus id
       attr_accessor :write_channel
-      # @return [Integer] connection protocol
+      # @return [Integer] connection protocol (0, 1, 3, or 4)
+      #   0 Compatibility with peers other than OS/390®.
+      #   1 Enhanced package checking for Linux peers.
+      #   3 For compatibility with OS/390 or z/OS peers.
+      #   4 For MPC connections to VTAM on traditional mainframe operating systems.
+      # @see https://github.com/SUSE/s390-tools/blob/master/ctc_configure#L16
+      #
+      # # FIXME: At lease in linuxrc the protocol is not needed anymore for lcs
+      # interfaces (once replaced ctc_configure by chzdev)
       attr_accessor :protocol
-      # @return [Integer] lcs timeout
+      # The time the driver wait for a reply issuing a LAN command.
+      #
+      # @return [Integer] lcs lancmd timeout (default 5sg)
+      # @see https://www.ibm.com/support/knowledgecenter/en/linuxonibm/com.ibm.linux.z.ljdd/ljdd_t_lcs_wrk_timeout.html
       attr_accessor :timeout
 
       # Constructor

--- a/src/lib/y2network/connection_config/lcs.rb
+++ b/src/lib/y2network/connection_config/lcs.rb
@@ -1,0 +1,43 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/connection_config/base"
+
+module Y2Network
+  module ConnectionConfig
+    # Configuration for lcs connections
+    class Lcs < Base
+      # @return [String] read bus id
+      attr_accessor :read_channel
+      # @return [String] write bus id
+      attr_accessor :write_channel
+      # @return [Integer] connection protocol
+      attr_accessor :protocol
+      # @return [Integer] lcs timeout
+      attr_accessor :timeout
+
+      # Constructor
+      def initialize
+        super()
+        @protocol = 0
+        @timeout = 5
+      end
+    end
+  end
+end

--- a/src/lib/y2network/connection_config/lcs.rb
+++ b/src/lib/y2network/connection_config/lcs.rb
@@ -55,7 +55,7 @@ module Y2Network
       attr_accessor :protocol
       # The time the driver wait for a reply issuing a LAN command.
       #
-      # @return [Integer] lcs lancmd timeout (default 5sg)
+      # @return [Integer] lcs lancmd timeout (default 5s)
       # @see https://www.ibm.com/support/knowledgecenter/en/linuxonibm/com.ibm.linux.z.ljdd/ljdd_t_lcs_wrk_timeout.html
       attr_accessor :timeout
 

--- a/src/lib/y2network/sysconfig/connection_config_readers/dummy.rb
+++ b/src/lib/y2network/sysconfig/connection_config_readers/dummy.rb
@@ -17,14 +17,14 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2network/sysconfig/connection_config_readers/ethernet"
+require "y2network/sysconfig/connection_config_readers/base"
 
 module Y2Network
   module Sysconfig
     module ConnectionConfigReaders
       # This class is able to build a ConnectionConfig::Dummy object given a
       # Sysconfig::InterfaceFile object.
-      class Dummy < Ethernet
+      class Dummy < Base
       end
     end
   end

--- a/src/lib/y2network/sysconfig/connection_config_readers/hsi.rb
+++ b/src/lib/y2network/sysconfig/connection_config_readers/hsi.rb
@@ -17,14 +17,14 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2network/sysconfig/connection_config_readers/ethernet"
+require "y2network/sysconfig/connection_config_readers/base"
 
 module Y2Network
   module Sysconfig
     module ConnectionConfigReaders
       # This class is able to build a ConnectionConfig::Hsi object given a
       # Sysconfig::InterfaceFile object.
-      class Hsi < Ethernet
+      class Hsi < Base
       end
     end
   end

--- a/src/lib/y2network/sysconfig/connection_config_readers/lcs.rb
+++ b/src/lib/y2network/sysconfig/connection_config_readers/lcs.rb
@@ -1,0 +1,36 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/sysconfig/connection_config_readers/base"
+
+module Y2Network
+  module Sysconfig
+    module ConnectionConfigReaders
+      # This class is able to build a ConnectionConfig::Lcs object given a
+      # Sysconfig::InterfaceFile object.
+      class Lcs < Base
+      private
+
+        # @see Y2Network::Sysconfig::ConnectionConfigReaders::Base#update_connection_config
+        def update_connection_config(_conn)
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2network/sysconfig/connection_config_readers/lcs.rb
+++ b/src/lib/y2network/sysconfig/connection_config_readers/lcs.rb
@@ -25,11 +25,6 @@ module Y2Network
       # This class is able to build a ConnectionConfig::Lcs object given a
       # Sysconfig::InterfaceFile object.
       class Lcs < Base
-      private
-
-        # @see Y2Network::Sysconfig::ConnectionConfigReaders::Base#update_connection_config
-        def update_connection_config(_conn)
-        end
       end
     end
   end

--- a/src/lib/y2network/sysconfig/connection_config_readers/qeth.rb
+++ b/src/lib/y2network/sysconfig/connection_config_readers/qeth.rb
@@ -17,14 +17,14 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2network/sysconfig/connection_config_readers/ethernet"
+require "y2network/sysconfig/connection_config_readers/base"
 
 module Y2Network
   module Sysconfig
     module ConnectionConfigReaders
       # This class is able to build a ConnectionConfig::Qeth object given a
       # Sysconfig::InterfaceFile object.
-      class Qeth < Ethernet
+      class Qeth < Base
       end
     end
   end

--- a/src/lib/y2network/sysconfig/connection_config_writers/hsi.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writers/hsi.rb
@@ -17,14 +17,14 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2network/sysconfig/connection_config_writers/ethernet"
+require "y2network/sysconfig/connection_config_writers/base"
 
 module Y2Network
   module Sysconfig
     module ConnectionConfigWriters
       # This class is responsible for writing the information from a
       # ConnectionConfig::Hsi object to the underlying system.
-      class Hsi < Ethernet
+      class Hsi < Base
       end
     end
   end

--- a/src/lib/y2network/sysconfig/connection_config_writers/lcs.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writers/lcs.rb
@@ -25,11 +25,6 @@ module Y2Network
       # This class is responsible for writing the information from a ConnectionConfig::Lcs
       # object to the underlying system.
       class Lcs < Base
-      private
-
-        # @see Y2Network::ConnectionConfigWriters::Base#update_file
-        def update_file(_conn)
-        end
       end
     end
   end

--- a/src/lib/y2network/sysconfig/connection_config_writers/lcs.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writers/lcs.rb
@@ -1,0 +1,36 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/sysconfig/connection_config_writers/base"
+
+module Y2Network
+  module Sysconfig
+    module ConnectionConfigWriters
+      # This class is responsible for writing the information from a ConnectionConfig::Lcs
+      # object to the underlying system.
+      class Lcs < Base
+      private
+
+        # @see Y2Network::ConnectionConfigWriters::Base#update_file
+        def update_file(_conn)
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2network/sysconfig/connection_config_writers/qeth.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writers/qeth.rb
@@ -17,14 +17,14 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2network/sysconfig/connection_config_writers/ethernet"
+require "y2network/sysconfig/connection_config_writers/base"
 
 module Y2Network
   module Sysconfig
     module ConnectionConfigWriters
       # This class is responsible for writing the information from a ConnectionConfig::Qeth
       # object to the underlying system.
-      class Qeth < Ethernet
+      class Qeth < Base
       end
     end
   end

--- a/test/data/scr_read/etc/sysconfig/network/ifcfg-eth6
+++ b/test/data/scr_read/etc/sysconfig/network/ifcfg-eth6
@@ -1,0 +1,4 @@
+# LCS interface
+STARTMODE='auto'
+BOOTPROTO='static'
+IPADDR='192.168.70.100/24'

--- a/test/y2network/connection_config/lcs_test.rb
+++ b/test/y2network/connection_config/lcs_test.rb
@@ -1,0 +1,30 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/connection_config/lcs"
+require "y2network/interface_type"
+
+describe Y2Network::ConnectionConfig::Lcs do
+  describe "#type" do
+    it "returns 'lcs'" do
+      expect(subject.type).to eq(Y2Network::InterfaceType::LCS)
+    end
+  end
+end

--- a/test/y2network/sysconfig/connection_config_readers/lcs_test.rb
+++ b/test/y2network/sysconfig/connection_config_readers/lcs_test.rb
@@ -1,0 +1,49 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "y2network/sysconfig/connection_config_readers/lcs"
+require "y2network/sysconfig/interface_file"
+require "y2network/boot_protocol"
+
+describe Y2Network::Sysconfig::ConnectionConfigReaders::Lcs do
+  subject(:handler) { described_class.new(file) }
+
+  let(:scr_root) { File.join(DATA_PATH, "scr_read") }
+
+  around do |example|
+    change_scr_root(scr_root, &example)
+  end
+
+  let(:interface_name) { "eth6" }
+
+  let(:file) do
+    Y2Network::Sysconfig::InterfaceFile.find(interface_name).tap(&:load)
+  end
+
+  describe "#connection_config" do
+    it "returns a lcs connection config object" do
+      lcs = handler.connection_config
+      expect(lcs.type).to eql(Y2Network::InterfaceType::LCS)
+      expect(lcs.interface).to eq("eth6")
+      expect(lcs.ip.address).to eq(Y2Network::IPAddress.from_string("192.168.70.100/24"))
+      expect(lcs.bootproto).to eq(Y2Network::BootProtocol::STATIC)
+    end
+  end
+end

--- a/test/y2network/sysconfig/connection_config_writers/lcs_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/lcs_test.rb
@@ -1,0 +1,50 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+
+require "y2network/sysconfig/connection_config_writers/lcs"
+require "y2network/startmode"
+require "y2network/boot_protocol"
+require "y2network/connection_config/lcs"
+
+describe Y2Network::Sysconfig::ConnectionConfigWriters::Lcs do
+  subject(:handler) { described_class.new(file) }
+
+  let(:conn) do
+    Y2Network::ConnectionConfig::Lcs.new.tap do |c|
+      c.name        = "eth0"
+      c.interface   = "eth0"
+      c.bootproto   = Y2Network::BootProtocol::DHCP
+      c.startmode   = Y2Network::Startmode.create("auto")
+    end
+  end
+
+  let(:file) { Y2Network::Sysconfig::InterfaceFile.new(conn.name) }
+
+  describe "#write" do
+    it "writes common properties" do
+      handler.write(conn)
+      expect(file).to have_attributes(
+        bootproto: "dhcp",
+        startmode: "auto"
+      )
+    end
+  end
+end


### PR DESCRIPTION
- https://trello.com/c/DT4tgPgw/1145-3-add-missing-connectionconfig-classes

**TODO:** There are some recommendations done in another s390 connection config types pull requests like moving the s390 yardoc documentation to a macro that will be done as part of a new trello card for s390 configuration handling.