### PR TITLE
Allow to select no driver (auto)

### DIFF
--- a/src/lib/y2network/driver.rb
+++ b/src/lib/y2network/driver.rb
@@ -67,8 +67,8 @@ module Y2Network
 
     # Determines whether two drivers are equal
     #
-    # @param other [Driver] Driver to compare with
-    # @return [Boolean]
+    # @param other [Object] Driver to compare with
+    # @return [Boolean] true if +other+ is a Driver instance with the same name and params; false otherwise.
     def ==(other)
       return false unless other.is_a?(Driver)
       name == other.name && params == other.params

--- a/src/lib/y2network/driver.rb
+++ b/src/lib/y2network/driver.rb
@@ -70,6 +70,7 @@ module Y2Network
     # @param other [Driver] Driver to compare with
     # @return [Boolean]
     def ==(other)
+      return false unless other.is_a?(Driver)
       name == other.name && params == other.params
     end
 

--- a/src/lib/y2network/widgets/driver.rb
+++ b/src/lib/y2network/widgets/driver.rb
@@ -87,8 +87,7 @@ module Y2Network
         return @kernel_module_widget if @kernel_module_widget
         drivers_names = @builder.drivers.map(&:name)
         selected_driver = @builder.driver.name if @builder.driver != :auto
-        current_driver = @builder.interface.current_driver if @builder.interface
-        @kernel_module_widget = KernelModule.new(drivers_names, selected_driver, current_driver)
+        @kernel_module_widget = KernelModule.new(drivers_names, selected_driver)
       end
 
       def kernel_options_widget

--- a/src/lib/y2network/widgets/kernel_module.rb
+++ b/src/lib/y2network/widgets/kernel_module.rb
@@ -28,10 +28,12 @@ module Y2Network
       #
       # @param names    [Array<String>] Drivers names
       # @param selected [String,nil] Initially selected driver (nil if no driver is selected)
-      def initialize(names, selected)
+      # @param current  [String] Name of the module currently used by the kernel
+      def initialize(names, selected, current)
         textdomain "network"
         @names = names
         @selected = selected
+        @current = current
         self.widget_id = "kernel_module"
       end
 
@@ -50,11 +52,22 @@ module Y2Network
       end
 
       def items
-        @names.map { |n| [n, n] }
+        @items ||= [["yast_auto", auto_label]] + @names.map { |n| [n, n] }
       end
 
       def init
         self.value = @selected if @selected
+      end
+
+      def value
+        ret = super
+        ret == "yast_auto" ? :auto : ret
+      end
+
+    private
+
+      def auto_label
+        @current ? format(_("Auto (%s)"), @current) : _("Auto")
       end
     end
   end

--- a/src/lib/y2network/widgets/kernel_module.rb
+++ b/src/lib/y2network/widgets/kernel_module.rb
@@ -50,7 +50,7 @@ module Y2Network
       end
 
       def items
-        @items ||= [["yast_auto", _("Auto")]] + @names.map { |n| [n, n] }
+        @items ||= [["", _("Auto")]] + @names.map { |n| [n, n] }
       end
 
       def init
@@ -59,7 +59,7 @@ module Y2Network
 
       def value
         ret = super
-        ret == "yast_auto" ? :auto : ret
+        ret == "" ? :auto : ret
       end
     end
   end

--- a/src/lib/y2network/widgets/kernel_module.rb
+++ b/src/lib/y2network/widgets/kernel_module.rb
@@ -28,12 +28,10 @@ module Y2Network
       #
       # @param names    [Array<String>] Drivers names
       # @param selected [String,nil] Initially selected driver (nil if no driver is selected)
-      # @param current  [String] Name of the module currently used by the kernel
-      def initialize(names, selected, current)
+      def initialize(names, selected)
         textdomain "network"
         @names = names
         @selected = selected
-        @current = current
         self.widget_id = "kernel_module"
       end
 
@@ -52,7 +50,7 @@ module Y2Network
       end
 
       def items
-        @items ||= [["yast_auto", auto_label]] + @names.map { |n| [n, n] }
+        @items ||= [["yast_auto", _("Auto")]] + @names.map { |n| [n, n] }
       end
 
       def init
@@ -62,12 +60,6 @@ module Y2Network
       def value
         ret = super
         ret == "yast_auto" ? :auto : ret
-      end
-
-    private
-
-      def auto_label
-        @current ? format(_("Auto (%s)"), @current) : _("Auto")
       end
     end
   end

--- a/test/y2network/interface_config_builder_test.rb
+++ b/test/y2network/interface_config_builder_test.rb
@@ -70,26 +70,34 @@ describe Y2Network::InterfaceConfigBuilder do
       subject.save
     end
 
-    context "when the selected driver is different from the current one" do
+    context "when a driver is selected" do
       before do
-        allow(eth0).to receive(:current_driver).and_return("e1000")
+        config_builder.driver = driver
       end
 
       it "sets the interface driver" do
         expect(eth0).to receive(:custom_driver=).with(driver.name)
-        config_builder.driver = driver
+        subject.save
+      end
+
+      it "updates the driver" do
+        expect(config).to receive(:add_or_update_driver).with(driver)
         subject.save
       end
     end
 
-    context "when the selected driver is the same than the current one" do
+    context "when no driver is selected" do
       before do
-        allow(eth0).to receive(:current_driver).and_return("virtio_net")
+        config_builder.driver = :auto
       end
 
-      it "sets the interface driver" do
-        expect(eth0).to_not receive(:custom_driver=)
-        config_builder.driver = driver
+      it "sets the interface driver to nil" do
+        expect(eth0).to receive(:custom_driver=).with(nil)
+        subject.save
+      end
+
+      it "does not update any driver" do
+        expect(config).to_not receive(:add_or_update_driver)
         subject.save
       end
     end

--- a/test/y2network/widgets/driver_test.rb
+++ b/test/y2network/widgets/driver_test.rb
@@ -42,7 +42,7 @@ describe Y2Network::Widgets::Driver do
   describe "#contents" do
     it "contains a kernel module widget" do
       expect(Y2Network::Widgets::KernelModule).to receive(:new)
-        .with(["virtio_net"], "virtio_net", nil)
+        .with(["virtio_net"], "virtio_net")
       widget.contents
     end
 

--- a/test/y2network/widgets/driver_test.rb
+++ b/test/y2network/widgets/driver_test.rb
@@ -29,10 +29,12 @@ describe Y2Network::Widgets::Driver do
     Y2Network::InterfaceConfigBuilder.for("eth")
   end
   let(:virtio_net) { Y2Network::Driver.new("virtio_net", "csum=1") }
+  let(:eth0) { Y2Network::PhysicalInterface.new("eth0") }
 
   before do
     allow(builder).to receive(:drivers).and_return([virtio_net])
     allow(builder).to receive(:driver).and_return(virtio_net)
+    allow(builder).to receive(:interface).and_return(eth0)
   end
 
   include_examples "CWM::CustomWidget"
@@ -40,7 +42,7 @@ describe Y2Network::Widgets::Driver do
   describe "#contents" do
     it "contains a kernel module widget" do
       expect(Y2Network::Widgets::KernelModule).to receive(:new)
-        .with(["virtio_net"], "virtio_net")
+        .with(["virtio_net"], "virtio_net", nil)
       widget.contents
     end
 

--- a/test/y2network/widgets/kernel_module_test.rb
+++ b/test/y2network/widgets/kernel_module_test.rb
@@ -23,7 +23,7 @@ require "cwm/rspec"
 require "y2network/widgets/kernel_module"
 
 describe Y2Network::Widgets::KernelModule do
-  subject { described_class.new(["virtio_net"], "virtio_net") }
+  subject { described_class.new(["virtio_net", "alt"], "virtio_net", "virtio_net") }
 
   include_examples "CWM::ComboBox"
 end

--- a/test/y2network/widgets/kernel_module_test.rb
+++ b/test/y2network/widgets/kernel_module_test.rb
@@ -23,7 +23,7 @@ require "cwm/rspec"
 require "y2network/widgets/kernel_module"
 
 describe Y2Network::Widgets::KernelModule do
-  subject { described_class.new(["virtio_net", "alt"], "virtio_net", "virtio_net") }
+  subject { described_class.new(["virtio_net", "alt"], "virtio_net") }
 
   include_examples "CWM::ComboBox"
 end


### PR DESCRIPTION
In my tests I ended in this scenario: let's say that I select a `custom` driver for a given interface, which caused a udev rule to be written. The next time that I open the hardware dialog again, I can only switch between the `custom` and the `virtio_net` driver. But, in both cases, a udev rule will be written (or updated). But what I want to do is to not force any driver at all. The only option is to manually delete the file.

As a solution, I have extended the drivers dialog to support an `auto` option, in which case no udev rule is written (and the kernel will decide which module to use).

![driver-auto](https://user-images.githubusercontent.com/15836/64935675-6b3f4980-d84a-11e9-9c8d-85447793e240.png)

