### PR TITLE
network-ng add interfaces renaming support

### DIFF
--- a/src/lib/network/edit_nic_name.rb
+++ b/src/lib/network/edit_nic_name.rb
@@ -19,33 +19,17 @@ module Yast
     # @return [String] current udev match criteria
     attr_reader :old_key
 
-    # udev rule attribute for MAC address
-    MAC_UDEV_ATTR   = "ATTR{address}".freeze
-
-    # udev rule attribute for BUS id
-    BUSID_UDEV_ATTR = "KERNELS".freeze
-
-    def initialize
+    # Constructor
+    #
+    # @param [Y2Network::InterfaceConfigBuilder] Interface configuration
+    def initialize(settings)
       textdomain "network"
-
-      Yast.include self, "network/routines.rb"
-
-      current_item = LanItems.getCurrentItem
-      current_rule = LanItems.current_udev_rule
-
-      @old_name = LanItems.current_udev_name
-      unless current_rule.empty?
-        @old_key = :mac unless LanItems.GetItemUdev(MAC_UDEV_ATTR).empty?
-        @old_key = :bus_id unless LanItems.GetItemUdev(BUSID_UDEV_ATTR).empty?
-      end
-
-      if current_item["hwinfo"]
-        @mac = current_item["hwinfo"]["permanent_mac"]
-        @bus_id = current_item["hwinfo"]["busid"]
-      else
-        @mac = ""
-        @bus_id = ""
-      end
+      @settings = settings
+      interface = settings.interface
+      @old_name = interface.name
+      @old_key = interface.renaming_mechanism
+      @mac = interface.hardware.mac
+      @bus_id = interface.hardware.busid
     end
 
     # Opens dialog for editing NIC name and runs event loop.
@@ -61,22 +45,16 @@ module Yast
         next if ret != :ok
 
         new_name = UI.QueryWidget(:dev_name, :Value)
+        udev_type = UI.QueryWidget(:udev_type, :CurrentButton)
 
         if CheckUdevNicName(new_name)
-          LanItems.rename(new_name)
+          @settings.rename_interface(new_name, udev_type)
         else
           UI.SetFocus(:dev_name)
           ret = nil
 
           next
         end
-
-        udev_type = UI.QueryWidget(:udev_type, :CurrentButton)
-
-        # FIXME: it changes udev key used for device identification
-        #  and / or its value only, name is changed elsewhere
-        LanItems.update_item_udev_rule!(udev_type) if udev_type && (old_key != udev_type)
-        LanItems.rename_current_device_in_routing(old_name) if new_name != old_name
       end
 
       close
@@ -146,11 +124,12 @@ module Yast
     # @return [boolean] false if name is invalid
     def CheckUdevNicName(name)
       # check if the name is assigned to another device already
-      if LanItems.GetNetcardNames.include?(name) && name != LanItems.GetCurrentName
+      if @settings.name_exists?(name)
         Popup.Error(_("Configuration name already exists."))
         return false
       end
-      if !ValidNicName(name)
+
+      if !@settings.valid_name?(name)
         Popup.Error(_("Invalid configuration name."))
         return false
       end

--- a/src/lib/network/edit_nic_name.rb
+++ b/src/lib/network/edit_nic_name.rb
@@ -21,7 +21,7 @@ module Yast
 
     # Constructor
     #
-    # @param [Y2Network::InterfaceConfigBuilder] Interface configuration
+    # @param settings [Y2Network::InterfaceConfigBuilder] Interface configuration
     def initialize(settings)
       textdomain "network"
       @settings = settings

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -129,6 +129,17 @@ module Y2Network
         routing == other.routing && dns == other.dns
     end
 
+    # Renames a given interface and the associated connections
+    #
+    # @param old_name  [String] Old interface's name
+    # @param new_name  [String] New interface's name
+    # @param mechanism [Symbol] Property to base the rename on (:mac or :bus_id)
+    def rename_interface(old_name, new_name, mechanism)
+      interface = interfaces.by_name(old_name)
+      interface.rename(new_name, mechanism)
+      connections.by_interface(old_name).each { |c| c.interface = new_name }
+    end
+
     alias_method :eql?, :==
   end
 end

--- a/src/lib/y2network/connection_configs_collection.rb
+++ b/src/lib/y2network/connection_configs_collection.rb
@@ -53,6 +53,14 @@ module Y2Network
       connection_configs.find { |c| c.name == name }
     end
 
+    # Returns connection configurations which are associated to the given interface
+    #
+    # @param interface_name [String] Interface name
+    # @return [Array<ConnectionConfig::Base>] Associated connection configs
+    def by_interface(interface_name)
+      connection_configs.select { |c| c.interface == interface_name }
+    end
+
     # Adds or updates a connection configuration
     #
     # @note It uses the name to do the matching.

--- a/src/lib/y2network/hwinfo.rb
+++ b/src/lib/y2network/hwinfo.rb
@@ -76,7 +76,8 @@ module Y2Network
       { name: "wl_auth_modes", default: "" },
       { name: "wl_enc_modes", default: nil },
       { name: "wl_channels", default: nil },
-      { name: "wl_bitrates", default: nil }
+      { name: "wl_bitrates", default: nil },
+      { name: "dev_port", default: nil }
     ].each do |hwinfo_item|
       define_method hwinfo_item[:name].downcase do
         @hwinfo ? @hwinfo.fetch(hwinfo_item[:name], hwinfo_item[:default]) : hwinfo_item[:default]
@@ -117,7 +118,14 @@ module Y2Network
     include Yast::I18n
 
     def load_hwinfo(name)
-      Yast::LanItems.Hardware.find { |h| h["dev_name"] == name }
+      hw = Yast::LanItems.Hardware.find { |h| h["dev_name"] == name }
+      return nil if hw.nil?
+
+      raw_dev_port = Yast::SCR.Read(
+        Yast::Path.new(".target.string"), "/sys/class_net/#{name}/dev_port"
+      ).to_s.strip
+      hw["dev_port"] = raw_dev_port unless raw_dev_port.empty?
+      hw
     end
   end
 end

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -45,6 +45,8 @@ module Y2Network
     attr_reader :configured
     # @return [HwInfo]
     attr_reader :hardware
+    # @return [Symbol] Mechanism to rename the interface (nil -no rename-, :bus_id or :mac)
+    attr_accessor :renaming_mechanism
 
     # Shortcuts for accessing interfaces' ifcfg options
     #

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -17,6 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast"
 require "y2network/interface_type"
 require "y2network/hwinfo"
 
@@ -35,6 +36,8 @@ module Y2Network
   # @see Y2Network::VirtualInterface
   # @see Y2Network::FakeInterface
   class Interface
+    include Yast::Logger
+
     # @return [String] Device name ('eth0', 'wlan0', etc.)
     attr_accessor :name
     # @return [String] Interface description
@@ -112,6 +115,7 @@ module Y2Network
     # @param new_name  [String] New interface's name
     # @param mechanism [Symbol] Property to base the rename on (:mac or :bus_id)
     def rename(new_name, mechanism)
+      log.info "Rename interface '#{name}' to '#{new_name}' using the '#{mechanism}'"
       @name = new_name
       @renaming_mechanism = mechanism
     end

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -107,6 +107,15 @@ module Y2Network
       hardware.drivers
     end
 
+    # Renames the interface
+    #
+    # @param new_name  [String] New interface's name
+    # @param mechanism [Symbol] Property to base the rename on (:mac or :bus_id)
+    def rename(new_name, mechanism)
+      @name = new_name
+      @renaming_mechanism = mechanism
+    end
+
   private
 
     def system_config(name)

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -50,7 +50,7 @@ module Y2Network
       require "y2network/interface_config_builders/#{type.file_name}"
       InterfaceConfigBuilders.const_get(type.class_name).new(config: config)
     rescue LoadError => e
-      log.info "Specialed builder for #{type} not found. Fallbacking to default. #{e.inspect}"
+      log.info "Specialized builder for #{type} not found. Falling back to default. #{e.inspect}"
       new(type: type, config: config)
     end
 
@@ -93,7 +93,8 @@ module Y2Network
 
       @connection_config.name = name
       @connection_config.interface = name
-      Yast::Lan.yast_config.connections.add_or_update(@connection_config)
+      yast_config.connections.add_or_update(@connection_config)
+      yast_config.rename_interface(@old_name, name, renaming_mechanism) if renamed_interface?
 
       # create new instance as name can change
       firewall_interface = Y2Firewall::Firewalld::Interface.new(name)
@@ -106,6 +107,40 @@ module Y2Network
       save_aliases
 
       nil
+    end
+
+    # Determines whether the interface has been renamed
+    #
+    # @return [Boolean] true if it was renamed; false otherwise
+    def renamed_interface?
+      name != interface.name || @renaming_mechanism != interface.renaming_mechanism
+    end
+
+    # Renames the interface
+    #
+    # @param new_name [String] New interface's name
+    # @param renaming_mechanism [Symbol,nil] Mechanism to rename the interface
+    #   (nil -no rename-, :mac or :bus_id)
+    def rename_interface(new_name, renaming_mechanism)
+      @old_name ||= name
+      self.name = new_name
+      @renaming_mechanism = renaming_mechanism
+    end
+
+    # Returns the current renaming mechanism
+    #
+    # @return [Symbol,nil] Mechanism to rename the interface (nil -no rename-, :mac or :bus_id)
+    def renaming_mechanism
+      @renaming_mechanism || interface.renaming_mechanism
+    end
+
+    # Returns the underlying interface
+    #
+    # If the interface has been renamed, take the old name into account.
+    #
+    # @return [Y2Network::Interface,nil]
+    def interface
+      @interface ||= yast_config.interfaces.by_name(@old_name || name)
     end
 
     # how many device names is proposed
@@ -601,6 +636,13 @@ module Y2Network
           id:    "_#{i}" # TODO: remember original prefixes
         )
       end
+    end
+
+    # Helper method to access to the current configuration
+    #
+    # @return [Y2Network::Config]
+    def yast_config
+      Yast::Lan.yast_config
     end
   end
 end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -113,6 +113,7 @@ module Y2Network
     #
     # @return [Boolean] true if it was renamed; false otherwise
     def renamed_interface?
+      return false unless interface
       name != interface.name || @renaming_mechanism != interface.renaming_mechanism
     end
 

--- a/src/lib/y2network/sysconfig/config_writer.rb
+++ b/src/lib/y2network/sysconfig/config_writer.rb
@@ -22,6 +22,7 @@ require "y2network/sysconfig_paths"
 require "y2network/sysconfig/routes_file"
 require "y2network/sysconfig/dns_writer"
 require "y2network/sysconfig/connection_config_writer"
+require "y2network/sysconfig/interfaces_writer"
 
 module Y2Network
   module Sysconfig
@@ -46,6 +47,7 @@ module Y2Network
         file.save
 
         write_dns_settings(config, old_config)
+        write_interfaces(config.interfaces)
         write_connections(config.connections)
       end
 
@@ -166,6 +168,15 @@ module Y2Network
         old_dns = old_config.dns if old_config
         writer = Y2Network::Sysconfig::DNSWriter.new
         writer.write(config.dns, old_dns)
+      end
+
+      # Updates the interfaces configuration
+      #
+      # @param interfaces [Y2Network::InterfacesCollection]
+      # @see Y2Network::Sysconfig::InterfacesWriter
+      def write_interfaces(interfaces)
+        writer = Y2Network::Sysconfig::InterfacesWriter.new
+        writer.write(interfaces)
       end
 
       # Writes connections configuration

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -75,10 +75,23 @@ module Y2Network
       # Physical interfaces are read from the old LanItems module
       def find_physical_interfaces
         return if @interfaces
-        physical_interfaces = Yast::LanItems.Hardware.map do |h|
+        physical_interfaces = hardware.map do |h|
           build_physical_interface(h)
         end
         @interfaces = Y2Network::InterfacesCollection.new(physical_interfaces)
+      end
+
+      # Returns hardware information
+      #
+      # This method makes sure that the hardware information was read.
+      #
+      # @todo It still relies on Yast::LanItems.Hardware
+      #
+      # @return [Array<Hash>] Hardware information
+      def hardware
+        Yast::LanItems.Hardware unless Yast::LanItems.Hardware.empty?
+        Yast::LanItems.Read # try again if no hardware was found
+        Yast::LanItems.Hardware
       end
 
       # Finds the connections configurations

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -26,6 +26,7 @@ require "y2network/fake_interface"
 require "y2network/sysconfig/connection_config_reader"
 require "y2network/interfaces_collection"
 require "y2network/connection_configs_collection"
+require "y2network/udev_rule"
 
 Yast.import "LanItems"
 Yast.import "NetworkInterfaces"
@@ -110,6 +111,7 @@ module Y2Network
         Y2Network::PhysicalInterface.new(data["dev_name"]).tap do |iface|
           iface.description = data["name"]
           type = data["type"] || Yast::NetworkInterfaces.GetTypeFromSysfs(iface.name)
+          iface.renaming_mechanism = renaming_mechanism_for(iface.name)
           iface.type = case type
           when nil then InterfaceType::ETHERNET
           when ::String then InterfaceType.from_short_name(type)
@@ -143,6 +145,20 @@ module Y2Network
       def add_interface(name, conn)
         interface_class = conn.virtual? ? VirtualInterface : FakeInterface
         @interfaces << interface_class.from_connection(name, conn)
+      end
+
+      # Detects the renaming mechanism used by the interface
+      #
+      # @param name [String] Interface's name
+      # @return [Symbol,nil] :mac (MAC address), :bus_id (BUS ID) or nil (no renaming)
+      def renaming_mechanism_for(name)
+        rule = UdevRule.find_for(name)
+        return nil unless rule
+        if rule.parts.any? { |p| p.key == "ATTR{address}" }
+          :mac
+        elsif rule.parts.any? { |p| p.key == "KERNELS" }
+          :bus_id
+        end
       end
     end
   end

--- a/src/lib/y2network/sysconfig/interfaces_writer.rb
+++ b/src/lib/y2network/sysconfig/interfaces_writer.rb
@@ -1,0 +1,64 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2network/udev_rule"
+require "yast2/execute"
+
+module Y2Network
+  module Sysconfig
+    # This class writes interfaces specific configuration
+    #
+    # Although it might be confusing, this class is only responsible for writing
+    # hardware specific configuration through udev rules.
+    #
+    # @see Y2Network::InterfacesCollection
+    class InterfacesWriter
+      # Writes interfaces hardware configuration and refreshes udev
+      #
+      # @param interfaces [Y2Network::InterfacesCollection] Interfaces collection
+      def write(interfaces)
+        udev_rules = interfaces.map { |i| udev_rule_for(i) }.compact
+        Y2Network::UdevRule.write(udev_rules)
+        update_udevd
+      end
+
+    private
+
+      # Creates an udev rule for the given interface
+      #
+      # @param iface [Interface] Interface to generate the udev rule for
+      # @return [UdevRule,nil] udev rule or nil if it is not needed
+      def udev_rule_for(iface)
+        case iface.renaming_mechanism
+        when :mac
+          Y2Network::UdevRule.new_mac_based_rename(iface.name, iface.hardware.mac)
+        when :bus_id
+          Y2Network::UdevRule.new_bus_id_based_rename(iface.name, iface.hardware.busid, iface.hardware.dev_port)
+        end
+      end
+
+      # Refreshes udev service
+      def update_udevd
+        Yast::Execute.on_target!("/usr/bin/udevadm", "control", "--reload")
+        Yast::Execute.on_target!("/usr/bin/udevadm", "trigger", "--subsystem-match=net", "--action=add")
+      end
+    end
+  end
+end

--- a/src/lib/y2network/sysconfig/interfaces_writer.rb
+++ b/src/lib/y2network/sysconfig/interfaces_writer.rb
@@ -56,8 +56,8 @@ module Y2Network
 
       # Refreshes udev service
       def update_udevd
-        Yast::Execute.on_target!("/usr/bin/udevadm", "control", "--reload")
-        Yast::Execute.on_target!("/usr/bin/udevadm", "trigger", "--subsystem-match=net", "--action=add")
+        Yast::Execute.on_target("/usr/bin/udevadm", "control", "--reload")
+        Yast::Execute.on_target("/usr/bin/udevadm", "trigger", "--subsystem-match=net", "--action=add")
       end
     end
   end

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -61,7 +61,7 @@ module Y2Network
       # Helper method to create a rename rule based on the BUS ID
       #
       # @param name     [String] Interface's name
-      # @param mac      [String] BUS ID (e.g., "0000:08:00.0")
+      # @param bus_id   [String] BUS ID (e.g., "0000:08:00.0")
       # @param dev_port [String] Device port
       def new_bus_id_based_rename(name, bus_id, dev_port = nil)
         parts = [UdevRulePart.new("KERNELS", "=", bus_id)]
@@ -100,7 +100,7 @@ module Y2Network
 
     # Constructor
     #
-    # @param [Array<UdevRulePart>] udev rule parts
+    # @param parts [Array<UdevRulePart>] udev rule parts
     def initialize(parts = [])
       @parts = parts
     end

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -53,10 +53,9 @@ module Y2Network
       # @param name [String] Interface's name
       # @param mac  [String] MAC address
       def new_mac_based_rename(name, mac)
-        new_network_rule([
-          UdevRulePart.new("ATTR{address}", "=", mac),
-          UdevRulePart.new("NAME", "=", name)
-        ])
+        new_network_rule(
+          [UdevRulePart.new("ATTR{address}", "=", mac), UdevRulePart.new("NAME", "=", name)]
+        )
       end
 
       # Helper method to create a rename rule based on the BUS ID

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -1,0 +1,125 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/udev_rule_part"
+
+module Y2Network
+  # Simple udev rule class
+  #
+  # This class represents a network udev rule. The current implementation is quite simplistic,
+  # featuring a pretty simple API.
+  #
+  # @example Create a rule containing some key/value pairs (rule part)
+  #   rule = Y2Network::UdevRule.new(
+  #     Y2Network::UdevRulePart.new("ATTR{address}", "==", "?*31:78:f2"),
+  #     Y2Network::UdevRulePart.new("NAME", "=", "mlx4_ib3")
+  #   )
+  #   rule.to_s #=> "ACTION==\"add\", SUBSYSTEM==\"net\", ATTR{address}==\"?*31:78:f2\", NAME=\"eth0\""
+  #
+  # @example Create a rule from a string
+  #   rule = UdevRule.find_for("eth0")
+  #   rule.to_s #=> "ACTION==\"add\", SUBSYSTEM==\"net\", ATTR{address}==\"?*31:78:f2\", NAME=\"eth0\""
+  class UdevRule
+    class << self
+      # Returns the udev rule for a given device
+      #
+      # @param device [String] Network device name
+      # @return [UdevRule] udev rule
+      def find_for(device)
+        rules_map = Yast::SCR.Read(Yast::Path.new(".udev_persistent.net")) || {}
+        return nil unless rules_map.key?(device)
+        parts = rules_map[device].map { |p| UdevRulePart.from_string(p) }
+        new(parts)
+      end
+
+      # Helper method to create a rename rule based on a MAC address
+      #
+      # @param name [String] Interface's name
+      # @param mac  [String] MAC address
+      def new_mac_based_rename(name, mac)
+        new_network_rule([
+          UdevRulePart.new("ATTR{address}", "=", mac),
+          UdevRulePart.new("NAME", "=", name)
+        ])
+      end
+
+      # Helper method to create a rename rule based on the BUS ID
+      #
+      # @param name     [String] Interface's name
+      # @param mac      [String] BUS ID (e.g., "0000:08:00.0")
+      # @param dev_port [String] Device port
+      def new_bus_id_based_rename(name, bus_id, dev_port = nil)
+        parts = [UdevRulePart.new("KERNELS", "=", bus_id)]
+        parts.push(UdevRulePart.new("ATTR{dev_port}", "=", dev_port)) if dev_port
+        parts.push(UdevRulePart.new("NAME", "=", name))
+        new_network_rule(parts)
+      end
+
+      # Returns a network rule
+      #
+      # The network rule includes some parts by default.
+      #
+      # @param parts [Array<UdevRulePart] Additional rule parts
+      # @return [UdevRule] udev rule
+      def new_network_rule(parts = [])
+        base_parts = [
+          UdevRulePart.new("SUBSYSTEM", "==", "net"),
+          UdevRulePart.new("ACTION", "==", "add"),
+          UdevRulePart.new("DRIVERS", "==", "?*"),
+          UdevRulePart.new("ATTR{type}", "==", "1")
+        ]
+        new(base_parts.concat(parts))
+      end
+
+      # Writes udev rules to the filesystem
+      #
+      # @param udev_rules [Array<UdevRule>] List of udev rules
+      def write(udev_rules)
+        Yast::SCR.Write(Yast::Path.new(".udev_persistent.rules"), udev_rules.map(&:to_s))
+        Yast::SCR.Write(Yast::Path.new(".udev_persistent.nil"), [])
+      end
+    end
+
+    # @return [Array<UdevRulePart>] Parts of the udev rule
+    attr_reader :parts
+
+    # Constructor
+    #
+    # @param [Array<UdevRulePart>] udev rule parts
+    def initialize(parts = [])
+      @parts = parts
+    end
+
+    # Adds a part to the rule
+    #
+    # @param key      [String] Key name
+    # @param operator [String] Operator
+    # @param value    [String] Value to match or assign
+    def add_part(key, operator, value)
+      @parts << UdevRulePart.new(key, operator, value)
+    end
+
+    # Returns an string representation that can be used in a rules file
+    #
+    # @return [String]
+    def to_s
+      parts.map(&:to_s).join(", ")
+    end
+  end
+end

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -65,8 +65,8 @@ module Y2Network
       # @param dev_port [String] Device port
       def new_bus_id_based_rename(name, bus_id, dev_port = nil)
         parts = [UdevRulePart.new("KERNELS", "=", bus_id)]
-        parts.push(UdevRulePart.new("ATTR{dev_port}", "=", dev_port)) if dev_port
-        parts.push(UdevRulePart.new("NAME", "=", name))
+        parts << UdevRulePart.new("ATTR{dev_port}", "=", dev_port) if dev_port
+        parts << UdevRulePart.new("NAME", "=", name)
         new_network_rule(parts)
       end
 
@@ -91,7 +91,7 @@ module Y2Network
       # @param udev_rules [Array<UdevRule>] List of udev rules
       def write(udev_rules)
         Yast::SCR.Write(Yast::Path.new(".udev_persistent.rules"), udev_rules.map(&:to_s))
-        Yast::SCR.Write(Yast::Path.new(".udev_persistent.nil"), [])
+        Yast::SCR.Write(Yast::Path.new(".udev_persistent.nil"), []) # Writes changes to the rules file
       end
     end
 

--- a/src/lib/y2network/udev_rule_part.rb
+++ b/src/lib/y2network/udev_rule_part.rb
@@ -1,0 +1,81 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Network
+  # Simple class to represent a key-value pair in a udev rule
+  #
+  # This class does not check whether operators or keys/values are valid or not. We can implement
+  # that logic later if required.
+  class UdevRulePart
+    # Regular expression to match a udev rule part
+    PART_REGEXP = Regexp.new("\\A(?<key>[A-Za-z\{\}]+)(?<operator>[^\"]+)\"(?<value>.+)\"\\Z")
+
+    class << self
+      # Returns a rule part from a string
+      #
+      # @example Simple case
+      #   part = UdevRulePart.from_string('ACTION=="add"')
+      #   part.key #=> "ACTION"
+      #   part.operator #=> "=="
+      #   part.value #=> "add"
+      #
+      # @param str [String] string form of an udev rule
+      # @return [UdevRule] udev rule object
+      def from_string(str)
+        match = PART_REGEXP.match(str)
+        return if match.nil?
+        new(match[:key], match[:operator], match[:value])
+      end
+    end
+    # @return [String] Key name
+    attr_accessor :key
+    # @return [String] Operator ("==", "!=", "=", "+=", "-=", ":=")
+    attr_accessor :operator
+    # @return [String] Value to match or assign
+    attr_accessor :value
+
+    # Constructor
+    #
+    # @param key      [String] Key name
+    # @param operator [String] Operator ("==", "!=", "=", "+=", "-=", ":=")
+    # @param value    [String] Value to match or assign
+    def initialize(key, operator, value)
+      @key = key
+      @operator = operator
+      @value = value
+    end
+
+    # Determines whether two udev rule parts are equivalent
+    #
+    # @param other [UdevRulePart] The rule part to compare with
+    # @return [Boolean]
+    def ==(other)
+      key == other.key && operator == other.operator && value == other.value
+    end
+
+    alias_method :eql?, :==
+
+    # Returns an string representation of the udev rule part
+    #
+    # @return [String]
+    def to_s
+      "#{key}#{operator}\"#{value}\""
+    end
+  end
+end

--- a/src/lib/y2network/udev_rule_part.rb
+++ b/src/lib/y2network/udev_rule_part.rb
@@ -35,6 +35,12 @@ module Y2Network
       #   part.operator #=> "=="
       #   part.value #=> "add"
       #
+      # @example Using globs
+      #   part = UdevRulePart.from_string('ATTR{address}=='"?*31:78:f2"')
+      #   part.key #=> "ATTR{æddress}"
+      #   part.operator #=> "=="
+      #   part.value #=> "\"?*31:78:f2\""
+
       # @param str [String] string form of an udev rule
       # @return [UdevRule] udev rule object
       def from_string(str)
@@ -45,7 +51,8 @@ module Y2Network
     end
     # @return [String] Key name
     attr_accessor :key
-    # @return [String] Operator ("==", "!=", "=", "+=", "-=", ":=")
+    # @return [String] Operator. There are two comparison operators ("==", "!=") and four assignment
+    #   operators ("=", "+=", "-=", ":="). See udev(7) for further information.
     attr_accessor :operator
     # @return [String] Value to match or assign
     attr_accessor :value

--- a/src/lib/y2network/widgets/udev_rules.rb
+++ b/src/lib/y2network/widgets/udev_rules.rb
@@ -27,7 +27,7 @@ module Y2Network
       end
 
       def handle
-        self.value = Yast::EditNicName.new.run
+        self.value = Yast::EditNicName.new(@settings).run
 
         nil
       end

--- a/test/default_route_test.rb
+++ b/test/default_route_test.rb
@@ -4,13 +4,17 @@ require_relative "test_helper"
 
 require "network/install_inf_convertor"
 require "y2network/interface_config_builder"
+require "y2network/interfaces_collection"
+require "y2network/physical_interface"
 
 Yast.import "Lan"
 
 describe "Yast::LanItemsClass" do
   subject { Yast::LanItems }
 
-  let(:config) { Y2Network::Config.new(source: :sysconfig) }
+  let(:config) { Y2Network::Config.new(interfaces: interfaces, source: :sysconfig) }
+  let(:interfaces) { Y2Network::InterfacesCollection.new([eth0]) }
+  let(:eth0) { Y2Network::PhysicalInterface.new("eth0") }
 
   before do
     allow(Yast::Lan).to receive(:yast_config).and_return(config)

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -20,6 +20,9 @@ require_relative "../test_helper"
 require "y2network/config"
 require "y2network/routing_table"
 require "y2network/interface"
+require "y2network/interfaces_collection"
+require "y2network/connection_config/ethernet"
+require "y2network/connection_configs_collection"
 require "y2network/sysconfig/config_reader"
 require "y2network/sysconfig/config_writer"
 
@@ -29,7 +32,9 @@ describe Y2Network::Config do
   end
 
   subject(:config) do
-    described_class.new(interfaces: [eth0], routing: routing, source: :sysconfig)
+    described_class.new(
+      interfaces: interfaces, connections: connections, routing: routing, source: :sysconfig
+    )
   end
 
   let(:route1) { Y2Network::Route.new }
@@ -39,6 +44,15 @@ describe Y2Network::Config do
   let(:table2) { Y2Network::RoutingTable.new([route2]) }
 
   let(:eth0) { Y2Network::Interface.new("eth0") }
+  let(:interfaces) { Y2Network::InterfacesCollection.new([eth0]) }
+
+  let(:eth0_conn) do
+    Y2Network::ConnectionConfig::Ethernet.new.tap do |conn|
+      conn.interface = "eth0"
+    end
+  end
+  let(:connections) { Y2Network::ConnectionConfigsCollection.new([eth0_conn]) }
+
 
   let(:routing) { Y2Network::Routing.new(tables: [table1, table2]) }
 
@@ -127,7 +141,7 @@ describe Y2Network::Config do
 
     context "when interfaces list is different" do
       it "returns false" do
-        copy.interfaces = [Y2Network::Interface.new("eth1")]
+        copy.interfaces = Y2Network::InterfacesCollection.new([Y2Network::Interface.new("eth1")])
         expect(copy).to_not eq(config)
       end
     end
@@ -144,6 +158,20 @@ describe Y2Network::Config do
         copy.dns.hostname = "dummy"
         expect(copy).to_not eq(config)
       end
+    end
+  end
+
+  describe "#rename_interface" do
+    it "adjusts the interface name" do
+      config.rename_interface("eth0", "eth1", :mac)
+      eth1 = config.interfaces.by_name("eth1")
+      expect(eth1.renaming_mechanism).to eq(:mac)
+    end
+
+    it "adjusts the connection configurations for that interface" do
+      config.rename_interface("eth0", "eth1", :mac)
+      eth1_conns = config.connections.by_interface("eth1")
+      expect(eth1_conns).to_not be_empty
     end
   end
 end

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -53,7 +53,6 @@ describe Y2Network::Config do
   end
   let(:connections) { Y2Network::ConnectionConfigsCollection.new([eth0_conn]) }
 
-
   let(:routing) { Y2Network::Routing.new(tables: [table1, table2]) }
 
   describe ".from" do

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -172,5 +172,21 @@ describe Y2Network::Config do
       eth1_conns = config.connections.by_interface("eth1")
       expect(eth1_conns).to_not be_empty
     end
+
+    context "when the interface is renamed twice" do
+      it "adjusts the interface name to the last name" do
+        config.rename_interface("eth0", "eth1", :mac)
+        config.rename_interface("eth1", "eth2", :bios_id)
+        eth2 = config.interfaces.by_name("eth2")
+        expect(eth2.renaming_mechanism).to eq(:bios_id)
+      end
+
+      it "adjusts the connection configurations for that interface using the last name" do
+        config.rename_interface("eth0", "eth1", :mac)
+        config.rename_interface("eth1", "eth2", :mac)
+        eth2_conns = config.connections.by_interface("eth2")
+        expect(eth2_conns).to_not be_empty
+      end
+    end
   end
 end

--- a/test/y2network/connection_configs_collection_test.rb
+++ b/test/y2network/connection_configs_collection_test.rb
@@ -26,7 +26,12 @@ describe Y2Network::ConnectionConfigsCollection do
   subject(:collection) { described_class.new(connections) }
 
   let(:connections) { [eth0, wlan0] }
-  let(:eth0) { Y2Network::ConnectionConfig::Ethernet.new.tap { |c| c.name = "eth0" } }
+  let(:eth0) do
+    Y2Network::ConnectionConfig::Ethernet.new.tap do |conn|
+      conn.name = "eth0"
+      conn.interface = "eth0"
+    end
+  end
   let(:wlan0) { Y2Network::ConnectionConfig::Wireless.new.tap { |c| c.name = "wlan0" } }
 
   describe "#by_name" do
@@ -38,6 +43,12 @@ describe Y2Network::ConnectionConfigsCollection do
       it "returns nil" do
         expect(collection.by_name("eth1")).to be_nil
       end
+    end
+  end
+
+  describe "#by_interface" do
+    it "returns the connection configurations associated to the given interface name" do
+      expect(collection.by_interface("eth0")).to eq([eth0])
     end
   end
 

--- a/test/y2network/hwinfo_test.rb
+++ b/test/y2network/hwinfo_test.rb
@@ -56,4 +56,30 @@ describe Y2Network::Hwinfo do
       )
     end
   end
+
+  describe "#dev_port" do
+    let(:interface_name) { "enp1s0" }
+
+    before do
+      allow(Yast::SCR).to receive(:Read)
+        .with(Yast::Path.new(".target.string"), "/sys/class_net/#{interface_name}/dev_port")
+        .and_return(raw_dev_port)
+    end
+
+    context "when the dev_port is defined" do
+      let(:raw_dev_port) { "0000:08:00.0" }
+
+      it "returns the dev_port" do
+        expect(hwinfo.dev_port).to eq("0000:08:00.0")
+      end
+    end
+
+    context "when the dev_port is not defined" do
+      let(:raw_dev_port) { "\n" }
+
+      it "returns the dev_port" do
+        expect(hwinfo.dev_port).to be_nil
+      end
+    end
+  end
 end

--- a/test/y2network/interface_config_builder_test.rb
+++ b/test/y2network/interface_config_builder_test.rb
@@ -4,6 +4,8 @@ require_relative "../test_helper"
 
 require "yast"
 require "y2network/interface_config_builder"
+require "y2network/interfaces_collection"
+require "y2network/physical_interface"
 
 Yast.import "Lan"
 
@@ -14,7 +16,9 @@ describe Y2Network::InterfaceConfigBuilder do
     res
   end
 
-  let(:config) { Y2Network::Config.new(source: :sysconfig) }
+  let(:config) { Y2Network::Config.new(interfaces: interfaces, source: :sysconfig) }
+  let(:interfaces) { Y2Network::InterfacesCollection.new([eth0]) }
+  let(:eth0) { Y2Network::PhysicalInterface.new("eth0") }
 
   before do
     allow(Yast::Lan).to receive(:yast_config).and_return(config)
@@ -77,6 +81,25 @@ describe Y2Network::InterfaceConfigBuilder do
       ip_alias = connection_config.ip_aliases.first
       expect(ip_alias.address).to eq(Y2Network::IPAddress.new("10.0.0.0", 24))
       expect(ip_alias.label).to eq("test")
+    end
+
+    context "when interface was renamed" do
+      before do
+        subject.rename_interface("eth2", :mac)
+      end
+
+      it "updates the name in the configuration" do
+        expect(Yast::Lan.yast_config).to receive(:rename_interface)
+          .with("eth0", "eth2", :mac)
+        subject.save
+      end
+    end
+
+    context "when interface was not renamed" do
+      it "does not alter the name" do
+        expect(Yast::Lan.yast_config).to_not receive(:rename_interface)
+        subject.save
+      end
     end
   end
 
@@ -166,6 +189,47 @@ describe Y2Network::InterfaceConfigBuilder do
             expect(result).to be_eql expected_startmode
           end
         end
+      end
+    end
+  end
+
+  describe "#rename_interface" do
+    it "updates the interface name" do
+      expect { config_builder.rename_interface("eth2", :mac) }
+        .to change { config_builder.name }.from("eth0").to("eth2")
+    end
+
+    it "updates the renaming mechanism" do
+      expect { config_builder.rename_interface("eth2", :mac) }
+        .to change { config_builder.renaming_mechanism }.from(nil).to(:mac)
+    end
+  end
+
+  describe "#renamed_interface?" do
+    context "when the interface has been renamed" do
+      it "returns false" do
+        expect(config_builder.renamed_interface?).to eq(false)
+      end
+    end
+
+    context "when the interface has been renamed" do
+      before do
+        config_builder.rename_interface("eth2", :mac)
+      end
+
+      it "returns true" do
+        expect(config_builder.renamed_interface?).to eq(true)
+      end
+    end
+
+    context "when the old name and mechanism have been restored " do
+      before do
+        config_builder.rename_interface("eth2", :mac)
+      end
+
+      it "returns false" do
+        config_builder.rename_interface("eth0", nil)
+        expect(config_builder.renamed_interface?).to eq(false)
       end
     end
   end

--- a/test/y2network/interface_config_builders/infiniband_test.rb
+++ b/test/y2network/interface_config_builders/infiniband_test.rb
@@ -4,6 +4,8 @@ require_relative "../../test_helper"
 
 require "yast"
 require "y2network/interface_config_builders/infiniband"
+require "y2network/interfaces_collection"
+require "y2network/physical_interface"
 
 describe Y2Network::InterfaceConfigBuilders::Infiniband do
   subject(:config_builder) do
@@ -12,7 +14,9 @@ describe Y2Network::InterfaceConfigBuilders::Infiniband do
     res
   end
 
-  let(:config) { Y2Network::Config.new(source: :sysconfig) }
+  let(:config) { Y2Network::Config.new(interfaces: interfaces, source: :sysconfig) }
+  let(:interfaces) { Y2Network::InterfacesCollection.new([ib0]) }
+  let(:ib0) { Y2Network::PhysicalInterface.new("ib0") }
 
   before do
     allow(Yast::Lan).to receive(:yast_config).and_return(config)

--- a/test/y2network/sysconfig/config_writer_test.rb
+++ b/test/y2network/sysconfig/config_writer_test.rb
@@ -20,6 +20,7 @@ require_relative "../../test_helper"
 require "y2network/sysconfig/config_writer"
 require "y2network/config"
 require "y2network/interface"
+require "y2network/interfaces_collection"
 require "y2network/routing"
 require "y2network/route"
 require "y2network/routing_table"
@@ -33,7 +34,7 @@ describe Y2Network::Sysconfig::ConfigWriter do
   describe "#write" do
     let(:config) do
       Y2Network::Config.new(
-        interfaces:  [eth0],
+        interfaces:  Y2Network::InterfacesCollection.new([eth0]),
         connections: [eth0_conn],
         routing:     routing,
         source:      :sysconfig
@@ -83,6 +84,7 @@ describe Y2Network::Sysconfig::ConfigWriter do
 
     let(:dns_writer) { instance_double(Y2Network::Sysconfig::DNSWriter, write: nil) }
     let(:conn_writer) { instance_double(Y2Network::Sysconfig::ConnectionConfigWriter, write: nil) }
+    let(:interfaces_writer)  { instance_double(Y2Network::Sysconfig::InterfacesWriter, write: nil) }
 
     before do
       allow(Y2Network::Sysconfig::RoutesFile).to receive(:new)
@@ -95,6 +97,8 @@ describe Y2Network::Sysconfig::ConfigWriter do
         .and_return(dns_writer)
       allow(Y2Network::Sysconfig::ConnectionConfigWriter).to receive(:new)
         .and_return(conn_writer)
+      allow(Y2Network::Sysconfig::InterfacesWriter).to receive(:new)
+        .and_return(interfaces_writer)
       allow(eth0).to receive(:configured).and_return(true)
     end
 
@@ -197,6 +201,11 @@ describe Y2Network::Sysconfig::ConfigWriter do
     it "writes connections configurations" do
       expect(conn_writer).to receive(:write).with(eth0_conn)
       writer.write(config, old_config)
+    end
+
+    it "writes interfaces configurations" do
+      expect(interfaces_writer).to receive(:write).with(config.interfaces)
+      writer.write(config)
     end
   end
 end

--- a/test/y2network/sysconfig/config_writer_test.rb
+++ b/test/y2network/sysconfig/config_writer_test.rb
@@ -84,7 +84,7 @@ describe Y2Network::Sysconfig::ConfigWriter do
 
     let(:dns_writer) { instance_double(Y2Network::Sysconfig::DNSWriter, write: nil) }
     let(:conn_writer) { instance_double(Y2Network::Sysconfig::ConnectionConfigWriter, write: nil) }
-    let(:interfaces_writer)  { instance_double(Y2Network::Sysconfig::InterfacesWriter, write: nil) }
+    let(:interfaces_writer) { instance_double(Y2Network::Sysconfig::InterfacesWriter, write: nil) }
 
     before do
       allow(Y2Network::Sysconfig::RoutesFile).to receive(:new)

--- a/test/y2network/sysconfig/interfaces_reader_test.rb
+++ b/test/y2network/sysconfig/interfaces_reader_test.rb
@@ -35,10 +35,12 @@ describe Y2Network::Sysconfig::InterfacesReader do
   end
 
   let(:udev_rule) do
-    Y2Network::UdevRule.new([
-      Y2Network::UdevRulePart.new("ATTR{address}", "==", "00:12:34:56:78"),
-      Y2Network::UdevRulePart.new("ACTION", "=", "eth0")
-    ])
+    Y2Network::UdevRule.new(
+      [
+        Y2Network::UdevRulePart.new("ATTR{address}", "==", "00:12:34:56:78"),
+        Y2Network::UdevRulePart.new("ACTION", "=", "eth0")
+      ]
+    )
   end
 
   let(:configured_interfaces) { ["lo", "eth0"] }

--- a/test/y2network/sysconfig/interfaces_reader_test.rb
+++ b/test/y2network/sysconfig/interfaces_reader_test.rb
@@ -19,6 +19,7 @@
 
 require_relative "../../test_helper"
 require "y2network/sysconfig/interfaces_reader"
+require "y2network/udev_rule_part"
 
 describe Y2Network::Sysconfig::InterfacesReader do
   subject(:reader) { described_class.new }
@@ -33,6 +34,13 @@ describe Y2Network::Sysconfig::InterfacesReader do
     }
   end
 
+  let(:udev_rule) do
+    Y2Network::UdevRule.new([
+      Y2Network::UdevRulePart.new("ATTR{address}", "==", "00:12:34:56:78"),
+      Y2Network::UdevRulePart.new("ACTION", "=", "eth0")
+    ])
+  end
+
   let(:configured_interfaces) { ["lo", "eth0"] }
   TYPES = { "eth0" => "eth" }.freeze
 
@@ -42,6 +50,7 @@ describe Y2Network::Sysconfig::InterfacesReader do
       .and_return(configured_interfaces)
     allow(Yast::SCR).to receive(:Dir).and_call_original
     allow(Yast::NetworkInterfaces).to receive(:GetTypeFromSysfs) { |n| TYPES[n] }
+    allow(Y2Network::UdevRule).to receive(:find_for).and_return(udev_rule)
   end
 
   around { |e| change_scr_root(File.join(DATA_PATH, "scr_read"), &e) }
@@ -50,6 +59,11 @@ describe Y2Network::Sysconfig::InterfacesReader do
     it "reads physical interfaces" do
       interfaces = reader.interfaces
       expect(interfaces.by_name("eth0")).to_not be_nil
+    end
+
+    it "sets the renaming mechanism" do
+      eth0 = reader.interfaces.by_name("eth0")
+      expect(eth0.renaming_mechanism).to eq(:mac)
     end
 
     it "reads wifi interfaces"

--- a/test/y2network/sysconfig/interfaces_writer_test.rb
+++ b/test/y2network/sysconfig/interfaces_writer_test.rb
@@ -1,0 +1,89 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/sysconfig/interfaces_writer"
+require "y2network/udev_rule"
+require "y2network/physical_interface"
+require "y2network/interfaces_collection"
+
+describe Y2Network::Sysconfig::InterfacesWriter do
+  subject(:writer) { described_class.new }
+
+  describe "#write" do
+    let(:interfaces) { Y2Network::InterfacesCollection.new([eth0]) }
+    let(:eth0) do
+      Y2Network::PhysicalInterface.new("eth0").tap { |i| i.renaming_mechanism = renaming_mechanism }
+    end
+    let(:hardware) do
+      instance_double(Y2Network::Hwinfo, busid: "00:1c.0", mac: "01:23:45:67:89:ab", dev_port: "1")
+    end
+    let(:renaming_mechanism) { nil }
+
+    before do
+      allow(Yast::Execute).to receive(:on_target!)
+      allow(eth0).to receive(:hardware).and_return(hardware)
+    end
+
+    context "when the interface is renamed using the MAC" do
+      let(:renaming_mechanism) { :mac }
+
+      it "writes a MAC based udev renaming rule" do
+        expect(Y2Network::UdevRule).to receive(:write) do |rules|
+          expect(rules.first.to_s).to eq(
+            "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", " \
+            "ATTR{type}==\"1\", ATTR{address}=\"01:23:45:67:89:ab\", NAME=\"eth0\""
+          )
+        end
+        subject.write(interfaces)
+      end
+    end
+
+    context "when the interface is renamed using the BUS ID" do
+      let(:renaming_mechanism) { :bus_id }
+
+      it "writes a BUS ID based udev renaming rule" do
+        expect(Y2Network::UdevRule).to receive(:write) do |rules|
+          expect(rules.first.to_s).to eq(
+            "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", " \
+              "ATTR{type}==\"1\", KERNELS=\"00:1c.0\", ATTR{dev_port}=\"1\", NAME=\"eth0\""
+          )
+        end
+        subject.write(interfaces)
+      end
+    end
+
+    context "when the interface is not renamed" do
+      let(:renaming_mechanism) { nil }
+
+      it "does not write a udev rule" do
+        expect(Y2Network::UdevRule).to receive(:write) do |rules|
+          expect(rules).to be_empty
+        end
+        subject.write(interfaces)
+      end
+    end
+
+    it "refreshes udev" do
+      expect(Yast::Execute).to receive(:on_target!).with("/usr/bin/udevadm", "control", any_args)
+      expect(Yast::Execute).to receive(:on_target!).with("/usr/bin/udevadm", "trigger", any_args)
+      subject.write(interfaces)
+    end
+  end
+end

--- a/test/y2network/sysconfig/interfaces_writer_test.rb
+++ b/test/y2network/sysconfig/interfaces_writer_test.rb
@@ -37,7 +37,7 @@ describe Y2Network::Sysconfig::InterfacesWriter do
     let(:renaming_mechanism) { nil }
 
     before do
-      allow(Yast::Execute).to receive(:on_target!)
+      allow(Yast::Execute).to receive(:on_target)
       allow(eth0).to receive(:hardware).and_return(hardware)
     end
 
@@ -81,8 +81,8 @@ describe Y2Network::Sysconfig::InterfacesWriter do
     end
 
     it "refreshes udev" do
-      expect(Yast::Execute).to receive(:on_target!).with("/usr/bin/udevadm", "control", any_args)
-      expect(Yast::Execute).to receive(:on_target!).with("/usr/bin/udevadm", "trigger", any_args)
+      expect(Yast::Execute).to receive(:on_target).with("/usr/bin/udevadm", "control", any_args)
+      expect(Yast::Execute).to receive(:on_target).with("/usr/bin/udevadm", "trigger", any_args)
       subject.write(interfaces)
     end
   end

--- a/test/y2network/udev_rule_part_test.rb
+++ b/test/y2network/udev_rule_part_test.rb
@@ -1,0 +1,78 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2network/udev_rule_part"
+
+describe Y2Network::UdevRulePart do
+  subject(:part) { described_class.new(key, operator, value) }
+
+  let(:key) { "ACTION" }
+  let(:operator) { "==" }
+  let(:value) { "add" }
+
+  describe ".from_string" do
+    it "returns an udev rule part extracting the elements from the string" do
+      part = described_class.from_string("ACTION==\"add\"")
+      expect(part.key).to eq("ACTION")
+      expect(part.operator).to eq("==")
+      expect(part.value).to eq("add")
+    end
+  end
+
+  describe "#to_s" do
+    it "returns an string representation compatible with rules files format" do
+      expect(part.to_s).to eq('ACTION=="add"')
+    end
+  end
+
+  describe "#==" do
+    let(:other) { described_class.new("ACTION", "==", "add") }
+
+    context "when key, operator and value are the same" do
+      it "returns true" do
+        expect(part).to eq(other)
+      end
+    end
+
+    context "when the key differs" do
+      let(:key) { "ENV{var1}" }
+
+      it "returns false" do
+        expect(part).to_not eq(other)
+      end
+    end
+
+    context "when the operator differs" do
+      let(:operator) { "!=" }
+
+      it "returns false" do
+        expect(part).to_not eq(other)
+      end
+    end
+
+    context "when the value differs" do
+      let(:value) { "remove" }
+
+      it "returns false" do
+        expect(part).to_not eq(other)
+      end
+    end
+  end
+end

--- a/test/y2network/udev_rule_test.rb
+++ b/test/y2network/udev_rule_test.rb
@@ -23,6 +23,8 @@ require "y2network/udev_rule"
 describe Y2Network::UdevRule do
   subject(:udev_rule) { described_class.new(parts) }
 
+  before { described_class.reset_cache }
+
   let(:parts) { [] }
 
   let(:udev_persistent) do

--- a/test/y2network/udev_rule_test.rb
+++ b/test/y2network/udev_rule_test.rb
@@ -1,0 +1,107 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2network/udev_rule"
+
+describe Y2Network::UdevRule do
+  subject(:udev_rule) { described_class.new(parts) }
+
+  let(:parts) { [] }
+
+  let(:udev_persistent) do
+    {
+      "eth0" => ["SUBSYSTEM==\"net\"", "ACTION==\"add\"", "ATTR{address}==\"?*31:78:f2\"", "NAME=\"eth0\""]
+    }
+  end
+
+  before do
+    allow(Yast::SCR).to receive(:Read).with(Yast::Path.new(".udev_persistent.net"))
+      .and_return(udev_persistent)
+  end
+
+  describe ".find_for" do
+    it "returns the udev rule for the given device" do
+      rule = described_class.find_for("eth0")
+      expect(rule.to_s).to eq(
+        "SUBSYSTEM==\"net\", ACTION==\"add\", ATTR{address}==\"?*31:78:f2\", NAME=\"eth0\""
+      )
+    end
+
+    context "when there is no udev rule for the given device" do
+      it "returns nil" do
+        expect(described_class.find_for("eth1")).to be_nil
+      end
+    end
+  end
+
+  describe ".new_mac_based_rename" do
+    it "returns a MAC based renaming rule" do
+      rule = described_class.new_mac_based_rename("eth0", "01:23:45:67:89:ab")
+      expect(rule.to_s).to eq(
+        "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", ATTR{type}==\"1\", " \
+          "ATTR{address}=\"01:23:45:67:89:ab\", NAME=\"eth0\""
+      )
+    end
+  end
+
+  describe ".new_bus_id_based_rename" do
+    it "returns a BUS ID based renaming rule" do
+      rule = described_class.new_bus_id_based_rename("eth0", "0000:08:00.0", "1")
+      expect(rule.to_s).to eq(
+        "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", ATTR{type}==\"1\", " \
+          "KERNELS=\"0000:08:00.0\", ATTR{dev_port}=\"1\", NAME=\"eth0\""
+      )
+    end
+
+    context "when the dev_port is not defined" do
+      it "does not include the dev_port part" do
+        rule = described_class.new_bus_id_based_rename("eth0", "0000:08:00.0")
+        expect(rule.to_s).to eq(
+          "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", ATTR{type}==\"1\", " \
+            "KERNELS=\"0000:08:00.0\", NAME=\"eth0\""
+        )
+      end
+    end
+  end
+
+  describe "#add_part" do
+    it "adds a new key/value to the rule" do
+      udev_rule.add_part("ACTION", "==", "add")
+      expect(udev_rule.parts).to eq([
+        Y2Network::UdevRulePart.new("ACTION", "==", "add")
+      ])
+    end
+  end
+
+  describe "#to_s" do
+    let(:parts) do
+      [
+        Y2Network::UdevRulePart.new("ACTION", "==", "add"),
+        Y2Network::UdevRulePart.new("NAME", "=", "dummy")
+      ]
+    end
+
+    it "returns the string representation for the rules file" do
+      expect(udev_rule.to_s).to eq(
+        'ACTION=="add", NAME="dummy"'
+      )
+    end
+  end
+end

--- a/test/y2network/udev_rule_test.rb
+++ b/test/y2network/udev_rule_test.rb
@@ -84,9 +84,9 @@ describe Y2Network::UdevRule do
   describe "#add_part" do
     it "adds a new key/value to the rule" do
       udev_rule.add_part("ACTION", "==", "add")
-      expect(udev_rule.parts).to eq([
-        Y2Network::UdevRulePart.new("ACTION", "==", "add")
-      ])
+      expect(udev_rule.parts).to eq(
+        [Y2Network::UdevRulePart.new("ACTION", "==", "add")]
+      )
     end
   end
 


### PR DESCRIPTION
This PR implements support to rename an interface using a udev rule.

* [x] Handle udev rules
* [x] Add an API to rename interfaces
* [x] Adapt UI
* [ ] Rename routes
* [ ] Support for hotplug devices
* [ ] Do not overwrite custom rules