### PR TITLE
network-ng: keep custom udev rules

### DIFF
--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -84,6 +84,16 @@ module Y2Network
       self
     end
 
+    # Returns all interfaces names
+    #
+    # For those interfaces that are renamed, the new and old names are included
+    # in the list.
+    #
+    # @return [Array<String>] List of known interfaces
+    def known_names
+      @interfaces.map { |i| [i.old_name, i.name] }.flatten.compact
+    end
+
     # Compares InterfacesCollections
     #
     # @return [Boolean] true when both collections contain only equal interfaces,

--- a/test/y2network/interfaces_collection_test.rb
+++ b/test/y2network/interfaces_collection_test.rb
@@ -91,4 +91,19 @@ describe Y2Network::InterfacesCollection do
       end
     end
   end
+
+  describe "#known_names" do
+    it "returns the list of known interfaces" do
+      expect(collection.known_names).to eq(["eth0", "br0", "wlan0"])
+    end
+
+    context "when an interface was renamed" do
+      before do
+        eth0.rename("eth1", :mac)
+      end
+      it "returns the old and the new names" do
+        expect(collection.known_names).to eq(["eth0", "eth1", "br0", "wlan0"])
+      end
+    end
+  end
 end

--- a/test/y2network/sysconfig/interfaces_writer_test.rb
+++ b/test/y2network/sysconfig/interfaces_writer_test.rb
@@ -41,6 +41,7 @@ describe Y2Network::Sysconfig::InterfacesWriter do
     before do
       allow(Yast::Execute).to receive(:on_target)
       allow(eth0).to receive(:hardware).and_return(hardware)
+      allow(writer).to receive(:sleep)
     end
 
     around do |example|

--- a/test/y2network/sysconfig/interfaces_writer_test.rb
+++ b/test/y2network/sysconfig/interfaces_writer_test.rb
@@ -111,6 +111,21 @@ describe Y2Network::Sysconfig::InterfacesWriter do
           subject.write(interfaces)
         end
       end
+
+      context "when there is some rule for an unknown interface" do
+        let(:unknown_rule) { Y2Network::UdevRule.new_mac_based_rename("unknown", "00:11:22:33:44:55:66") }
+
+        before do
+          allow(Y2Network::UdevRule).to receive(:all).and_return([unknown_rule])
+        end
+
+        it "keeps the rule" do
+          expect(Y2Network::UdevRule).to receive(:write) do |rules|
+            expect(rules.first.to_s).to eq(unknown_rule.to_s)
+          end
+          subject.write(interfaces)
+        end
+      end
     end
 
     context "when the interface is not renamed" do

--- a/test/y2network/udev_rule_test.rb
+++ b/test/y2network/udev_rule_test.rb
@@ -140,7 +140,7 @@ describe Y2Network::UdevRule do
     end
   end
 
-  describe "#bus_id" do
+  describe "#dev_port" do
     subject(:udev_rule) { described_class.new_bus_id_based_rename("eth0", "0000:08:00.0", "1") }
 
     it "returns the device port from the udev rule" do
@@ -153,6 +153,14 @@ describe Y2Network::UdevRule do
       it "returns nil" do
         expect(udev_rule.dev_port).to be_nil
       end
+    end
+  end
+
+  describe "#device" do
+    subject(:udev_rule) { described_class.new_mac_based_rename("eth0", "01:23:45:67:89:ab") }
+
+    it "returns device" do
+      expect(udev_rule.device).to eq("eth0")
     end
   end
 end


### PR DESCRIPTION
Do not overwrite rules for unknown devices (an unknown device is that interface which is not mentioned in the configuration -not even in renames, e.g. a hotplug device with no configuration file-).

Take into account that `.udev_persistent.net` only reads `NAME=` rules (ignoring the rest). The good thing is that, when writing, the "rest" is kept as it is (and only `NAME=` rules are replaced).