### PR TITLE
network-ng: fix dhclient set hostname handling

### DIFF
--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -139,6 +139,7 @@ module Y2Network
       interface = interfaces.by_name(old_name)
       interface.rename(new_name, mechanism)
       connections.by_interface(old_name).each { |c| c.interface = new_name }
+      dns.dhcp_hostname = new_name if dns.dhcp_hostname == old_name
     end
 
     # deletes interface and all its config. If interface is physical,

--- a/src/lib/y2network/dns.rb
+++ b/src/lib/y2network/dns.rb
@@ -32,7 +32,9 @@ module Y2Network
     # @return [String] resolv.conf update policy
     attr_accessor :resolv_conf_policy
 
-    # @return [Boolean] Whether to take the hostname from DHCP
+    # @return [String,Symbol] Whether to take the hostname from DHCP.
+    #   It can be an interface name (String), :any for any interface or :none from no taking
+    #   the hostname from DHCP.
     attr_accessor :dhcp_hostname
 
     # @todo receive an array instead all these arguments

--- a/src/lib/y2network/sysconfig/config_writer.rb
+++ b/src/lib/y2network/sysconfig/config_writer.rb
@@ -46,9 +46,9 @@ module Y2Network
         file.routes = find_routes_for(nil, config.routing.routes)
         file.save
 
-        write_dns_settings(config, old_config)
         write_interfaces(config.interfaces)
         write_connections(config.connections)
+        write_dns_settings(config, old_config)
       end
 
     private

--- a/src/lib/y2network/sysconfig/connection_config_writers/base.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writers/base.rb
@@ -45,7 +45,9 @@ module Y2Network
           file.lladdr = conn.lladdress
           file.startmode = conn.startmode.to_s
           file.ifplugd_priority = conn.startmode.priority if conn.startmode.name == "ifplugd"
-          file.ethtool_options = conn.ethtool_options unless conn.ethtool_options.empty?
+          if conn.ethtool_options && !conn.ethtool_options.empty?
+            file.ethtool_options = conn.ethtool_options
+          end
           file.zone = conn.firewall_zone
           add_ips(conn)
           update_file(conn)

--- a/src/lib/y2network/sysconfig/dns_reader.rb
+++ b/src/lib/y2network/sysconfig/dns_reader.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 require "yast"
 require "y2network/dns"
+require "y2network/sysconfig/interface_file"
 
 Yast.import "Hostname"
 Yast.import "Mode"
@@ -126,10 +127,15 @@ module Y2Network
 
       # Returns whether the hostname should be taken from DHCP
       #
-      # @return [Boolean]
+      # @return [String,:any,:none] Interface to set the hostname based on DHCP settings;
+      #   :any for any interface; :none for ignoring the hostname assigned via DHCP
       def dhcp_hostname
         value = Yast::SCR.Read(Yast::Path.new(".sysconfig.network.dhcp.DHCLIENT_SET_HOSTNAME"))
-        value == "yes"
+        return :any if value == "yes"
+        files = InterfaceFile.all
+        files.each(&:load)
+        file = files.find { |f| f.dhclient_set_hostname == "yes" }
+        file ? file.interface : :none
       end
     end
   end

--- a/src/lib/y2network/sysconfig/dns_reader.rb
+++ b/src/lib/y2network/sysconfig/dns_reader.rb
@@ -133,8 +133,10 @@ module Y2Network
         value = Yast::SCR.Read(Yast::Path.new(".sysconfig.network.dhcp.DHCLIENT_SET_HOSTNAME"))
         return :any if value == "yes"
         files = InterfaceFile.all
-        files.each(&:load)
-        file = files.find { |f| f.dhclient_set_hostname == "yes" }
+        file = files.find do |f|
+          f.load
+          f.dhclient_set_hostname == "yes"
+        end
         file ? file.interface : :none
       end
     end

--- a/src/lib/y2network/sysconfig/interface_file.rb
+++ b/src/lib/y2network/sysconfig/interface_file.rb
@@ -349,6 +349,10 @@ module Y2Network
       #   @return [String] tunnel group
       define_variable(:tunnel_set_group)
 
+      # @!attribute [r] dhclient_set_hostname
+      #   @return [String] use hostname from dhcp
+      define_variable(:dhclient_set_hostname)
+
       # Constructor
       #
       # @param interface [String] Interface interface

--- a/src/lib/y2network/sysconfig/interface_file.rb
+++ b/src/lib/y2network/sysconfig/interface_file.rb
@@ -55,6 +55,18 @@ module Y2Network
       class << self
         SYSCONFIG_NETWORK_DIR = Pathname.new("/etc/sysconfig/network").freeze
 
+        # @return [Regex] expression to filter out invalid ifcfg-* files
+        IGNORE_IFCFG_REGEX = /(\.bak|\.orig|\.rpmnew|\.rpmorig|-range|~|\.old|\.scpmbackup)$/
+
+        # Returns all configuration files
+        #
+        # @return [Array<InterfaceFile>]
+        def all
+          Yast::SCR.Dir(Yast::Path.new(".network.section"))
+                   .reject { |f| IGNORE_IFCFG_REGEX =~ f || f == "lo" }
+                   .map { |f| find(f) }
+        end
+
         # Finds the ifcfg-* file for a given interface
         #
         # @param interface [String] Interface name

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -189,6 +189,28 @@ describe Y2Network::Config do
         expect(eth2_conns).to_not be_empty
       end
     end
+
+    context "when dhcp_hostname points to the renamed interface" do
+      before do
+        allow(config.dns).to receive(:dhcp_hostname).and_return("eth0")
+      end
+
+      it "adjusts the dhcp_hostname" do
+        expect(config.dns).to receive(:dhcp_hostname=).with("eth1")
+        config.rename_interface("eth0", "eth1", :mac)
+      end
+    end
+
+    context "when dhcp_hostname does not point to the renamed interface" do
+      before do
+        allow(config.dns).to receive(:dhcp_hostname).and_return(:any)
+      end
+
+      it "does not adjust the dhcp_hostname" do
+        expect(config.dns).to_not receive(:dhcp_hostname=)
+        config.rename_interface("eth0", "eth1", :mac)
+      end
+    end
   end
 
   describe "#add_or_update_connection_config" do

--- a/test/y2network/sysconfig/interface_file_test.rb
+++ b/test/y2network/sysconfig/interface_file_test.rb
@@ -56,6 +56,15 @@ describe Y2Network::Sysconfig::InterfaceFile do
     end
   end
 
+  describe ".all" do
+    it "returns all the present interfaces files" do
+      files = described_class.all
+      expect(files).to be_all(Y2Network::Sysconfig::InterfaceFile)
+      interfaces = files.map(&:interface)
+      expect(interfaces).to include("wlan0")
+    end
+  end
+
   describe "#remove" do
     subject(:file) { described_class.find("eth0") }
 


### PR DESCRIPTION
Fixes proper support for DHCLIENT_SET_HOSTNAME. There is one drawback: if more than one interface has the `DHCLIENT_SET_HOSTNAME` set to `yes`, YaST will not warn the user. It will simply write the first one when writing changes to disk. I meant [this message](https://github.com/yast/yast-network/blob/e1f0db2fecf41f773856767629c3c093e1b1a0c8/src/include/network/routines.rb#L872).

I decided to put this setting into `Y2Network::DNS#dhcp_hostname` instead of adding it to `ConnectionConfig::Base` because it looks more natural to me. Of course, it can be changed.