### PR TITLE
network-ng: fix interfaces table description

### DIFF
--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -92,16 +92,16 @@ module Y2Network
           result << "<b>(" << _("No hardware information") << ")</b><br>"
         else
           result << "<b>(" << _("Not connected") << ")</b><br>" if !hwinfo.link
-          if !hwinfo.mac.empty?
+          if hwinfo.mac
             result << "<b>MAC : </b>" << hwinfo.mac << "<br>"
           end
-          if !hwinfo.busid.empty?
+          if hwinfo.busid
             result << "<b>BusID : </b>" << hwinfo.busid << "<br>"
           end
         end
         connection = Yast::Lan.yast_config.connections.by_name(value)
         if connection
-          result << _("Device Name: %s") % ifcfg_name
+          result << _("Device Name: %s") % connection.name
           # TODO: start mode description. Ideally in startmode class
           # TODO: ip overview
         else

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -92,12 +92,8 @@ module Y2Network
           result << "<b>(" << _("No hardware information") << ")</b><br>"
         else
           result << "<b>(" << _("Not connected") << ")</b><br>" if !hwinfo.link
-          if hwinfo.mac
-            result << "<b>MAC : </b>" << hwinfo.mac << "<br>"
-          end
-          if hwinfo.busid
-            result << "<b>BusID : </b>" << hwinfo.busid << "<br>"
-          end
+          result << "<b>MAC : </b>" << hwinfo.mac << "<br>" if hwinfo.mac
+          result << "<b>BusID : </b>" << hwinfo.busid << "<br>" if hwinfo.busid
         end
         connection = Yast::Lan.yast_config.connections.by_name(value)
         if connection

--- a/test/y2network/widgets/interfaces_table_test.rb
+++ b/test/y2network/widgets/interfaces_table_test.rb
@@ -43,12 +43,10 @@ describe Y2Network::Widgets::InterfacesTable do
     Y2Network::ConnectionConfig::Ethernet.new.tap { |c| c.name = "eth0" }
   end
 
-
   before do
     allow(Yast::Lan).to receive(:yast_config).and_return(double(interfaces: interfaces, connections: connections))
     allow(Yast::UI).to receive(:QueryWidget).and_return([])
     allow(subject).to receive(:value).and_return("eth0")
-    # allow(subject).to receive(:create_description).and_return("")
   end
 
   include_examples "CWM::Table"

--- a/test/y2network/widgets/interfaces_table_test.rb
+++ b/test/y2network/widgets/interfaces_table_test.rb
@@ -25,13 +25,105 @@ require "y2network/widgets/interfaces_table"
 Yast.import "Lan"
 
 describe Y2Network::Widgets::InterfacesTable do
-  subject { described_class.new(double(:"value=" => nil)) }
+  subject { described_class.new(description) }
+
+  let(:description) { double(:value= => nil) }
+
+  let(:eth0) { instance_double(Y2Network::Interface, name: "eth0", hardware: hwinfo) }
+  let(:interfaces) { Y2Network::InterfacesCollection.new([eth0]) }
+  let(:hwinfo) do
+    instance_double(Y2Network::Hwinfo, link: link, mac: mac, busid: busid, exists?: exists?, description: "")
+  end
+  let(:mac) { "01:23:45:67:89:ab" }
+  let(:busid) { "0000:04:00.0" }
+  let(:link) { false }
+  let(:exists?) { true }
+  let(:connections) { Y2Network::ConnectionConfigsCollection.new([eth0_conn]) }
+  let(:eth0_conn) do
+    Y2Network::ConnectionConfig::Ethernet.new.tap { |c| c.name = "eth0" }
+  end
+
 
   before do
-    allow(Yast::Lan).to receive(:yast_config).and_return(double(interfaces: [], connections: []))
+    allow(Yast::Lan).to receive(:yast_config).and_return(double(interfaces: interfaces, connections: connections))
     allow(Yast::UI).to receive(:QueryWidget).and_return([])
-    allow(subject).to receive(:create_description).and_return("")
+    allow(subject).to receive(:value).and_return("eth0")
+    # allow(subject).to receive(:create_description).and_return("")
   end
 
   include_examples "CWM::Table"
+
+  describe "#handle" do
+
+    it "updates the description" do
+      expect(description).to receive(:value=)
+      subject.handle
+    end
+
+    it "includes the MAC address in the description" do
+      expect(description).to receive(:value=).with(/MAC/)
+      subject.handle
+    end
+
+    context "when there is no MAC address" do
+      let(:mac) { nil }
+
+      it "does not include the MAC in the description" do
+        expect(description).to receive(:value=) do |text|
+          expect(text).to_not include("MAC")
+        end
+        subject.handle
+      end
+    end
+
+    it "includes the Bus ID address in the description" do
+      expect(description).to receive(:value=).with(/BusID/)
+      subject.handle
+    end
+
+    context "when there is no Bus ID" do
+      let(:busid) { nil }
+
+      it "does not include the Bus ID in the description" do
+        expect(description).to receive(:value=) do |text|
+          expect(text).to_not include("BusID")
+        end
+        subject.handle
+      end
+    end
+
+    context "when there is no hardware information" do
+      let(:exists?) { false }
+
+      it "sets the description with 'no hardware information' warning" do
+        expect(description).to receive(:value=).with(/No hardware information/)
+        subject.handle
+      end
+    end
+
+    context "when there is no link" do
+      let(:link) { false }
+
+      it "sets includes a 'Not connected' text" do
+        expect(description).to receive(:value=).with(/Not connected/)
+        subject.handle
+      end
+    end
+
+    context "when the device is configured" do
+      it "includes its device name in the description" do
+        expect(description).to receive(:value=).with(/Device Name: eth0/)
+        subject.handle
+      end
+    end
+
+    context "when the device is not configured" do
+      let(:connections) { Y2Network::ConnectionConfigsCollection.new([]) }
+
+      it "includes a warning in the description" do
+        expect(description).to receive(:value=).with(/The device is not configured./)
+        subject.handle
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Fix crash when rendering interfaces table description.
* Improve InterfacesTable widget test coverage.