### PR TITLE
network-ng: AutoYaST 2nd stage fixes

### DIFF
--- a/src/lib/y2network/autoinst/config_reader.rb
+++ b/src/lib/y2network/autoinst/config_reader.rb
@@ -39,7 +39,7 @@ module Y2Network
       # Constructor
       #
       # @param section [AutoinstProfile::NetworkingSection]
-      # @param system_config [Config] system configuration
+      # @param original_config [Config] system configuration
       def initialize(section, original_config)
         @section = section
         @original_config = original_config

--- a/src/lib/y2network/autoinst/config_reader.rb
+++ b/src/lib/y2network/autoinst/config_reader.rb
@@ -39,13 +39,15 @@ module Y2Network
       # Constructor
       #
       # @param section [AutoinstProfile::NetworkingSection]
-      def initialize(section)
+      # @param system_config [Config] system configuration
+      def initialize(section, original_config)
         @section = section
+        @original_config = original_config
       end
 
       # @return [Y2Network::Config] Network configuration
       def config
-        config = Yast::Lan.system_config || Y2Network::Config.new(source: :autoyast)
+        config = @original_config.copy
         # apply at first udev rules, so interfaces names are correct
         UdevRulesReader.new(section.udev_rules).apply(config) if section.udev_rules
         config.routing = RoutingReader.new(section.routing).config if section.routing

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -57,10 +57,10 @@ module Y2Network
 
     class << self
       # @param source [Symbol] Source to read the configuration from
-      # @param opts   [Hash]   Reader options. Check readers documentation to find out
-      #                        supported options.
-      def from(source, opts = {})
-        reader = ConfigReader.for(source, opts)
+      # @param *opts  [Array<Object>] Reader options. Check readers documentation to find out
+      #   supported options.
+      def from(source, *opts)
+        reader = ConfigReader.for(source, *opts)
         reader.config
       end
 
@@ -113,14 +113,16 @@ module Y2Network
 
     # Writes the configuration into the YaST modules
     #
-    # Writes only changes agains original configuration if the original configuration
+    # Writes only changes against original configuration if the original configuration
     # is provided
     #
     # @param original [Y2Network::Config] configuration used for detecting changes
+    # @param target   [Symbol] Target to write the configuration to (:sysconfig)
     #
     # @see Y2Network::ConfigWriter
-    def write(original: nil)
-      Y2Network::ConfigWriter.for(source).write(self, original)
+    def write(original: nil, target: nil)
+      target ||= source
+      Y2Network::ConfigWriter.for(target).write(self, original)
     end
 
     # Determines whether two configurations are equal

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -57,7 +57,7 @@ module Y2Network
 
     class << self
       # @param source [Symbol] Source to read the configuration from
-      # @param *opts  [Array<Object>] Reader options. Check readers documentation to find out
+      # @param opts   [Array<Object>] Reader options. Check readers documentation to find out
       #   supported options.
       def from(source, *opts)
         reader = ConfigReader.for(source, *opts)

--- a/src/lib/y2network/config_reader.rb
+++ b/src/lib/y2network/config_reader.rb
@@ -21,7 +21,7 @@ module Y2Network
     # Config reader for a given source
     #
     # @param source [Symbol] Source name (e.g., :sysconfig)
-    # @param *opts  [Array<Object>] Reader options
+    # @param opts  [Array<Object>] Reader options
     # @return [Y2Network::Autoinst::ConfigReader,Y2Network::Sysconfig::ConfigReader]
     def self.for(source, *opts)
       require "y2network/#{source}/config_reader"

--- a/src/lib/y2network/config_reader.rb
+++ b/src/lib/y2network/config_reader.rb
@@ -21,13 +21,13 @@ module Y2Network
     # Config reader for a given source
     #
     # @param source [Symbol] Source name (e.g., :sysconfig)
-    # @param opts   [Hash] Reader options
+    # @param *opts  [Array<Object>] Reader options
     # @return [Y2Network::Autoinst::ConfigReader,Y2Network::Sysconfig::ConfigReader]
-    def self.for(source, opts = {})
+    def self.for(source, *opts)
       require "y2network/#{source}/config_reader"
       modname = source.to_s.split("_").map(&:capitalize).join
       klass = Y2Network.const_get("#{modname}::ConfigReader")
-      klass.new(opts)
+      klass.new(*opts)
     end
   end
 end

--- a/src/lib/y2network/sysconfig/config_writer.rb
+++ b/src/lib/y2network/sysconfig/config_writer.rb
@@ -36,9 +36,7 @@ module Y2Network
       # @param config     [Y2Network::Config] Configuration to write
       # @param old_config [Y2Network::Config] Old configuration
       def write(config, old_config = nil)
-        return unless config.routing
-
-        write_ip_forwarding(config.routing)
+        write_ip_forwarding(config.routing) if config.routing
         write_interface_changes(config, old_config)
 
         # update /etc/sysconfig/network/routes file

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -524,7 +524,8 @@ module Yast
       ProgressNextStage(_("Writing routing configuration..."))
       orig = Progress.set(false)
 
-      yast_config.write(original: system_config)
+      target = :sysconfig if Mode.auto
+      yast_config.write(original: system_config, target: target)
       Progress.set(orig)
       Builtins.sleep(sl)
 

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -716,8 +716,9 @@ module Yast
     def Import(settings)
       settings = {} if settings.nil?
 
+      Lan.Read(:cache)
       profile = Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(settings)
-      config = Y2Network::Config.from(:autoinst, profile)
+      config = Y2Network::Config.from(:autoinst, profile, system_config)
       add_config(:yast, config)
 
       LanItems.Import(settings)

--- a/test/y2network/autoinst/config_reader_test.rb
+++ b/test/y2network/autoinst/config_reader_test.rb
@@ -26,10 +26,11 @@ require "y2network/autoinst/config_reader"
 require "y2network/sysconfig/interfaces_reader"
 
 describe Y2Network::Autoinst::ConfigReader do
-  let(:subject) { described_class.new(networking_section) }
+  let(:subject) { described_class.new(networking_section, system_config) }
   let(:networking_section) do
     Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(profile)
   end
+  let(:system_config) { Y2Network::Config.new(source: :testing) }
 
   let(:eth0) { { "device" => "eth0", "bootproto" => "dhcp", "startmode" => "auto" } }
   let(:interfaces) { [eth0] }

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -67,7 +67,7 @@ describe Y2Network::Config do
     end
 
     before do
-      allow(Y2Network::ConfigReader).to receive(:for).with(:sysconfig, {})
+      allow(Y2Network::ConfigReader).to receive(:for).with(:sysconfig)
         .and_return(reader)
     end
 


### PR DESCRIPTION
AutoYaST uses the current configuration as a starting point, so the list of interfaces is already available (it was missing). We could consider using only the list of interfaces to avoid that some configuration bits from the running system leak into the final configuration. But, for the time being, this approach looks good enough.