### PR TITLE
network ng: fix name validation

### DIFF
--- a/src/lib/y2network/widgets/interface_name.rb
+++ b/src/lib/y2network/widgets/interface_name.rb
@@ -30,6 +30,7 @@ module Y2Network
         textdomain "network"
 
         @settings = settings
+        @old_name = @settings.name
       end
 
       def label
@@ -57,7 +58,7 @@ module Y2Network
       end
 
       def validate
-        if @settings.name_exists?(value)
+        if @old_name != value && @settings.name_exists?(value)
           Yast::Popup.Error(
             format(_("Configuration name %s already exists.\nChoose a different one."), value)
           )

--- a/test/y2network/widgets/interface_name_test.rb
+++ b/test/y2network/widgets/interface_name_test.rb
@@ -52,12 +52,26 @@ describe Y2Network::Widgets::InterfaceName do
       expect(subject.validate).to be false
     end
 
-    it "fails for already used names" do
-      allow(subject).to receive(:value).and_return valid_name
-      allow(Yast::NetworkInterfaces).to receive(:List).and_return [valid_name]
+    context "when the name is already used" do
+      before do
+        allow(subject).to receive(:value).and_return valid_name
+        allow(Yast::NetworkInterfaces).to receive(:List).and_return [valid_name]
+      end
 
-      expect(Yast::UI).to receive(:SetFocus)
-      expect(subject.validate).to be false
+      context "if the name was changed" do
+        let(:valid_name) { "eth1" }
+
+        it "fails" do
+          expect(Yast::UI).to receive(:SetFocus)
+          expect(subject.validate).to be false
+        end
+      end
+
+      context "if the name was not changed" do
+        it "passes" do
+          expect(subject.validate).to eq(true)
+        end
+      end
     end
   end
 

--- a/test/y2network/widgets/interface_naming_test.rb
+++ b/test/y2network/widgets/interface_naming_test.rb
@@ -31,7 +31,7 @@ describe Y2Network::Widgets::InterfaceNaming do
     instance_double(
       Y2Network::InterfaceConfigBuilder,
       interface: interface,
-      name: "eth0"
+      name:      "eth0"
     )
   end
 

--- a/test/y2network/widgets/interface_naming_test.rb
+++ b/test/y2network/widgets/interface_naming_test.rb
@@ -30,7 +30,8 @@ describe Y2Network::Widgets::InterfaceNaming do
   let(:builder) do
     instance_double(
       Y2Network::InterfaceConfigBuilder,
-      interface: interface
+      interface: interface,
+      name: "eth0"
     )
   end
 


### PR DESCRIPTION
Do not complain of an already used name when it has not been changed at all.