### PR TITLE
network-ng: fix configured interface detection

### DIFF
--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -192,6 +192,17 @@ module Y2Network
       end
     end
 
+    # Determines whether a given interface is configured or not
+    #
+    # An interface is considered as configured when it has an associated collection.
+    #
+    # @param iface_name [String] Interface's name
+    # @return [Boolean]
+    def configured_interface?(iface_name)
+      return false if iface_name.nil? || iface_name.empty?
+      !connections.by_interface(iface_name).empty?
+    end
+
     alias_method :eql?, :==
   end
 end

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -43,8 +43,6 @@ module Y2Network
     attr_accessor :description
     # @return [InterfaceType] Interface type
     attr_accessor :type
-    # @return [Boolean]
-    attr_reader :configured
     # @return [HwInfo]
     attr_reader :hardware
     # @return [Symbol] Mechanism to rename the interface (:none -no rename-, :bus_id or :mac)
@@ -76,8 +74,6 @@ module Y2Network
       @type = type
       # TODO: move renaming logic to physical interfaces only
       @renaming_mechanism = :none
-
-      init(name)
     end
 
     # Determines whether two interfaces are equal
@@ -117,17 +113,6 @@ module Y2Network
       @old_name = name if name != new_name # same name, just set different mechanism
       @name = new_name
       @renaming_mechanism = mechanism
-    end
-
-  private
-
-    def system_config(name)
-      Yast::Lan.system_config.connections.by_name(name)
-    end
-
-    def init(name)
-      @configured = false
-      @configured = !system_config(name).nil? if !(name.nil? || name.empty?)
     end
   end
 end

--- a/src/lib/y2network/interface_config_builders/bonding.rb
+++ b/src/lib/y2network/interface_config_builders/bonding.rb
@@ -84,7 +84,7 @@ module Y2Network
         # already contains partially configured bond when adding
         return false if iface.name == @name
 
-        return true if !iface.configured
+        return true unless yast_config.configured_interface?(iface.name)
 
         iface.bootproto == "none"
       end

--- a/src/lib/y2network/interface_config_builders/bridge.rb
+++ b/src/lib/y2network/interface_config_builders/bridge.rb
@@ -73,7 +73,7 @@ module Y2Network
         # FIXME: this can happen only bcs we silently use LanItems::Items which
         # already contains partially configured bridge when adding
         return false if iface.name == @name
-        return true if !iface.configured
+        return true unless yast_config.configured_interface?(iface.name)
 
         if interfaces.bond_index[iface.name]
           log.debug("Excluding (#{iface.name}) - is bonded")

--- a/src/lib/y2network/sysconfig/config_writer.rb
+++ b/src/lib/y2network/sysconfig/config_writer.rb
@@ -69,7 +69,7 @@ module Y2Network
           file = routes_file_for(dev)
 
           # Remove ifroutes-* if empty or interface is not configured
-          file.remove if routes.empty? || !dev.configured
+          file.remove if routes.empty? || !config.configured_interface?(dev.name)
 
           file.routes = routes
           file.save

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -372,4 +372,30 @@ describe Y2Network::Config do
       end
     end
   end
+
+  describe "#configured_interface?" do
+    context "when a connection for the given interface exists" do
+      it "reeturns true" do
+        expect(config.configured_interface?("eth0")).to eq(true)
+      end
+    end
+
+    context "when no connection for the given interface exists" do
+      it "reeturns false" do
+        expect(config.configured_interface?("eth9")).to eq(false)
+      end
+    end
+
+    context "when interface name is nil" do
+      it "returns false" do
+        expect(config.configured_interface?(nil)).to eq(false)
+      end
+    end
+
+    context "when interface name is empty" do
+      it "returns false" do
+        expect(config.configured_interface?("")).to eq(false)
+      end
+    end
+  end
 end

--- a/test/y2network/sysconfig/config_writer_test.rb
+++ b/test/y2network/sysconfig/config_writer_test.rb
@@ -19,6 +19,7 @@
 require_relative "../../test_helper"
 require "y2network/sysconfig/config_writer"
 require "y2network/config"
+require "y2network/connection_configs_collection"
 require "y2network/interface"
 require "y2network/interfaces_collection"
 require "y2network/routing"
@@ -35,7 +36,7 @@ describe Y2Network::Sysconfig::ConfigWriter do
     let(:config) do
       Y2Network::Config.new(
         interfaces:  Y2Network::InterfacesCollection.new([eth0]),
-        connections: [eth0_conn],
+        connections: Y2Network::ConnectionConfigsCollection.new([eth0_conn]),
         routing:     routing,
         source:      :sysconfig
       )
@@ -99,7 +100,6 @@ describe Y2Network::Sysconfig::ConfigWriter do
         .and_return(conn_writer)
       allow(Y2Network::Sysconfig::InterfacesWriter).to receive(:new)
         .and_return(interfaces_writer)
-      allow(eth0).to receive(:configured).and_return(true)
     end
 
     it "saves general routes to main routes file" do
@@ -150,7 +150,6 @@ describe Y2Network::Sysconfig::ConfigWriter do
         allow(Y2Network::Sysconfig::RoutesFile).to receive(:new)
           .with("/etc/sysconfig/network/ifroute-eth1")
           .and_return(ifroute_eth1)
-        allow(eth1).to receive(:configured).and_return(true)
       end
 
       it "removes the ifroute file" do


### PR DESCRIPTION
This PR fixes a problem when trying to find out when an interface was configured or not. Actually, it is the `Y2Network::Config` who knows this piece of information. We could think about linking interfaces and connections instances, but for the time being let's keep it simple.