### PR TITLE
network-ng: builder fixes

### DIFF
--- a/src/lib/y2network/can_be_copied.rb
+++ b/src/lib/y2network/can_be_copied.rb
@@ -1,0 +1,28 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Network
+  # This module adds a #copy method.
+  module CanBeCopied
+    # Returns a deep-copy of the configuration
+    def copy
+      Marshal.load(Marshal.dump(self))
+    end
+  end
+end

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -23,6 +23,7 @@ require "y2network/dns"
 require "y2network/interfaces_collection"
 require "y2network/connection_configs_collection"
 require "y2network/virtual_interface"
+require "y2network/can_be_copied"
 
 module Y2Network
   # This class represents the current network configuration including interfaces,
@@ -38,6 +39,8 @@ module Y2Network
   #   config.routing.tables.first << route
   #   config.write
   class Config
+    include CanBeCopied
+
     # @return [InterfacesCollection]
     attr_accessor :interfaces
     # @return [ConnectionConfigsCollection]
@@ -113,13 +116,6 @@ module Y2Network
     # @see Y2Network::ConfigWriter
     def write(original: nil)
       Y2Network::ConfigWriter.for(source).write(self, original)
-    end
-
-    # Returns a deep-copy of the configuration
-    #
-    # @return [Config]
-    def copy
-      Marshal.load(Marshal.dump(self))
     end
 
     # Determines whether two configurations are equal

--- a/src/lib/y2network/connection_config/ip_config.rb
+++ b/src/lib/y2network/connection_config/ip_config.rb
@@ -16,9 +16,14 @@
 #
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
+
+require "y2network/can_be_copied"
+
 module Y2Network
   module ConnectionConfig
     class IPConfig
+      include CanBeCopied
+
       # @return [IPAddress] IP address
       attr_accessor :address
       # @return [String,nil] Address label
@@ -44,6 +49,14 @@ module Y2Network
         @label = label
         @remote_address = remote_address
         @broadcast = broadcast
+      end
+
+      # Determines whether IP configurations are equal
+      #
+      # @return [Boolean] true if both are equal; false otherwise
+      def ==(other)
+        address == other.address && label == other.label &&
+          remote_address == other.remote_address && broadcast == other.broadcast
       end
     end
   end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -343,13 +343,16 @@ module Y2Network
       @hostname = value
     end
 
+    # Saves the hostname
+    #
+    # It needs to take into account whether the old configuration and the boot protocol.
     def save_hostname
-      # avoid unnecessary modification
-      return if @original_ip_config == @connection_config.ip && @original_hostname == hostname
+      if !required_ip_config? || hostname.empty?
+        Yast::Host.remove_ip(@original_ip_config.address.to_s)
+        return
+      end
 
-      # remove old ip
-      Yast::Host.remove_ip(@original_ip_config.address.to_s) if @original_ip_config != @connection_config.ip
-
+      return if @original_ip_config == connection_config.ip && @original_hostname == hostname
       Yast::Host.Update(@original_hostname, hostname, @connection_config.ip.address.to_s)
     end
 
@@ -448,6 +451,13 @@ module Y2Network
     # @return [Y2Network::Config]
     def yast_config
       Yast::Lan.yast_config
+    end
+
+    # Determines whether the IP configuration is required
+    #
+    # @return [Boolean]
+    def required_ip_config?
+      boot_protocol == BootProtocol::STATIC
     end
   end
 end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -348,7 +348,7 @@ module Y2Network
       return if @original_ip_config == @connection_config.ip && @original_hostname == hostname
 
       # remove old ip
-      Yast::Host.remove_ip(@original_ip_config.ip.address.to_s) if @original_ip_config != @connection_config.ip
+      Yast::Host.remove_ip(@original_ip_config.address.to_s) if @original_ip_config != @connection_config.ip
 
       Yast::Host.Update(@original_hostname, hostname, @connection_config.ip.address.to_s)
     end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -438,7 +438,7 @@ module Y2Network
     # @return [Y2Network::Interface,nil]
     def find_interface
       return nil unless yast_config # in some tests, it could return nil
-      yast_config.interfaces.by_name(name)
+      interfaces.by_name(name)
     end
 
     # Returns the interfaces collection

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -86,7 +86,7 @@ module Y2Network
         config.propose
       end
       @connection_config = config
-      @original_ip_config = ip_config_default
+      @original_ip_config = ip_config_default.copy
     end
 
     # Sets the interface name
@@ -345,9 +345,11 @@ module Y2Network
 
     # Saves the hostname
     #
-    # It needs to take into account whether the old configuration and the boot protocol.
+    # The hostname entry must be updated when the IP or the hostname change. Moreover, it must be
+    # removed when the hostname is empty or when the boot protocol is not STATIC (as there is no IP
+    # to associate with the name).
     def save_hostname
-      if !required_ip_config? || hostname.empty?
+      if !required_ip_config?
         Yast::Host.remove_ip(@original_ip_config.address.to_s)
         return
       end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -117,8 +117,8 @@ module Y2Network
 
       @connection_config.name = name
       @connection_config.interface = name
-      yast_config.add_or_update_connection_config(@connection_config)
       yast_config.rename_interface(@old_name, name, renaming_mechanism) if renamed_interface?
+      yast_config.add_or_update_connection_config(@connection_config)
 
       # write to ifcfg always and to firewalld only when available
       @connection_config.firewall_zone = firewall_zone

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -436,6 +436,13 @@ module Y2Network
       yast_config.interfaces.by_name(name)
     end
 
+    # Returns the interfaces collection
+    #
+    # @return [Y2Network::InterfacesCollection]
+    def interfaces
+      yast_config.interfaces
+    end
+
     # Helper method to access to the current configuration
     #
     # @return [Y2Network::Config]

--- a/src/lib/y2network/interface_config_builders/bonding.rb
+++ b/src/lib/y2network/interface_config_builders/bonding.rb
@@ -33,7 +33,7 @@ module Y2Network
 
       # @return [Array<Interface>] list of interfaces usable for the bond device
       def bondable_interfaces
-        interfaces.all.select { |i| bondable?(i) }
+        interfaces.select { |i| bondable?(i) }
       end
 
       def_delegators :connection_config,

--- a/src/lib/y2network/interface_config_builders/bridge.rb
+++ b/src/lib/y2network/interface_config_builders/bridge.rb
@@ -44,7 +44,7 @@ module Y2Network
 
       # @return [Array<Interface>] list of interfaces usable in the bridge
       def bridgeable_interfaces
-        interfaces.all.select { |i| bridgeable?(i) }
+        interfaces.select { |i| bridgeable?(i) }
       end
 
       def_delegators :@connection_config,

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -46,7 +46,7 @@ module Y2Network
     attr_reader :interfaces
     alias_method :to_a, :interfaces
 
-    def_delegators :@interfaces, :each, :push, :<<, :reject!, :map, :flat_map, :any?, :size
+    def_delegators :@interfaces, :each, :push, :<<, :reject!, :map, :flat_map, :any?, :size, :select
 
     # Constructor
     #
@@ -156,17 +156,6 @@ module Y2Network
       log.debug("bond slaves index: #{index}")
 
       index
-    end
-
-    def all
-      # FIXME: this is only helper when coexisting with old LanItems module
-      # can be used in new API of network-ng for read-only methods. It converts
-      # old LanItems::Items into new Interface objects
-      Yast::LanItems.Items.map do |_index, item|
-        name = item["ifcfg"] || item["hwinfo"]["dev_name"]
-        type = Yast::NetworkInterfaces.GetType(name)
-        Y2Network::Interface.new(name, type: InterfaceType.from_short_name(type))
-      end
     end
   end
 end

--- a/test/y2network/can_be_copied_test.rb
+++ b/test/y2network/can_be_copied_test.rb
@@ -1,0 +1,38 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2network/can_be_copied"
+
+describe Y2Network::CanBeCopied do
+  Dummy = Struct.new(:value) do
+    include Y2Network::CanBeCopied
+  end
+
+  subject { Dummy.new("test") }
+
+  describe "#copy" do
+    it "returns an equivalent but different object" do
+      other = subject.copy
+      expect(subject.value).to eq(other.value)
+      expect(subject).to_not be(other)
+    end
+  end
+end


### PR DESCRIPTION
Several unrelated fixes:

* Do not duplicate interfaces when an already existing one is renamed.
* Use the correct list of interfaces when determining which of them can be used in a bridge or a bonding.
* Take the boot protocol into account when writing the hostname.