### PR TITLE
Network ng write drivers options

### DIFF
--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -50,6 +50,8 @@ module Y2Network
     attr_accessor :routing
     # @return [DNS] DNS configuration
     attr_accessor :dns
+    # @return [Array<Driver>] Available drivers
+    attr_accessor :drivers
     # @return [Symbol] Information source (see {Y2Network::Reader} and {Y2Network::Writer})
     attr_accessor :source
 
@@ -98,10 +100,12 @@ module Y2Network
     # @param routing     [Routing] Object with routing configuration
     # @param dns         [DNS] Object with DNS configuration
     # @param source      [Symbol] Configuration source
+    # @param drivers     [Array<Driver>] List of available drivers
     def initialize(interfaces: InterfacesCollection.new, connections: ConnectionConfigsCollection.new,
-      routing: Routing.new, dns: DNS.new, source:)
+      routing: Routing.new, dns: DNS.new, drivers: [], source:)
       @interfaces = interfaces
       @connections = connections
+      @drivers = drivers
       @routing = routing
       @dns = dns
       @source = source

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -173,6 +173,7 @@ module Y2Network
     def drivers_for_interface(name)
       interface = interfaces.by_name(name)
       names = interface.drivers.map(&:name)
+      names << interface.custom_driver if interface.custom_driver && !names.include?(interface.custom_driver)
       drivers.select { |d| names.include?(d.name) }
     end
 

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -167,6 +167,27 @@ module Y2Network
       interfaces << Interface.from_connection(connection_config)
     end
 
+    # Returns the candidate drivers for a given interface
+    #
+    # @return [Array<Driver>]
+    def drivers_for_interface(name)
+      interface = interfaces.by_name(name)
+      names = interface.drivers.map(&:name)
+      drivers.select { |d| names.include?(d.name) }
+    end
+
+    # Adds or update a driver
+    #
+    # @param new_driver [Driver] Driver to add or update
+    def add_or_update_driver(new_driver)
+      idx = drivers.find_index { |d| d.name == new_driver.name }
+      if idx
+        drivers[idx] = new_driver
+      else
+        drivers << new_driver
+      end
+    end
+
     alias_method :eql?, :==
   end
 end

--- a/src/lib/y2network/driver.rb
+++ b/src/lib/y2network/driver.rb
@@ -17,11 +17,15 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "y2network/can_be_copied"
+
 module Y2Network
   # This class represents a driver for an interface
   #
   # It is composed of a kernel module name and a string representing the module options
   class Driver
+    include CanBeCopied
+
     # @return [String] Kernel module name
     attr_accessor :name
     # @return [String] Kernel module parameters
@@ -32,7 +36,7 @@ module Y2Network
       @params = params
     end
 
-    # Determines whether two interfaces are equal
+    # Determines whether two drivers are equal
     #
     # @param other [Driver] Driver to compare with
     # @return [Boolean]

--- a/src/lib/y2network/driver.rb
+++ b/src/lib/y2network/driver.rb
@@ -18,12 +18,15 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "y2network/can_be_copied"
 
 module Y2Network
   # This class represents a driver for an interface
   #
   # It is composed of a kernel module name and a string representing the module options
   class Driver
+    include CanBeCopied
+
     class << self
       # Returns a driver using the information from the system
       #
@@ -76,7 +79,7 @@ module Y2Network
     # is called. The reason is that writing them is an expensive operation, so it is
     # better to write parameters for all drivers at the same time.
     #
-    # You might prefer to use Y2Network::Driver.write_options instead.
+    # You might prefer to use {.write_options} instead.
     #
     # @see Y2Network::Driver.commit
     def write_options

--- a/src/lib/y2network/hwinfo.rb
+++ b/src/lib/y2network/hwinfo.rb
@@ -233,9 +233,9 @@ module Y2Network
     #
     # @return [Array<Driver>] List of drivers
     def drivers
-      drivers_list = @hwinfo.fetch("drivers", [])
-      return [] unless drivers_list[0]
-      modules = drivers_list[0].fetch("modules", [])
+      driver = @hwinfo.fetch("drivers", []).first
+      return [] unless driver
+      modules = driver.fetch("modules", [])
       modules.map { |m| Driver.new(*m) }
     end
 

--- a/src/lib/y2network/hwinfo.rb
+++ b/src/lib/y2network/hwinfo.rb
@@ -194,7 +194,8 @@ module Y2Network
       { name: "wl_bitrates", default: nil },
       { name: "dev_port", default: nil },
       { name: "type", default: nil },
-      { name: "name", default: "" }
+      { name: "name", default: "" },
+      { name: "modalias", default: nil }
     ].each do |hwinfo_item|
       define_method hwinfo_item[:name].downcase do
         @hwinfo ? @hwinfo.fetch(hwinfo_item[:name], hwinfo_item[:default]) : hwinfo_item[:default]

--- a/src/lib/y2network/hwinfo.rb
+++ b/src/lib/y2network/hwinfo.rb
@@ -234,6 +234,7 @@ module Y2Network
     # @return [Array<Driver>] List of drivers
     def drivers
       drivers_list = @hwinfo.fetch("drivers", [])
+      return [] unless drivers_list[0]
       modules = drivers_list[0].fetch("modules", [])
       modules.map { |m| Driver.new(*m) }
     end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -109,12 +109,6 @@ module Y2Network
     #   down, so here mainly workarounds, but ideally this save should change
     #   completely backend
     def save
-      if !driver.empty?
-        # TODO: new backend?
-        Yast::LanItems.setDriver(driver)
-        Yast::LanItems.driver_options[driver] = driver_options
-      end
-
       @connection_config.ip_aliases = aliases.each_with_object([]) do |map, result|
         ipaddr = IPAddress.from_string(map[:ip])
         ipaddr.prefix = map[:prefixlen].delete("/").to_i if map[:prefixlen]
@@ -132,6 +126,10 @@ module Y2Network
         firewall_interface.zone = firewall_zone if !firewall_interface.zone || firewall_zone != firewall_interface.zone.name
       end
 
+      if interface.respond_to?(:custom_driver) && driver
+        interface.custom_driver = driver.name if driver.name != interface.current_driver
+        yast_config.add_or_update_driver(driver)
+      end
       yast_config.rename_interface(@old_name, name, renaming_mechanism) if renamed_interface?
       yast_config.add_or_update_connection_config(@connection_config)
 
@@ -193,9 +191,9 @@ module Y2Network
     end
 
     # gets a list of available kernel modules for the interface
-    def kernel_modules
-      # TODO: new backend?
-      Yast::LanItems.GetItemModules("")
+    def drivers
+      return [] unless interface
+      yast_config.drivers_for_interface(interface.name)
     end
 
     # gets currently assigned firewall zone
@@ -246,28 +244,16 @@ module Y2Network
 
     # gets currently assigned kernel module
     def driver
-      # TODO: new backend
-      @driver ||= Yast::Ops.get_string(Yast::LanItems.getCurrentItem, ["udev", "driver"], "")
+      return @driver if @driver
+      driver_name = @interface.custom_driver || @interface.current_driver
+      return nil unless driver_name
+      @driver = yast_config.drivers.find { |d| d.name == driver_name }
     end
 
     # sets kernel module for interface
+    # @param value [Driver]
     def driver=(value)
-      # TODO: new backend
       @driver = value
-    end
-
-    # gets specific options for kernel driver
-    def driver_options
-      target_driver = @driver
-      target_driver = hwinfo.module if target_driver.empty?
-      # TODO: new backend
-      @driver_options ||= Yast::LanItems.driver_options[target_driver] || ""
-    end
-
-    # sets specific options for kernel driver
-    def driver_options=(value)
-      # TODO: new backend
-      @driver_options = value
     end
 
     # gets aliases for interface

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -76,6 +76,13 @@ module Y2Network
       InterfacesCollection.new(interfaces.select { |i| i.type == type })
     end
 
+    # Returns the list of physical interfaces
+    #
+    # @return [InterfacesCollection] List of physical interfaces
+    def physical
+      interfaces.select { |i| i.is_a?(PhysicalInterface) }
+    end
+
     # Deletes elements which meet a given condition
     #
     # @return [InterfacesCollection]

--- a/src/lib/y2network/physical_interface.rb
+++ b/src/lib/y2network/physical_interface.rb
@@ -26,6 +26,13 @@ module Y2Network
     # @return [String]
     attr_accessor :ethtool_options
 
+    # User selected driver
+    #
+    # This driver will be set using a udev rule.
+    #
+    # @return [String]
+    attr_accessor :driver
+
     # Constructor
     #
     # @param name [String] Interface name (e.g., "eth0")
@@ -36,6 +43,13 @@ module Y2Network
       # @hardware and @name should not change during life of the object
       @hardware = hardware || Hwinfo.for(name) || Hwinfo.new
       @description = @hardware.name
+    end
+
+    # Returns interface modalias
+    #
+    # @return [String,nil] Modalias
+    def modalias
+      @hardware.modalias
     end
 
     # Determines whether the interface is present (attached)

--- a/src/lib/y2network/physical_interface.rb
+++ b/src/lib/y2network/physical_interface.rb
@@ -31,7 +31,7 @@ module Y2Network
     # This driver will be set using a udev rule.
     #
     # @return [String]
-    attr_accessor :driver
+    attr_accessor :custom_driver
 
     # Constructor
     #

--- a/src/lib/y2network/physical_interface.rb
+++ b/src/lib/y2network/physical_interface.rb
@@ -52,6 +52,13 @@ module Y2Network
       @hardware.modalias
     end
 
+    # Returns the name of the current driver
+    #
+    # @return [String]
+    def current_driver
+      @hardware.module
+    end
+
     # Determines whether the interface is present (attached)
     #
     # It relies in the hardware information

--- a/src/lib/y2network/sysconfig/config_reader.rb
+++ b/src/lib/y2network/sysconfig/config_reader.rb
@@ -48,6 +48,7 @@ module Y2Network
         Config.new(
           interfaces:  interfaces_reader.interfaces,
           connections: interfaces_reader.connections,
+          drivers:     interfaces_reader.drivers,
           routing:     routing,
           dns:         dns,
           source:      :sysconfig

--- a/src/lib/y2network/sysconfig/config_writer.rb
+++ b/src/lib/y2network/sysconfig/config_writer.rb
@@ -46,6 +46,7 @@ module Y2Network
         file.routes = find_routes_for(nil, config.routing.routes)
         file.save
 
+        write_drivers(config.drivers)
         write_interfaces(config.interfaces)
         write_connections(config.connections)
         write_dns_settings(config, old_config)
@@ -187,6 +188,13 @@ module Y2Network
       def write_connections(conns)
         writer = Y2Network::Sysconfig::ConnectionConfigWriter.new
         conns.each { |c| writer.write(c) }
+      end
+
+      # Writes drivers options
+      #
+      # @param drivers [Array<Y2Network::Driver>] Drivers to write options
+      def write_drivers(drivers)
+        Y2Network::Driver.write_options(drivers)
       end
     end
   end

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -48,7 +48,8 @@ module Y2Network
         return @config if @config
         find_physical_interfaces
         find_connections
-        @config = { interfaces: @interfaces, connections: @connections }
+        find_drivers
+        @config = { interfaces: @interfaces, connections: @connections, drivers: @drivers }
       end
 
       # Convenience method to get connections configuration
@@ -64,6 +65,13 @@ module Y2Network
       # @return [Y2Network::InterfacesCollection]
       def interfaces
         config[:interfaces]
+      end
+
+      # Convenience method to get the drivers list
+      #
+      # @return [Array<Y2Network::Driver>]
+      def drivers
+        config[:drivers]
       end
 
     private
@@ -90,6 +98,14 @@ module Y2Network
             add_interface(connection) if interface.nil?
             conns << connection
           end
+      end
+
+      # Finds the available drivers
+      def find_drivers
+        candidate_drivers = @interfaces
+          .select { |i| i.is_a?(Y2Network::PhysicalInterface) }
+          .flat_map { |i| i.drivers }
+        @drivers = candidate_drivers.map(&:copy).uniq
       end
 
       # Instantiates an interface given a hash containing hardware details

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -143,7 +143,7 @@ module Y2Network
 
       # Detects the renaming mechanism used by the interface
       #
-      # @param name [PhysicalInterface] Interface
+      # @param iface [PhysicalInterface] Interface
       # @return [Symbol] :mac (MAC address), :bus_id (BUS ID) or :none (no renaming)
       def renaming_mechanism_for(iface)
         rule = UdevRule.find_for(iface.name)

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -165,7 +165,7 @@ module Y2Network
       # @return [String,nil] Custom driver (or nil if not set)
       def custom_driver_for(iface)
         return nil unless iface.modalias
-        rule = UdevRule.all(:drivers).find { |r| r.original_modalias == iface.modalias }
+        rule = UdevRule.drivers_rules.find { |r| r.original_modalias == iface.modalias }
         rule ? rule.driver : nil
       end
     end

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -102,12 +102,10 @@ module Y2Network
 
       # Finds the available drivers
       def find_drivers
-        drivers_names =
-          @interfaces
-          .select { |i| i.is_a?(Y2Network::PhysicalInterface) }
-          .flat_map(&:drivers)
-          .map(&:name)
-          .uniq
+        physical_interfaces = @interfaces.physical
+        drivers_names = physical_interfaces.flat_map(&:drivers).map(&:name)
+        drivers_names += @interfaces.physical.map(&:custom_driver).compact
+        drivers_names.uniq!
 
         @drivers = drivers_names.map do |name|
           Y2Network::Driver.from_system(name)

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -102,10 +102,16 @@ module Y2Network
 
       # Finds the available drivers
       def find_drivers
-        candidate_drivers = @interfaces
+        drivers_names =
+          @interfaces
           .select { |i| i.is_a?(Y2Network::PhysicalInterface) }
-          .flat_map { |i| i.drivers }
-        @drivers = candidate_drivers.map(&:copy).uniq
+          .flat_map(&:drivers)
+          .map(&:name)
+          .uniq
+
+        @drivers = drivers_names.map do |name|
+          Y2Network::Driver.from_system(name)
+        end
       end
 
       # Instantiates an interface given a hash containing hardware details

--- a/src/lib/y2network/sysconfig/interfaces_writer.rb
+++ b/src/lib/y2network/sysconfig/interfaces_writer.rb
@@ -62,8 +62,8 @@ module Y2Network
       # @param iface [Interface] Interface to generate the udev rule for
       # @return [UdevRule,nil] udev rule or nil if it is not needed
       def driver_udev_rule_for(iface)
-        return nil unless iface.respond_to?(:driver) && iface.driver
-        Y2Network::UdevRule.new_driver_assignment(iface.modalias, iface.driver)
+        return nil unless iface.respond_to?(:custom_driver) && iface.custom_driver
+        Y2Network::UdevRule.new_driver_assignment(iface.modalias, iface.custom_driver)
       end
 
       # Renames interfaces and refreshes the udev service

--- a/src/lib/y2network/sysconfig/interfaces_writer.rb
+++ b/src/lib/y2network/sysconfig/interfaces_writer.rb
@@ -44,11 +44,11 @@ module Y2Network
 
     private
 
-      # Creates an udev rule for the given interface
+      # Creates an udev rule to rename the given interface
       #
       # @param iface [Interface] Interface to generate the udev rule for
       # @return [UdevRule,nil] udev rule or nil if it is not needed
-      def udev_rule_for(iface)
+      def renaming_udev_rule_for(iface)
         case iface.renaming_mechanism
         when :mac
           Y2Network::UdevRule.new_mac_based_rename(iface.name, iface.hardware.mac)
@@ -57,19 +57,34 @@ module Y2Network
         end
       end
 
+      # Creates an udev rule to set the driver for the given interface
+      #
+      # @param iface [Interface] Interface to generate the udev rule for
+      # @return [UdevRule,nil] udev rule or nil if it is not needed
+      def driver_udev_rule_for(iface)
+        return nil unless iface.respond_to?(:driver) && iface.driver
+        Y2Network::UdevRule.new_driver_assignment(iface.modalias, iface.driver)
+      end
+
       # Renames interfaces and refreshes the udev service
       #
       # @param interfaces [InterfaceCollection] Interfaces
       def update_udevd(interfaces)
-        update_udev_rules(interfaces)
+        update_renaming_udev_rules(interfaces)
+        update_drivers_udev_rules(interfaces)
         reload_udev_rules
       end
 
-      def update_udev_rules(interfaces)
-        udev_rules = interfaces.map { |i| udev_rule_for(i) }.compact
+      def update_renaming_udev_rules(interfaces)
+        udev_rules = interfaces.map { |i| renaming_udev_rule_for(i) }.compact
         known_names = interfaces.known_names
-        custom_rules = Y2Network::UdevRule.all.reject { |u| known_names.include?(u.device) }
-        Y2Network::UdevRule.write(custom_rules + udev_rules)
+        custom_rules = Y2Network::UdevRule.all(:net).reject { |u| known_names.include?(u.device) }
+        Y2Network::UdevRule.write_net_rules(custom_rules + udev_rules)
+      end
+
+      def update_drivers_udev_rules(interfaces)
+        udev_rules = interfaces.map { |i| driver_udev_rule_for(i) }.compact
+        Y2Network::UdevRule.write_drivers_rules(udev_rules)
       end
 
       def reload_udev_rules

--- a/src/lib/y2network/sysconfig/interfaces_writer.rb
+++ b/src/lib/y2network/sysconfig/interfaces_writer.rb
@@ -78,7 +78,7 @@ module Y2Network
       def update_renaming_udev_rules(interfaces)
         udev_rules = interfaces.map { |i| renaming_udev_rule_for(i) }.compact
         known_names = interfaces.known_names
-        custom_rules = Y2Network::UdevRule.all(:net).reject { |u| known_names.include?(u.device) }
+        custom_rules = Y2Network::UdevRule.naming_rules.reject { |u| known_names.include?(u.device) }
         Y2Network::UdevRule.write_net_rules(custom_rules + udev_rules)
       end
 

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -31,10 +31,10 @@ module Y2Network
   # * 79-yast2-drivers.rules ('drivers' group): rules to assign drivers to interfaces.
   #
   # This class offers a set of constructors to build different kinds of rules.
-  # See {#new_mac_based_rename}, {#new_bus_id_based_rename} and {#new_driver_assignment}.
+  # See {.new_mac_based_rename}, {.new_bus_id_based_rename} and {.new_driver_assignment}.
   #
   # When it comes to write rules to the filesystem, we decided to offer different methods to
-  # write to each file. See {#write_net_rules} and {#write_drivers_rules}.
+  # write to each file. See {.write_net_rules} and {.write_drivers_rules}.
   #
   # @example Create a rule containing some key/value pairs (rule part)
   #   rule = Y2Network::UdevRule.new(
@@ -53,7 +53,6 @@ module Y2Network
   #
   # @example Writing driver assignment rules
   #   rule = UdevRule.new_driver_assignment("virtio:d00000001v00001AF4", "virtio_net")
-  #   rule.to_s #=> "ENV{MODALIAS}==\"virtio:d00000001v00001AF4\", ENV{MODALIAS}=\"e1000\""
   #   UdevRule.write_drivers_rules([rule])
   #
   class UdevRule

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -247,9 +247,23 @@ module Y2Network
 
     # Returns the device mentioned in the rule (if any)
     #
-    # @return [String]
+    # @return [String,nil] Device name or nil if not found
     def device
       part_value_for("NAME", "=")
+    end
+
+    # Returns the original modalias
+    #
+    # @return [String,nil] Original modalias or nil if not found
+    def original_modalias
+      part_value_for("ENV{MODALIAS}", "==")
+    end
+
+    # Returns the modalias
+    #
+    # @return [String,nil] Original modalias or nil if not found
+    def driver
+      part_value_for("ENV{MODALIAS}", "=")
     end
   end
 end

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -80,6 +80,8 @@ module Y2Network
 
       # Returns the udev rule for a given device
       #
+      # Only the naming rules are considered.
+      #
       # @param device [String] Network device name
       # @return [UdevRule] udev rule
       def find_for(device)

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -146,7 +146,7 @@ module Y2Network
 
       # Writes drivers specific udev rules to the filesystem
       #
-      # Those roles that does not have an "ENV{MODALIAS}=\"xxx\"" part will be ignored.
+      # Those rules that does not have an MODALIAS part will be ignored.
       #
       # @param udev_rules [Array<UdevRule>] List of udev rules
       def write_drivers_rules(udev_rules)

--- a/src/lib/y2network/widgets/driver.rb
+++ b/src/lib/y2network/widgets/driver.rb
@@ -1,0 +1,87 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm"
+require "y2network/widgets/kernel_module"
+require "y2network/widgets/kernel_options"
+
+module Y2Network
+  module Widgets
+    # Widget to select the driver and to specify its options
+    class Driver < CWM::CustomWidget
+      include Yast::Logger
+
+      def initialize(builder)
+        textdomain "network"
+        @builder = builder
+        self.handle_all_events = true
+      end
+
+      def contents
+        Frame(
+          _("&Kernel Module"),
+          HBox(
+            HSpacing(0.5),
+            VBox(
+              VSpacing(0.4),
+              HBox(
+                kernel_module_widget,
+                HSpacing(0.5),
+                kernel_options_widget
+              ),
+              VSpacing(0.4)
+            ),
+            HSpacing(0.5)
+          )
+        )
+      end
+
+      def handle(event)
+        return unless event["ID"] == "kernel_module" && event["EventReason"] == "ValueChanged"
+        return nil if @old_kernel_module == kernel_module_widget.value
+
+        new_driver = @builder.drivers.find { |d| d.name == kernel_module_widget.value }
+        kernel_options_widget.value = new_driver.params if new_driver
+        @old_kernel_module = kernel_module_widget.value
+
+        nil
+      end
+
+      def store
+        @builder.driver = Y2Network::Driver.new(kernel_module_widget.value, kernel_options_widget.value)
+      end
+
+    private
+
+      def kernel_module_widget
+        return @kernel_module_width if @kernel_module_width
+        drivers_names = @builder.drivers.map(&:name)
+        selected_driver = @builder.driver.name if @builder.driver
+        @kernel_module_widget = KernelModule.new(drivers_names, selected_driver)
+      end
+
+      def kernel_options_widget
+        return @kernel_options_widget if @kernel_options_widget
+        options = @builder.driver ? @builder.driver.params : ""
+        @kernel_options_widget ||= KernelOptions.new(options)
+      end
+    end
+  end
+end

--- a/src/lib/y2network/widgets/driver.rb
+++ b/src/lib/y2network/widgets/driver.rb
@@ -71,7 +71,7 @@ module Y2Network
     private
 
       def kernel_module_widget
-        return @kernel_module_width if @kernel_module_width
+        return @kernel_module_widget if @kernel_module_widget
         drivers_names = @builder.drivers.map(&:name)
         selected_driver = @builder.driver.name if @builder.driver
         @kernel_module_widget = KernelModule.new(drivers_names, selected_driver)

--- a/src/lib/y2network/widgets/hardware_tab.rb
+++ b/src/lib/y2network/widgets/hardware_tab.rb
@@ -22,8 +22,7 @@ require "cwm/tabs"
 
 # used widgets
 require "y2network/widgets/blink_button"
-require "y2network/widgets/kernel_module"
-require "y2network/widgets/kernel_options"
+require "y2network/widgets/driver"
 require "y2network/widgets/ethtools_options"
 
 module Y2Network
@@ -43,22 +42,7 @@ module Y2Network
         VBox(
           # FIXME: ensure that only eth, maybe also ib?
           eth? ? BlinkButton.new(@settings) : Empty(),
-          Frame(
-            _("&Kernel Module"),
-            HBox(
-              HSpacing(0.5),
-              VBox(
-                VSpacing(0.4),
-                HBox(
-                  KernelModule.new(@settings),
-                  HSpacing(0.5),
-                  KernelOptions.new(@settings)
-                ),
-                VSpacing(0.4)
-              ),
-              HSpacing(0.5)
-            )
-          ),
+          Driver.new(@settings),
           # FIXME: probably makes sense only for eth
           EthtoolsOptions.new(@settings),
           VStretch()

--- a/src/lib/y2network/widgets/kernel_module.rb
+++ b/src/lib/y2network/widgets/kernel_module.rb
@@ -24,9 +24,15 @@ require "cwm/common_widgets"
 module Y2Network
   module Widgets
     class KernelModule < CWM::ComboBox
-      def initialize(settings)
+      # Constructor
+      #
+      # @param names    [Array<String>] Drivers names
+      # @param selected [String,nil] Initially selected driver (nil if no driver is selected)
+      def initialize(names, selected)
         textdomain "network"
-        @settings = settings
+        @names = names
+        @selected = selected
+        self.widget_id = "kernel_module"
       end
 
       def label
@@ -40,21 +46,15 @@ module Y2Network
       end
 
       def opt
-        [:editable]
+        [:editable, :notify]
       end
 
       def items
-        @settings.kernel_modules.map do |i|
-          [i, i]
-        end
+        @names.map { |n| [n, n] }
       end
 
       def init
-        self.value = @settings.driver unless @settings.driver.empty?
-      end
-
-      def store
-        @settings.driver = value
+        self.value = @selected if @selected
       end
     end
   end

--- a/src/lib/y2network/widgets/kernel_options.rb
+++ b/src/lib/y2network/widgets/kernel_options.rb
@@ -25,10 +25,12 @@ Yast.import "Label"
 module Y2Network
   module Widgets
     class KernelOptions < CWM::InputField
-      def initialize(settings)
+      # Constructor
+      #
+      # @param options [String] Driver options
+      def initialize(options)
         textdomain "network"
-
-        @settings = settings
+        @options = options
       end
 
       def label
@@ -48,11 +50,7 @@ module Y2Network
       end
 
       def init
-        self.value = @settings.driver_options
-      end
-
-      def store
-        @settings.driver_options = value
+        self.value = @options
       end
     end
   end

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -323,7 +323,8 @@ describe Y2Network::Config do
 
   describe "#drivers_for_interface" do
     let(:e1000) { Y2Network::Driver.new("e1000", "") }
-    let(:drivers) { [virtio_net, e1000] }
+    let(:custom) { Y2Network::Driver.new("custom", "") }
+    let(:drivers) { [virtio_net, e1000, custom] }
 
     before do
       allow(eth0).to receive(:drivers).and_return([Y2Network::Driver.new("virtio_net")])
@@ -332,6 +333,17 @@ describe Y2Network::Config do
     it "returns the driver for a given interface" do
       drivers = config.drivers_for_interface("eth0")
       expect(drivers).to eq([virtio_net])
+    end
+
+    context "when a custom driver is set" do
+      before do
+        eth0.custom_driver = custom.name
+      end
+
+      it "includes the custom driver" do
+        expect(config.drivers_for_interface("eth0"))
+          .to include(custom)
+      end
     end
   end
 

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 require_relative "../test_helper"
 require "y2network/config"
+require "y2network/driver"
 require "y2network/routing_table"
 require "y2network/interface"
 require "y2network/interfaces_collection"
@@ -34,7 +35,8 @@ describe Y2Network::Config do
 
   subject(:config) do
     described_class.new(
-      interfaces: interfaces, connections: connections, routing: routing, source: :sysconfig
+      interfaces: interfaces, connections: connections, routing: routing,
+      drivers: drivers, source: :sysconfig
     )
   end
 
@@ -53,6 +55,9 @@ describe Y2Network::Config do
     end
   end
   let(:connections) { Y2Network::ConnectionConfigsCollection.new([eth0_conn]) }
+
+  let(:virtio_net) { Y2Network::Driver.new("virtio_net", "csum=1") }
+  let(:drivers) { [virtio_net] }
 
   let(:routing) { Y2Network::Routing.new(tables: [table1, table2]) }
 
@@ -312,6 +317,38 @@ describe Y2Network::Config do
           expect { config.delete_interface(eth0.name) }.to change { config.interfaces.to_a }
             .from([eth0, br0]).to([br0])
         end
+      end
+    end
+  end
+
+  describe "#drivers_for_interface" do
+    let(:e1000) { Y2Network::Driver.new("e1000", "") }
+    let(:drivers) { [virtio_net, e1000] }
+
+    before do
+      allow(eth0).to receive(:drivers).and_return([Y2Network::Driver.new("virtio_net")])
+    end
+
+    it "returns the driver for a given interface" do
+      drivers = config.drivers_for_interface("eth0")
+      expect(drivers).to eq([virtio_net])
+    end
+  end
+
+  describe "#add_or_update_driver" do
+    let(:new_driver) { Y2Network::Driver.new("e1000", "") }
+
+    it "adds the driver" do
+      config.add_or_update_driver(new_driver)
+      expect(config.drivers).to eq([virtio_net, new_driver])
+    end
+
+    context "when a driver with the same name already exists" do
+      let(:new_driver) { Y2Network::Driver.new("virtio_net", "csum=0") }
+
+      it "replaces the driver with the given one" do
+        config.add_or_update_driver(new_driver)
+        expect(config.drivers).to eq([new_driver])
       end
     end
   end

--- a/test/y2network/driver_test.rb
+++ b/test/y2network/driver_test.rb
@@ -36,11 +36,20 @@ describe Y2Network::Driver do
     end
   end
 
-  describe "#save" do
+  describe ".write_options" do
+    it "writes the parameters to the underlying system" do
+      expect(driver).to receive(:write_options)
+      expect(Yast::SCR).to receive(:Write)
+        .with(Yast::Path.new(".modules"), nil)
+      described_class.write_options([driver])
+    end
+  end
+
+  describe "#write_options" do
     it "writes options to the underlying system" do
       expect(Yast::SCR).to receive(:Write)
         .with(Yast::Path.new(".modules.options.virtio_net"), "debug" => "16")
-      driver.save
+      driver.write_options
     end
   end
 end

--- a/test/y2network/driver_test.rb
+++ b/test/y2network/driver_test.rb
@@ -1,0 +1,46 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2network/driver"
+
+describe Y2Network::Driver do
+  subject(:driver) { described_class.new("virtio_net", "debug=16") }
+
+  describe ".from_system" do
+    before do
+      allow(Yast::SCR).to receive(:Read).with(Yast::Path.new(".modules.options.virtio_net"))
+        .and_return("csum" => "1")
+    end
+
+    it "reads the parameters from the underlying system" do
+      driver = described_class.from_system("virtio_net")
+      expect(driver.params).to eq("csum=1")
+    end
+  end
+
+  describe "#save" do
+    it "writes options to the underlying system" do
+      expect(Yast::SCR).to receive(:Write)
+        .with(Yast::Path.new(".modules.options.virtio_net"), "debug" => "16")
+      driver.save
+    end
+  end
+end

--- a/test/y2network/interfaces_collection_test.rb
+++ b/test/y2network/interfaces_collection_test.rb
@@ -92,6 +92,12 @@ describe Y2Network::InterfacesCollection do
     end
   end
 
+  describe "#physical" do
+    it "returns only physical interfaces" do
+      expect(collection.physical.map(&:name)).to eq(["eth0", "wlan0"])
+    end
+  end
+
   describe "#known_names" do
     it "returns the list of known interfaces" do
       expect(collection.known_names).to eq(["eth0", "br0", "wlan0"])

--- a/test/y2network/sysconfig/config_reader_test.rb
+++ b/test/y2network/sysconfig/config_reader_test.rb
@@ -36,7 +36,7 @@ describe Y2Network::Sysconfig::ConfigReader do
       Y2Network::Sysconfig::InterfacesReader,
       interfaces:  Y2Network::InterfacesCollection.new(interfaces),
       connections: connections,
-      drivers: drivers
+      drivers:     drivers
     )
   end
 

--- a/test/y2network/sysconfig/config_reader_test.rb
+++ b/test/y2network/sysconfig/config_reader_test.rb
@@ -28,13 +28,15 @@ describe Y2Network::Sysconfig::ConfigReader do
   let(:interfaces) { [eth0, wlan0] }
   let(:eth0_config) { instance_double(Y2Network::ConnectionConfig::Ethernet) }
   let(:connections) { [eth0_config] }
+  let(:drivers) { Y2Network::Driver.new("virtio_net", "") }
   let(:routes_file) { instance_double(Y2Network::Sysconfig::RoutesFile, load: nil, routes: []) }
   let(:dns_reader) { instance_double(Y2Network::Sysconfig::DNSReader, config: dns) }
   let(:interfaces_reader) do
     instance_double(
       Y2Network::Sysconfig::InterfacesReader,
       interfaces:  Y2Network::InterfacesCollection.new(interfaces),
-      connections: connections
+      connections: connections,
+      drivers: drivers
     )
   end
 
@@ -68,6 +70,11 @@ describe Y2Network::Sysconfig::ConfigReader do
     it "returns a configuration which includes DNS settings" do
       config = reader.config
       expect(config.dns).to eq(dns)
+    end
+
+    it "returns a configuration which includes available drivers" do
+      config = reader.config
+      expect(config.drivers).to eq(drivers)
     end
 
     it "sets the config source to :sysconfig" do

--- a/test/y2network/sysconfig/interfaces_reader_test.rb
+++ b/test/y2network/sysconfig/interfaces_reader_test.rb
@@ -23,9 +23,8 @@ require "y2network/udev_rule_part"
 
 describe Y2Network::Sysconfig::InterfacesReader do
   subject(:reader) { described_class.new }
-  let(:netcards) do
-    [eth0]
-  end
+
+  let(:netcards) { [eth0] }
 
   let(:eth0) do
     {
@@ -46,6 +45,7 @@ describe Y2Network::Sysconfig::InterfacesReader do
 
   let(:configured_interfaces) { ["lo", "eth0"] }
   let(:hardware_wrapper) { Y2Network::HardwareWrapper.new }
+  let(:driver) { Y2Network::Driver.new("virtio_net") }
 
   TYPES = { "eth0" => "eth" }.freeze
 
@@ -57,6 +57,7 @@ describe Y2Network::Sysconfig::InterfacesReader do
     allow(Yast::SCR).to receive(:Dir).and_call_original
     allow(Yast::NetworkInterfaces).to receive(:GetTypeFromSysfs) { |n| TYPES[n] }
     allow(Y2Network::UdevRule).to receive(:find_for).and_return(udev_rule)
+    allow(Y2Network::Driver).to receive(:from_system).and_return(driver)
   end
 
   around { |e| change_scr_root(File.join(DATA_PATH, "scr_read"), &e) }
@@ -108,10 +109,7 @@ describe Y2Network::Sysconfig::InterfacesReader do
 
   describe "#drivers" do
     it "returns a list of drivers" do
-      drivers = reader.drivers
-      expect(drivers).to eq(
-        [Y2Network::Driver.new("virtio_net", "")]
-      )
+      expect(reader.drivers).to eq([driver])
     end
   end
 end

--- a/test/y2network/sysconfig/interfaces_reader_test.rb
+++ b/test/y2network/sysconfig/interfaces_reader_test.rb
@@ -29,8 +29,9 @@ describe Y2Network::Sysconfig::InterfacesReader do
 
   let(:eth0) do
     {
-      "active" => true, "dev_name" => "eth0", "mac" => "00:12:34:56:78:90", "name" => "Ethernet Connection",
-      "type" => "eth"
+      "active" => true, "dev_name" => "eth0", "mac" => "00:12:34:56:78:90",
+      "name" => "Ethernet Connection", "type" => "eth",
+      "drivers" => [{ "modules" => [["virtio_net", ""]] }]
     }
   end
 
@@ -102,6 +103,15 @@ describe Y2Network::Sysconfig::InterfacesReader do
       connections = reader.connections
       conn = connections.by_name("eth0")
       expect(conn.interface).to eq("eth0")
+    end
+  end
+
+  describe "#drivers" do
+    it "returns a list of drivers" do
+      drivers = reader.drivers
+      expect(drivers).to eq(
+        [Y2Network::Driver.new("virtio_net", "")]
+      )
     end
   end
 end

--- a/test/y2network/sysconfig/interfaces_writer_test.rb
+++ b/test/y2network/sysconfig/interfaces_writer_test.rb
@@ -127,7 +127,7 @@ describe Y2Network::Sysconfig::InterfacesWriter do
         let(:unknown_rule) { Y2Network::UdevRule.new_mac_based_rename("unknown", "00:11:22:33:44:55:66") }
 
         before do
-          allow(Y2Network::UdevRule).to receive(:all).and_return([unknown_rule])
+          allow(Y2Network::UdevRule).to receive(:naming_rules).and_return([unknown_rule])
         end
 
         it "keeps the rule" do

--- a/test/y2network/sysconfig/interfaces_writer_test.rb
+++ b/test/y2network/sysconfig/interfaces_writer_test.rb
@@ -32,7 +32,7 @@ describe Y2Network::Sysconfig::InterfacesWriter do
     let(:eth0) do
       Y2Network::PhysicalInterface.new("eth0", hardware: hardware).tap do |i|
         i.renaming_mechanism = renaming_mechanism
-        i.driver = driver
+        i.custom_driver = driver
       end
     end
 

--- a/test/y2network/sysconfig/interfaces_writer_test.rb
+++ b/test/y2network/sysconfig/interfaces_writer_test.rb
@@ -30,17 +30,24 @@ describe Y2Network::Sysconfig::InterfacesWriter do
   describe "#write" do
     let(:interfaces) { Y2Network::InterfacesCollection.new([eth0]) }
     let(:eth0) do
-      Y2Network::PhysicalInterface.new("eth0").tap { |i| i.renaming_mechanism = renaming_mechanism }
+      Y2Network::PhysicalInterface.new("eth0", hardware: hardware).tap do |i|
+        i.renaming_mechanism = renaming_mechanism
+        i.driver = driver
+      end
     end
+
     let(:hardware) do
-      instance_double(Y2Network::Hwinfo, busid: "00:1c.0", mac: "01:23:45:67:89:ab", dev_port: "1")
+      instance_double(
+        Y2Network::Hwinfo, name: "Ethernet Card 0", busid: "00:1c.0", mac: "01:23:45:67:89:ab",
+        dev_port: "1", modalias: "virtio:d00000001v00001AF4"
+      )
     end
     let(:renaming_mechanism) { :none }
+    let(:driver) { nil }
     let(:scr_root) { Dir.mktmpdir }
 
     before do
       allow(Yast::Execute).to receive(:on_target)
-      allow(eth0).to receive(:hardware).and_return(hardware)
       allow(writer).to receive(:sleep)
 
       # prevent collision with real hardware
@@ -91,7 +98,7 @@ describe Y2Network::Sysconfig::InterfacesWriter do
         let(:renaming_mechanism) { :mac }
 
         it "writes a MAC based udev renaming rule" do
-          expect(Y2Network::UdevRule).to receive(:write) do |rules|
+          expect(Y2Network::UdevRule).to receive(:write_net_rules) do |rules|
             expect(rules.first.to_s).to eq(
               "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", " \
                 "ATTR{type}==\"1\", ATTR{dev_id}==\"0x0\", " \
@@ -106,7 +113,7 @@ describe Y2Network::Sysconfig::InterfacesWriter do
         let(:renaming_mechanism) { :bus_id }
 
         it "writes a BUS ID based udev renaming rule" do
-          expect(Y2Network::UdevRule).to receive(:write) do |rules|
+          expect(Y2Network::UdevRule).to receive(:write_net_rules) do |rules|
             expect(rules.first.to_s).to eq(
               "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", " \
                 "ATTR{type}==\"1\", KERNELS==\"00:1c.0\", ATTR{dev_port}==\"1\", NAME=\"eth1\""
@@ -124,7 +131,7 @@ describe Y2Network::Sysconfig::InterfacesWriter do
         end
 
         it "keeps the rule" do
-          expect(Y2Network::UdevRule).to receive(:write) do |rules|
+          expect(Y2Network::UdevRule).to receive(:write_net_rules) do |rules|
             expect(rules.first.to_s).to eq(unknown_rule.to_s)
           end
           subject.write(interfaces)
@@ -136,8 +143,19 @@ describe Y2Network::Sysconfig::InterfacesWriter do
       let(:renaming_mechanism) { nil }
 
       it "does not write a udev rule" do
-        expect(Y2Network::UdevRule).to receive(:write) do |rules|
+        expect(Y2Network::UdevRule).to receive(:write_net_rules) do |rules|
           expect(rules).to be_empty
+        end
+        subject.write(interfaces)
+      end
+    end
+
+    context "when a driver is set for an interface" do
+      let(:driver) { "virtio_net" }
+
+      it "writes an udev driver rule" do
+        expect(Y2Network::UdevRule).to receive(:write_drivers_rules) do |rules|
+          expect(rules.first.to_s).to eq("ENV{MODALIAS}==\"#{hardware.modalias}\", ENV{MODALIAS}=\"#{driver}\"")
         end
         subject.write(interfaces)
       end

--- a/test/y2network/udev_rule_test.rb
+++ b/test/y2network/udev_rule_test.rb
@@ -212,4 +212,20 @@ describe Y2Network::UdevRule do
       expect(udev_rule.device).to eq("eth0")
     end
   end
+
+  describe "#original_modalias" do
+    subject(:udev_rule) { described_class.new_driver_assignment("virtio:0000", "virtio_net") }
+
+    it "returns the original modalias" do
+      expect(udev_rule.original_modalias).to eq("virtio:0000")
+    end
+  end
+
+  describe "#driver" do
+    subject(:udev_rule) { described_class.new_driver_assignment("virtio:0000", "virtio_net") }
+
+    it "return the assigned driver" do
+      expect(udev_rule.driver).to eq("virtio_net")
+    end
+  end
 end

--- a/test/y2network/udev_rule_test.rb
+++ b/test/y2network/udev_rule_test.rb
@@ -126,7 +126,7 @@ describe Y2Network::UdevRule do
 
     it "writes changes using the udev_persistent agent" do
       expect(Yast::SCR).to receive(:Write).with(
-        Yast::Path.new(".udev_persistent.drivers"), { "virtio_net" => udev_rule.parts.map(&:to_s) }
+        Yast::Path.new(".udev_persistent.drivers"), "virtio_net" => udev_rule.parts.map(&:to_s)
       )
       expect(Yast::SCR).to receive(:Write).with(Yast::Path.new(".udev_persistent.nil"), [])
       described_class.write_drivers_rules([udev_rule])

--- a/test/y2network/udev_rule_test.rb
+++ b/test/y2network/udev_rule_test.rb
@@ -46,14 +46,16 @@ describe Y2Network::UdevRule do
       .and_return(udev_persistent_drivers)
   end
 
-  describe ".all" do
-    it "returns the rules from :net group" do
-      rules = described_class.all(:net)
+  describe ".naming_rules" do
+    it "returns naming rules" do
+      rules = described_class.naming_rules
       expect(rules.first.to_s).to match(/NAME=/)
     end
+  end
 
-    it "returns the rules from :drivers group" do
-      rules = described_class.all(:drivers)
+  describe ".drivers_rules" do
+    it "returns drivers rules" do
+      rules = described_class.drivers_rules
       expect(rules.first.to_s).to match(/MODALIAS/)
     end
   end

--- a/test/y2network/widgets/driver_test.rb
+++ b/test/y2network/widgets/driver_test.rb
@@ -1,0 +1,55 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "cwm/rspec"
+
+require "y2network/widgets/driver"
+
+describe Y2Network::Widgets::Driver do
+  subject(:widget) { described_class.new(builder) }
+
+  let(:builder) do
+    Y2Network::InterfaceConfigBuilder.for("eth")
+  end
+  let(:virtio_net) { Y2Network::Driver.new("virtio_net", "csum=1") }
+
+  before do
+    allow(builder).to receive(:drivers).and_return([virtio_net])
+    allow(builder).to receive(:driver).and_return(virtio_net)
+  end
+
+  include_examples "CWM::CustomWidget"
+
+  describe "#contents" do
+    it "contains a kernel module widget" do
+      expect(Y2Network::Widgets::KernelModule).to receive(:new)
+        .with(["virtio_net"], "virtio_net")
+      widget.contents
+    end
+
+    it "contains a kernel options widget" do
+      expect(Y2Network::Widgets::KernelOptions).to receive(:new)
+        .with("csum=1")
+      widget.contents
+    end
+  end
+
+  describe "#handle"
+end

--- a/test/y2network/widgets/kernel_module_test.rb
+++ b/test/y2network/widgets/kernel_module_test.rb
@@ -21,13 +21,9 @@ require_relative "../../test_helper"
 require "cwm/rspec"
 
 require "y2network/widgets/kernel_module"
-require "y2network/interface_config_builder"
 
 describe Y2Network::Widgets::KernelModule do
-  let(:builder) do
-    Y2Network::InterfaceConfigBuilder.for("eth")
-  end
-  subject { described_class.new(builder) }
+  subject { described_class.new(["virtio_net"], "virtio_net") }
 
   include_examples "CWM::ComboBox"
 end


### PR DESCRIPTION
This PR adds support for drivers handling. It is rather long, and it includes these changes:

* `Y2Network::Config` includes now a list of drivers (`#drivers`). The reason to keep a unified list if that drivers options are shared for all interfaces.
* A new widget to specify driver name and options have been added.
* When an interface has a custom driver (a driver specified by the user), it is written to `/etc/udev/rules.d/79-yast2-drivers.rules`.
* Drivers options are placed at `/etc/modprobe.d/50-yast.conf`.

# TODO

- [ ] Rename Driver#params to Driver#options (to keep consistency with the rest).
- [ ] Keep driver options when the selection changes. For instance, let's say that you modify "virtio_net" and set options to "csum=1". If you change your selection, these options are lost.
- [ ] Drop udev code from the old backend.