### PR TITLE
network-ng: merge master

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,29 @@
 -------------------------------------------------------------------
+Tue Sep 10 07:40:04 UTC 2019 - Michal Filka <mfilka@suse.com>
+
+- bnc#1149234
+  - apply udev rule from AY profile according to device's mac
+    value when permanent_mac is missing in list of the device's
+    options
+- bsc#1133442
+  - Increased the DHCP timeout when NetworkManager is in use to
+    its default (45 seconds).
+- 4.2.12
+
+-------------------------------------------------------------------
+Tue Jul 30 11:14:04 UTC 2019 - Dominique Leuenberger <dimstar@opensuse.org>
+
+- Requires hostname: there are many places where the module calls
+  /bin/hostname (boo#1142595).
+- 4.2.11
+
+-------------------------------------------------------------------
+Fri Jul 19 08:10:14 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- avoid dependency on autoyast2-installation
+- 4.2.10
+
+-------------------------------------------------------------------
 Wed Jul 17 10:30:31 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Revamp UI internals, adding new widgets, sequences and

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.9
+Version:        4.2.12
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only
@@ -57,12 +57,10 @@ Requires:       augeas-lenses
 Requires:       hwinfo         >= 21.35
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       yast2-xml
+Requires:       hostname
 
 # testsuite
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
-
-# support for reading Profile etc.
-BuildRequires:  autoyast2-installation
 
 # carrier detection
 Conflicts:      yast2-core < 2.10.6

--- a/src/lib/y2network/hwinfo.rb
+++ b/src/lib/y2network/hwinfo.rb
@@ -181,7 +181,7 @@ module Y2Network
     #   @return [String,nil]
     [
       { name: "dev_name", default: "" },
-      { name: "mac", default: nil },
+      { name: "permanent_mac", default: nil },
       { name: "busid", default: nil },
       { name: "link", default: false },
       { name: "driver", default: "" },
@@ -248,6 +248,25 @@ module Y2Network
     # @return [Boolean]
     def present?
       !!type
+    end
+
+    # Returns the MAC adress
+    #
+    # It usually returns the permanent MAC address (defined in the firmware).  However, when
+    # missing, it will use the current MAC. See bsc#1136929 and bsc#1149234 for the reasons
+    # behind preferring the permanent MAC address.
+    #
+    # @return [String,nil] MAC address
+    def mac
+      return permanent_mac unless permanent_mac.nil? || permanent_mac.empty?
+      used_mac
+    end
+
+    # MAC address which is being used by the device
+    #
+    # @return [String,nil] MAC address
+    def used_mac
+      @hwinfo["mac"]
     end
 
     # Determines whether two objects are equivalent

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -449,6 +449,8 @@ module Yast
       nil
     end
 
+    NM_DHCP_TIMEOUT = 45
+
     # Update the SCR according to network settings
     # @return true on success
     def Write(gui: true)
@@ -572,7 +574,7 @@ module Yast
 
       if NetworkService.is_network_manager
         network = false
-        timeout = 15
+        timeout = NM_DHCP_TIMEOUT
         while Ops.greater_than(timeout, 0)
           if NetworkService.isNetworkRunning
             network = true

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -431,7 +431,7 @@ module Yast
 
       hardware.each do |hw|
         hw_dev_name = hw["dev_name"] || ""
-        hw_dev_mac = hw["permanent_mac"] || ""
+        hw_dev_mac = hw["permanent_mac"] || hw["mac"] || ""
         hw_dev_busid = hw["busid"] || ""
 
         case oldname

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -221,11 +221,6 @@ describe Yast::NetworkAutoconfiguration do
       let(:interfaces) { Y2Network::InterfacesCollection.new([eth0]) }
       let(:proposal) { true }
 
-      after(:each) do
-        # some methods might have sideeffects - clen them :-/
-        Yast::NetworkInterfaces.Devices.reject! { |k, _| k == "br" }
-      end
-
       it "creates the virtulization proposal config" do
         expect(Yast::Lan).to receive(:ProposeVirtualized).and_call_original
         expect { instance.configure_virtuals }.to change { yast_config.connections.size }.from(0).to(2)

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -221,6 +221,11 @@ describe Yast::NetworkAutoconfiguration do
       let(:interfaces) { Y2Network::InterfacesCollection.new([eth0]) }
       let(:proposal) { true }
 
+      after(:each) do
+        # some methods might have sideeffects - clen them :-/
+        Yast::NetworkInterfaces.Devices.reject! { |k, _| k == "br" }
+      end
+
       it "creates the virtulization proposal config" do
         expect(Yast::Lan).to receive(:ProposeVirtualized).and_call_original
         expect { instance.configure_virtuals }.to change { yast_config.connections.size }.from(0).to(2)

--- a/test/y2network/hwinfo_test.rb
+++ b/test/y2network/hwinfo_test.rb
@@ -167,4 +167,34 @@ describe Y2Network::Hwinfo do
       end
     end
   end
+
+  describe "#mac" do
+    before do
+      allow(hwinfo).to receive(:permanent_mac).and_return(permanent_mac)
+    end
+
+    context "when the permanent MAC is defined" do
+      let(:permanent_mac) { "00:11:22:33:44:55" }
+
+      it "returns the permanent MAC" do
+        expect(hwinfo.mac).to eq(hwinfo.permanent_mac)
+      end
+    end
+
+    context "when the permanent MAC is empty" do
+      let(:permanent_mac) { "" }
+
+      it "returns the current MAC" do
+        expect(hwinfo.mac).to eq(hwinfo.used_mac)
+      end
+    end
+
+    context "when the permanent MAC is not defined" do
+      let(:permanent_mac) { nil }
+
+      it "returns the current MAC" do
+        expect(hwinfo.mac).to eq(hwinfo.used_mac)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Merge the `master` branch into `network-ng`. It includes an additional commit (894c2b47) to use `permanent_mac` whenever is available instead of `mac`.