### PR TITLE
network-ng: bridge interface relationship

### DIFF
--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -48,7 +48,7 @@ module Y2Network
     attr_reader :configured
     # @return [HwInfo]
     attr_reader :hardware
-    # @return [Symbol] Mechanism to rename the interface (nil -no rename-, :bus_id or :mac)
+    # @return [Symbol] Mechanism to rename the interface (:none -no rename-, :bus_id or :mac)
     attr_accessor :renaming_mechanism
     # @return [String,nil]
     attr_reader :old_name
@@ -78,6 +78,7 @@ module Y2Network
       @name = name
       @description = ""
       @type = type
+      @renaming_mechanism = :none
       # @hardware and @name should not change during life of the object
       @hardware = Hwinfo.for(name)
 

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -151,14 +151,16 @@ module Y2Network
       # Detects the renaming mechanism used by the interface
       #
       # @param name [String] Interface's name
-      # @return [Symbol,nil] :mac (MAC address), :bus_id (BUS ID) or nil (no renaming)
+      # @return [Symbol] :mac (MAC address), :bus_id (BUS ID) or :none (no renaming)
       def renaming_mechanism_for(name)
         rule = UdevRule.find_for(name)
-        return nil unless rule
+        return :none unless rule
         if rule.parts.any? { |p| p.key == "ATTR{address}" }
           :mac
         elsif rule.parts.any? { |p| p.key == "KERNELS" }
           :bus_id
+        else
+          :none
         end
       end
     end

--- a/test/y2network/interface_config_builder_test.rb
+++ b/test/y2network/interface_config_builder_test.rb
@@ -112,9 +112,19 @@ describe Y2Network::InterfaceConfigBuilder do
   end
 
   describe "#renamed_interface?" do
-    context "when the interface has been renamed" do
+    context "when the interface name has not been changed" do
       it "returns false" do
         expect(config_builder.renamed_interface?).to eq(false)
+      end
+
+      context "but it was initially renamed by udev" do
+        before do
+          allow(eth0).to receive(:renaming_mechanism).and_return(:mac)
+        end
+
+        it "returns false" do
+          expect(config_builder.renamed_interface?).to eq(false)
+        end
       end
     end
 

--- a/test/y2network/interface_config_builder_test.rb
+++ b/test/y2network/interface_config_builder_test.rb
@@ -146,7 +146,7 @@ describe Y2Network::InterfaceConfigBuilder do
 
       it "returns false" do
         config_builder.rename_interface("eth0")
-        config_builder.renaming_mechanism = nil
+        config_builder.renaming_mechanism = :none
         expect(config_builder.renamed_interface?).to eq(false)
       end
     end

--- a/test/y2network/sysconfig/interfaces_writer_test.rb
+++ b/test/y2network/sysconfig/interfaces_writer_test.rb
@@ -35,7 +35,7 @@ describe Y2Network::Sysconfig::InterfacesWriter do
     let(:hardware) do
       instance_double(Y2Network::Hwinfo, busid: "00:1c.0", mac: "01:23:45:67:89:ab", dev_port: "1")
     end
-    let(:renaming_mechanism) { nil }
+    let(:renaming_mechanism) { :none }
     let(:scr_root) { Dir.mktmpdir }
 
     before do


### PR DESCRIPTION
This PR fixes a problem when the builder tries to determine whether the interface was initially renamed or not. Now, the `#name=` method sets the interface and registers the initial value; additionally, `:none` is now used to indicate that an interface has not been renamed, so `renaming_mechanism` cannot be `nil` anymore.