### PR TITLE
network-ng: LanItems module clean up

### DIFF
--- a/src/clients/lan_auto.rb
+++ b/src/clients/lan_auto.rb
@@ -86,9 +86,9 @@ module Yast
       elsif @func == "Packages"
         @ret = Lan.AutoPackages
       elsif @func == "SetModified"
-        @ret = LanItems.SetModified
+        @ret = Lan.SetModified
       elsif @func == "GetModified"
-        @ret = LanItems.GetModified
+        @ret = Lan.Modified
       elsif @func == "Export"
         @settings2 = Lan.Export
         Builtins.y2debug("settings: %1", @settings2)

--- a/src/include/network/widgets.rb
+++ b/src/include/network/widgets.rb
@@ -116,7 +116,7 @@ module Yast
       end
 
       if NetworkService.Modified
-        LanItems.SetModified
+        Lan.SetModified
 
         if Stage.normal && NetworkService.is_network_manager
           Popup.AnyMessage(

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "y2network/interface"
+require "y2network/can_be_copied"
 require "forwardable"
 
 module Y2Network
@@ -41,6 +42,7 @@ module Y2Network
   class InterfacesCollection
     extend Forwardable
     include Yast::Logger
+    include CanBeCopied
 
     # @return [Array<Interface>] List of interfaces
     attr_reader :interfaces

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -100,6 +100,8 @@ module Yast
 
       @backend = nil
 
+      @modified = false
+
       # Y2Network::Config objects
       @configs = {}
     end
@@ -111,13 +113,18 @@ module Yast
     # Return a modification status
     # @return true if data was modified
     def Modified
-      return true if LanItems.GetModified
+      return true if @modified
       return true unless system_config == yast_config
       return true if NetworkConfig.Modified
       return true if NetworkService.Modified
       return true if Host.GetModified
 
       false
+    end
+
+    def SetModified
+      @modified = true
+      nil
     end
 
     # function for use from autoinstallation (Fate #301032)
@@ -396,7 +403,7 @@ module Yast
       if @ipv6 != status
         @ipv6 = status
         Popup.Warning(_("To apply this change, a reboot is needed."))
-        LanItems.SetModified
+        Lan.SetModified
       end
 
       nil

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -265,10 +265,6 @@ module Yast
         return true
       end
 
-      system_config = Y2Network::Config.from(:sysconfig)
-      add_config(:system, system_config)
-      add_config(:yast, system_config.copy)
-
       # Read dialog caption
       caption = _("Initializing Network Configuration")
 
@@ -334,7 +330,7 @@ module Yast
 
       return false if Abort()
       ProgressNextStage(_("Reading device configuration...")) if @gui
-      LanItems.Read
+      read_config
 
       Builtins.sleep(sl)
 
@@ -1041,16 +1037,21 @@ module Yast
       true
     end
 
+    # Refreshes YaST network configuration
+    #
+    # It does not modified the system configuration that was already read.
     def refresh_lan_items
-      LanItems.force_restart = true
-      # re-read configuration to see new items in UI
-      LanItems.Read
+      yast_config = Y2Network::Config.from(:sysconfig)
+      Yast::Lan.add_config(:yast, yast_config)
+    end
 
-      # note: LanItems.Read resets modification flag
-      # the Read is used as a trick how to update LanItems' internal
-      # cache according NetworkInterfaces' one. As NetworkInterfaces'
-      # cache was edited directly, LanItems is not aware of changes.
-      LanItems.SetModified
+    # Reads system configuration
+    #
+    # It clears already read configuration.
+    def read_config
+      system_config = Y2Network::Config.from(:sysconfig)
+      Yast::Lan.add_config(:system, system_config)
+      Yast::Lan.add_config(:yast, system_config.copy)
     end
 
     # Returns the routing summary

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -870,7 +870,7 @@ module Yast
         builder.configure_as_slave
         builder.save
         LanItems.move_routes(builder.name, bridge_builder.name)
-        refresh_lan_items
+        refresh_interfaces
       end
 
       nil
@@ -1044,12 +1044,16 @@ module Yast
       true
     end
 
-    # Refreshes YaST network configuration
+    # Refreshes YaST network interfaces
     #
-    # It does not modified the system configuration that was already read.
-    def refresh_lan_items
-      yast_config = Y2Network::Config.from(:sysconfig)
-      Yast::Lan.add_config(:yast, yast_config)
+    # It refreshes system configuration and update the list of interfaces
+    # for the current YaST configuration. The rest of the configuration
+    # is not modified.
+    #
+    # TODO: consider adding an API to Y2Network::Config to do partial refreshes.
+    def refresh_interfaces
+      system_config = Y2Network::Config.from(:sysconfig)
+      yast_config.interfaces = system_config.interfaces.copy
     end
 
     # Reads system configuration

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -33,20 +33,6 @@ require "y2network/boot_protocol"
 require "shellwords"
 
 module Yast
-  # Does way too many things.
-  #
-  # 1. Aggregates data about network interfaces, both configured
-  # and unconfigured, in {#Items}, which see.
-  #
-  # 2. Provides direct access to individual items of ifcfg files.
-  # For example BOOTPROTO and STARTMODE are accessible in
-  # {#bootproto} and {#startmode} (set via {#SetDeviceVars}
-  # via {#Select} or {#SetItem}). The reverse direction (putting
-  # the individual values back to an item) is {#Commit}.
-  #
-  # 3. ...
-  #
-
   # FIXME: well this class really is not nice
   class LanItemsClass < Module
     include Logger
@@ -268,30 +254,6 @@ module Yast
       nil
     end
 
-    def AddNew
-      @current = @Items.to_h.size
-      # Items[@current] is expected to always exist
-      @Items[@current] = {}
-      @operation = :add
-
-      nil
-    end
-
-    # return list of available modules for current device
-    # with default default_module (on first possition)
-
-    def GetItemModules(default_module)
-      mods = []
-      mods = Builtins.add(mods, default_module) if IsNotEmpty(default_module)
-      Builtins.foreach(
-        Ops.get_list(@Items, [@current, "hwinfo", "drivers"], [])
-      ) do |row|
-        tmp_mod = Ops.get_string(row, ["modules", 0, 0], "")
-        mods = Builtins.add(mods, tmp_mod) if !Builtins.contains(mods, tmp_mod)
-      end
-      deep_copy(mods)
-    end
-
     # Creates list of all known netcard items
     #
     # It means list of item ids of all netcards which are detected and/or
@@ -395,29 +357,6 @@ module Yast
       !item_id.nil?
     end
 
-    # search all known devices to find it's index in Items array
-    #
-    # @param [String] device matched with item[ "hwinfo", "dev_name"]
-    # @return index in Items or -1 if not found
-    def FindDeviceIndex(device)
-      ret = -1
-
-      Builtins.foreach(
-        Convert.convert(
-          @Items,
-          from: "map <integer, any>",
-          to:   "map <integer, map <string, any>>"
-        )
-      ) do |i, a|
-        if Ops.get_string(a, ["hwinfo", "dev_name"], "") == device
-          ret = i
-          raise Break
-        end
-      end
-
-      ret
-    end
-
     # It finds a new style device name for device name in old fashioned format
     #
     # It goes through currently present devices and tries to mach it to given
@@ -496,39 +435,6 @@ module Yast
       SetModified() if !settings.empty?
 
       true
-    end
-
-    def GetDescr
-      descr = []
-      Builtins.foreach(
-        Convert.convert(
-          @Items,
-          from: "map <integer, any>",
-          to:   "map <integer, map <string, any>>"
-        )
-      ) do |key, value|
-        if Builtins.haskey(value, "table_descr") &&
-            Ops.greater_than(
-              Builtins.size(Ops.get_map(@Items, [key, "table_descr"], {})),
-              1
-            )
-          descr = Builtins.add(
-            descr,
-            "id"          => key,
-            "rich_descr"  => Ops.get_string(
-              @Items,
-              [key, "table_descr", "rich_descr"],
-              ""
-            ),
-            "table_descr" => Ops.get_list(
-              @Items,
-              [key, "table_descr", "table_descr"],
-              []
-            )
-          )
-        end
-      end
-      deep_copy(descr)
     end
 
     def needFirmwareCurrentItem
@@ -709,98 +615,6 @@ module Yast
       Y2Network::BootProtocol.from_name(devmap["BOOTPROTO"]).dhcp?
     end
 
-    def GetItemDescription
-      Ops.get_string(@Items, [@current, "table_descr", "rich_descr"], "")
-    end
-
-    # Select the hardware component
-    # @param hardware the component
-    def SelectHWMap(hardware)
-      hardware = deep_copy(hardware)
-      sel = SelectHardwareMap(hardware)
-
-      # common stuff
-      @description = Ops.get_string(sel, "name", "")
-      @type = Ops.get_string(sel, "type", "eth")
-      @hotplug = Ops.get_string(sel, "hotplug", "")
-
-      @Requires = Ops.get_list(sel, "requires", [])
-      # #44977: Requires now contain the appropriate kernel packages
-      # but they are handled differently due to multiple kernel flavors
-      # (see Package::InstallKernel)
-      # Leave only those not starting with "kernel".
-      @Requires = Builtins.filter(@Requires) do |r|
-        Builtins.search(r, "kernel") != 0
-      end
-      Builtins.y2milestone("requires=%1", @Requires)
-
-      # FIXME: devname
-      @hotplug = ""
-
-      Builtins.y2milestone("hw=%1", hardware)
-
-      @hw = deep_copy(hardware)
-      if Arch.s390 && @operation == :add
-        Builtins.y2internal("Propose chan_ids values for %1", @hw)
-        devid = 0
-        devstr = ""
-        s390chanid = "[0-9]+\\.[0-9]+\\."
-        if Builtins.regexpmatch(Ops.get_string(@hw, "busid", ""), s390chanid)
-          devid = Builtins.tointeger(
-            Ops.add(
-              "0x",
-              Builtins.regexpsub(
-                Ops.get_string(@hw, "busid", ""),
-                Ops.add(s390chanid, "(.*)"),
-                "\\1"
-              )
-            )
-          )
-          devstr = Builtins.regexpsub(
-            Ops.get_string(@hw, "busid", ""),
-            Ops.add(Ops.add("(", s390chanid), ").*"),
-            "\\1"
-          )
-        end
-
-        Builtins.y2milestone("devid=%1(%2)", devid, devstr)
-        devid = 0 if devid.nil?
-        devid0 = String.PadZeros(
-          Builtins.regexpsub(Builtins.tohexstring(devid), "0x(.*)", "\\1"),
-          4
-        )
-        devid1 = String.PadZeros(
-          Builtins.regexpsub(
-            Builtins.tohexstring(Ops.add(devid, 1)),
-            "0x(.*)",
-            "\\1"
-          ),
-          4
-        )
-        devid2 = String.PadZeros(
-          Builtins.regexpsub(
-            Builtins.tohexstring(Ops.add(devid, 2)),
-            "0x(.*)",
-            "\\1"
-          ),
-          4
-        )
-        @qeth_chanids = if DriverType(@type) == "ctc" || DriverType(@type) == "lcs"
-          Builtins.sformat("%1%2 %1%3", devstr, devid0, devid1)
-        else
-          Builtins.sformat(
-            "%1%2 %1%3 %1%4",
-            devstr,
-            devid0,
-            devid1,
-            devid2
-          )
-        end
-      end
-
-      nil
-    end
-
     #-------------------
     # PRIVATE FUNCTIONS
 
@@ -849,44 +663,6 @@ module Yast
       true
     end
 
-    # Deletes item and its configuration
-    #
-    # Item for deletion is searched using device name
-    def delete_dev(name)
-      FindAndSelect(name)
-      DeleteItem()
-    end
-
-    # Deletes the {#current} item and its configuration
-    def DeleteItem
-      return if @current < 0
-      return if @Items.nil? || @Items.empty?
-
-      log.info("DeleteItem: #{@Items[@current]}")
-
-      devmap = GetCurrentMap()
-      drop_hosts(devmap["IPADDR"]) if devmap
-      # We have to remove it from routing before deleting the item
-      remove_current_device_from_routing
-
-      current_item = @Items[@current]
-
-      if current_item["hwinfo"].nil? || current_item["hwinfo"].empty?
-        # size is always > 0 here and items are numbered 0, 1, ..., size -1
-        delete_index = @Items.size - 1
-
-        @Items[@current] = @Items[delete_index] if delete_index != @current
-        @Items.delete(delete_index)
-
-        # item was deleted, so original @current is invalid
-        @current = -1
-      end
-
-      SetModified()
-
-      nil
-    end
-
     def SetItem(*)
       @hotplug = ""
       Builtins.y2debug("type=%1", @type)
@@ -896,35 +672,6 @@ module Yast
       Builtins.y2debug("type=%1", @type)
 
       nil
-    end
-
-    def setDriver(driver)
-      Builtins.y2milestone(
-        "driver %1, %2",
-        driver,
-        Ops.get_string(getCurrentItem, ["hwinfo", "module"], "")
-      )
-      if Ops.get_string(getCurrentItem, ["hwinfo", "module"], "") == driver &&
-          IsEmpty(Ops.get_string(getCurrentItem, ["udev", "driver"], ""))
-        return
-      end
-      Ops.set(@Items, [@current, "udev", "driver"], driver)
-
-      nil
-    end
-
-    def enableCurrentEditButton
-      return true if needFirmwareCurrentItem
-      return true if Arch.s390
-      if IsEmpty(Ops.get_string(getCurrentItem, ["hwinfo", "dev_name"], "")) &&
-          Ops.greater_than(
-            Builtins.size(Ops.get_map(getCurrentItem, "hwinfo", {})),
-            0
-          )
-        return false
-      else
-        return true
-      end
     end
 
     # Creates eth emulation for s390 devices
@@ -1394,26 +1141,14 @@ module Yast
     publish function: :GetDeviceMap, type: "map <string, any> (integer)"
     publish function: :GetModified, type: "boolean ()"
     publish function: :SetModified, type: "void ()"
-    publish function: :AddNew, type: "void ()"
-    publish function: :GetItemModules, type: "list <string> (string)"
-    publish function: :GetNetcardNames, type: "list <string> ( list <integer>)"
     publish function: :FindAndSelect, type: "boolean (string)"
-    publish function: :FindDeviceIndex, type: "integer (string)"
     publish function: :ReadHw, type: "void ()"
     publish function: :Read, type: "void ()"
     publish function: :needFirmwareCurrentItem, type: "boolean ()"
-    publish function: :GetFirmwareForCurrentItem, type: "string ()"
-    publish function: :GetBondSlaves, type: "list <string> (string)"
     publish function: :isCurrentHotplug, type: "boolean ()"
     publish function: :isCurrentDHCP, type: "boolean ()"
-    publish function: :GetItemDescription, type: "string ()"
-    publish function: :SelectHWMap, type: "void (map)"
-    publish function: :SetDeviceVars, type: "void (map, map)"
-    publish function: :Select, type: "boolean (string)"
     publish function: :Commit, type: "boolean ()"
     publish function: :Rollback, type: "boolean ()"
-    publish function: :setDriver, type: "void (string)"
-    publish function: :enableCurrentEditButton, type: "boolean ()"
     publish function: :createS390Device, type: "boolean ()"
     publish function: :find_dhcp_ifaces, type: "list <string> ()"
   end

--- a/src/modules/LanItems.rb
+++ b/src/modules/LanItems.rb
@@ -457,22 +457,6 @@ module Yast
       nil
     end
 
-    # initializates @Items
-    #
-    # It does:
-    # (1) read hardware present on the system
-    # (2) read known configurations (e.g. ifcfg-eth0)
-    # (3) joins together. Join is done via device name (e.g. eth0) as key.
-    # It is full outer join in -> you can have hwinfo part with no coresponding
-    # netconfig part (or vice versa) in @Items when the method is done.
-    def Read
-      reset_cache
-
-      system_config = Y2Network::Config.from(:sysconfig)
-      Yast::Lan.add_config(:system, system_config)
-      Yast::Lan.add_config(:yast, system_config.copy)
-    end
-
     # Clears internal cache of the module to default values
     #
     # TODO: LanItems consists of several sets of internal variables.

--- a/test/bridge_test.rb
+++ b/test/bridge_test.rb
@@ -27,6 +27,7 @@ require "y2network/config"
 require "y2network/interface"
 require "y2network/type_detector"
 
+Yast.import "Lan"
 Yast.import "LanItems"
 
 describe Yast::LanItems do
@@ -119,7 +120,6 @@ describe Yast::LanItems do
       .to receive(:type_of)
       .with(/eth[0-9]/)
       .and_return(Y2Network::InterfaceType::ETHERNET)
-    Yast::LanItems.Read
   end
 
   describe "#GetBridgeableInterfaces" do

--- a/test/lan_auto_test.rb
+++ b/test/lan_auto_test.rb
@@ -34,13 +34,13 @@ describe Yast::LanAutoClient do
     context "when func is GetModified" do
       let(:func) { "GetModified" }
 
-      it "returns true if LanItems.GetModified is true" do
-        expect(Yast::LanItems).to receive(:GetModified).and_return(true)
+      it "returns true if Lan.GetModified is true" do
+        expect(Yast::Lan).to receive(:Modified).and_return(true)
         expect(subject.main).to eq(true)
       end
 
-      it "returns false if LanItems.GetModified is false" do
-        expect(Yast::LanItems).to receive(:GetModified).and_return(false)
+      it "returns false if Lan.GetModified is false" do
+        expect(Yast::Lan).to receive(:Modified).and_return(false)
         expect(subject.main).to eq(false)
       end
     end

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -115,32 +115,6 @@ describe "LanItemsClass#getNetworkInterfaces" do
   end
 end
 
-describe "LanItemsClass#s390_correct_lladdr" do
-  Yast.import "Arch"
-
-  before(:each) do
-    allow(Yast::Arch)
-      .to receive(:s390)
-      .and_return(true)
-  end
-
-  it "fails if given lladdr is nil" do
-    expect(Yast::LanItems.send(:s390_correct_lladdr, nil)).to be false
-  end
-
-  it "fails if given lladdr is empty" do
-    expect(Yast::LanItems.send(:s390_correct_lladdr, "")).to be false
-  end
-
-  it "fails if given lladdr contains zeroes only" do
-    expect(Yast::LanItems.send(:s390_correct_lladdr, "00:00:00:00:00:00")).to be false
-  end
-
-  it "succeeds if given lladdr contains valid MAC" do
-    expect(Yast::LanItems.send(:s390_correct_lladdr, "0a:00:27:00:00:00")).to be true
-  end
-end
-
 describe "LanItems#find_type_ifaces" do
   let(:mocked_items) do
     {
@@ -313,39 +287,6 @@ describe "DHCLIENT_SET_HOSTNAME helpers" do
     end
   end
 
-  describe "LanItems#clear_set_hostname" do
-    let(:dhcp_yes_maps) do
-      {
-        "eth0" => { "DHCLIENT_SET_HOSTNAME" => "yes" }
-      }.freeze
-    end
-    let(:dhcp_no_maps) do
-      {
-        "eth1" => { "DHCLIENT_SET_HOSTNAME" => "no" }
-      }.freeze
-    end
-    let(:no_dhclient_maps) do
-      { "eth6" => { "BOOT" => "dhcp" } }.freeze
-    end
-
-    it "clears all DHCLIENT_SET_HOSTNAME options" do
-      dhclient_maps = dhcp_yes_maps.merge(dhcp_no_maps)
-      mock_items(dhclient_maps.merge(no_dhclient_maps))
-
-      expect(Yast::LanItems)
-        .to receive(:SetDeviceMap)
-        .with(kind_of(Integer), "DHCLIENT_SET_HOSTNAME" => nil)
-        .twice
-      expect(Yast::LanItems)
-        .to receive(:SetModified)
-        .at_least(:once)
-
-      ret = Yast::LanItems.clear_set_hostname
-
-      expect(ret).to eql dhclient_maps.keys
-    end
-  end
-
   describe "LanItems#valid_dhcp_cfg?" do
     def mock_dhcp_setup(ifaces, global)
       allow(Yast::LanItems)
@@ -442,78 +383,6 @@ describe "LanItems renaming methods" do
         Yast::LanItems.add_device_to_routing
         names = yast_config.interfaces.map(&:name)
         expect(names).to eq(["eth0", "wlan0"])
-      end
-    end
-  end
-
-  describe "LanItems.rename_current_device_in_routing" do
-    let(:eth0) { Y2Network::Interface.new("eth0") }
-    let(:wlan0) { Y2Network::Interface.new("wlan0") }
-    let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, wlan0]) }
-    let(:yast_config) do
-      instance_double(Y2Network::Config, interfaces: interfaces, routing: double("routing"))
-    end
-
-    before do
-      allow(Y2Network::Config).to receive(:find).with(:yast).and_return(yast_config)
-      allow(Yast::LanItems).to receive(:current_name).and_return("wlan1")
-    end
-
-    it "updates the list of Routing devices with current device names" do
-      Yast::LanItems.rename_current_device_in_routing("wlan0")
-      new_names = yast_config.interfaces.map(&:name)
-      expect(new_names).to eq(["eth0", "wlan1"])
-    end
-  end
-
-  describe "LanItems.remove_current_device_from_routing" do
-    let(:eth0) { Y2Network::Interface.new("eth0") }
-    let(:wlan0) { Y2Network::Interface.new("wlan0") }
-    let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, wlan0]) }
-
-    let(:yast_config) do
-      instance_double(Y2Network::Config, interfaces: interfaces, routing: double("routing"))
-    end
-
-    before do
-      allow(Y2Network::Config).to receive(:find).with(:yast).and_return(yast_config)
-      allow(Yast::LanItems).to receive(:current_name).and_return("wlan0")
-    end
-
-    it "removes the device" do
-      Yast::LanItems.remove_current_device_from_routing
-      names = yast_config.interfaces.map(&:name)
-      expect(names).to eq(["eth0"])
-    end
-  end
-
-  describe "LanItems.update_routing_devices?" do
-    let(:eth0) { Y2Network::Interface.new("eth0") }
-    let(:wlan0) { Y2Network::Interface.new("wlan0") }
-    let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, wlan0]) }
-
-    let(:yast_config) do
-      instance_double(Y2Network::Config, interfaces: interfaces, routing: double("routing"))
-    end
-
-    before do
-      allow(Y2Network::Config).to receive(:find).with(:yast).and_return(yast_config)
-      allow(Yast::LanItems).to receive(:current_name).and_return(current_name)
-    end
-
-    context "when there are no changes in the device names" do
-      let(:current_name) { "eth0" }
-
-      it "returns false" do
-        expect(Yast::LanItems.update_routing_devices?).to eql(false)
-      end
-    end
-
-    context "when some interface have been renaming and Routing device names differs" do
-      let(:current_name) { "eth1" }
-
-      it "returns true" do
-        expect(Yast::LanItems.update_routing_devices?).to eql(true)
       end
     end
   end

--- a/test/lan_items_helpers_test.rb
+++ b/test/lan_items_helpers_test.rb
@@ -50,21 +50,6 @@ describe "LanItemsClass#IsItemConfigured" do
   end
 end
 
-describe "LanItemsClass#delete_dev" do
-  before(:each) do
-    Yast::LanItems.Items = {
-      0 => {
-        "ifcfg" => "enp0s3"
-      }
-    }
-  end
-
-  it "removes device config when found" do
-    Yast::LanItems.delete_dev("enp0s3")
-    expect(Yast::LanItems.Items).to be_empty
-  end
-end
-
 describe "LanItemsClass#getNetworkInterfaces" do
   NETCONFIG_ITEMS = {
     "eth"  => {

--- a/test/lan_test.rb
+++ b/test/lan_test.rb
@@ -30,12 +30,8 @@ Yast.import "Lan"
 
 describe "LanClass" do
   subject { Yast::Lan }
-  let(:system_config) { instance_double(Y2Network::Config, "System") }
 
-  before do
-    Yast::Lan.clear_configs
-    allow(Yast::Lan).to receive(:system_config).and_call_original
-  end
+  let(:system_config) { Y2Network::Config.new(interfaces: [], source: :sysconfig) }
 
   describe "#Packages" do
     before(:each) do
@@ -164,11 +160,11 @@ describe "LanClass" do
 
     it "flushes internal state of LanItems correctly when asked for reset" do
       expect(Yast::Lan.Import(ay_profile)).to be true
-      expect(Yast::LanItems.GetModified).to be true
+      expect(Yast::Lan.GetModified).to be true
       expect(Yast::LanItems.Items).not_to be_empty
 
       expect(Yast::Lan.Import({})).to be true
-      expect(Yast::LanItems.GetModified).to be false
+      expect(Yast::Lan.GetModified).to be false
       expect(Yast::LanItems.Items).to be_empty
     end
 
@@ -180,56 +176,68 @@ describe "LanClass" do
   end
 
   describe "#Modified" do
-    def reset_modification_statuses
-      allow(Yast::LanItems).to receive(:GetModified).and_return false
-      allow(Yast::DNS).to receive(:modified).and_return false
+    let(:yast_config) { system_config.copy }
+
+    before do
+      allow(Yast::NetworkConfig).to receive(:Modified).and_return false
+      allow(Yast::NetworkService).to receive(:Modified).and_return false
+      allow(Yast::Host).to receive(:GetModified).and_return false
+
+      Yast::Lan.add_config(:system, system_config)
+      Yast::Lan.add_config(:yast, yast_config)
+    end
+
+    context "when the configuration was not changed" do
+      it "returns false" do
+        expect(Yast::Lan.Modified).to eq(false)
+      end
+    end
+
+    context "when the configuration was changed" do
+      before do
+        yast_config.routing.forward_ipv4 = !system_config.routing.forward_ipv4
+      end
+
+      it "returns true" do
+        expect(Yast::Lan.Modified).to eq(true)
+      end
+    end
+
+    context "when the NetworkConfig module was modified" do
+      before { allow(Yast::NetworkConfig).to receive(:Modified).and_return(true) }
+
+      it "returns true" do
+        expect(Yast::Lan.Modified).to eq(true)
+      end
+    end
+
+    context "when the NetworkService module was modified" do
+      before { allow(Yast::NetworkService).to receive(:Modified).and_return(true) }
+
+      it "returns true" do
+        expect(Yast::Lan.Modified).to eq(true)
+      end
+    end
+
+    context "when the Host module was modified" do
+      before { allow(Yast::Host).to receive(:GetModified).and_return(true) }
+
+      it "returns true" do
+        expect(Yast::Lan.Modified).to eq(true)
+      end
+    end
+  end
+
+  describe "#SetModified" do
+    before do
       allow(Yast::NetworkConfig).to receive(:Modified).and_return false
       allow(Yast::NetworkService).to receive(:Modified).and_return false
       allow(Yast::Host).to receive(:GetModified).and_return false
     end
 
-    def expect_modification_succeedes(modname, method)
-      reset_modification_statuses
-
-      allow(modname)
-        .to receive(method)
-        .and_return true
-
-      expect(modname.send(method)).to be true
-      expect(Yast::Lan.Modified).to be true
-    end
-
-    it "returns true when LanItems module was modified" do
-      expect_modification_succeedes(Yast::LanItems, :GetModified)
-    end
-
-    let(:config) do
-      Y2Network::Config.new(interfaces: [], routing: routing, source: :sysconfig)
-    end
-    let(:routing) { Y2Network::Routing.new(tables: []) }
-
-    it "returns true when Routing module was modified" do
-      Yast::Lan.add_config(:system, config)
-      yast_config = config.copy
-      yast_config.routing.forward_ipv4 = !config.routing.forward_ipv4
-      Yast::Lan.add_config(:yast, yast_config)
-
-      reset_modification_statuses
-      expect(Yast::Lan.Modified).to eq(true)
-      Yast::Lan.clear_configs
-    end
-
-    it "returns true when NetworkConfig module was modified" do
-      expect_modification_succeedes(Yast::NetworkConfig, :Modified)
-    end
-
-    it "returns true when NetworkService module was modified" do
-      expect_modification_succeedes(Yast::NetworkService, :Modified)
-    end
-
-    it "returns false when no module was modified" do
-      reset_modification_statuses
-      expect(Yast::Lan.Modified).to be false
+    it "changes Modified to true" do
+      subject.main
+      expect { subject.SetModified }.to change { subject.Modified }.from(false).to(true)
     end
   end
 
@@ -571,9 +579,8 @@ describe "LanClass" do
     end
 
     it "cleans the configurations list" do
-      expect { subject.clear_configs }
-        .to change { subject.find_config(:system) }
-        .from(system_config).to(nil)
+      subject.clear_configs
+      expect(subject.find_config(:system)).to be_nil
     end
   end
 

--- a/test/netcard_test.rb
+++ b/test/netcard_test.rb
@@ -91,27 +91,6 @@ require "yast"
 
 Yast.import "LanItems"
 
-describe "When querying netcard device name" do
-  before(:each) do
-    @lan_items = Yast::LanItems
-    @lan_items.main
-
-    # mocking only neccessary parts of Yast::LanItems so we need not to call
-    # and mock inputs for Yast::LanItems.Read here
-    @lan_items.Items = Yast.deep_copy(MOCKED_ITEMS)
-  end
-
-  it "returns empty list when querying device name with nil or empty input" do
-    [nil, []].each { |i| expect(@lan_items.GetDeviceNames(i)).to be_empty }
-  end
-
-  it "can return list of device names available in the system" do
-    expected_names = ["bond0", "br0", "eth1", "eth11", "enp0s3", "tap0", "tun0"].sort
-
-    expect(@lan_items.GetNetcardNames.sort).to eq expected_names
-  end
-end
-
 class NetworkComplexIncludeClass < Yast::Module
   def initialize
     Yast.include self, "network/complex.rb"
@@ -154,41 +133,6 @@ describe "NetworkComplexInclude#HardwareName" do
 
   it "returns empty string when querying unknown id" do
     expect(subject.HardwareName(@hwinfo, "unknown")).to be_empty
-  end
-end
-
-describe "LanItemsClass#DeleteItem" do
-  before(:each) do
-    @lan_items = Yast::LanItems
-    @lan_items.main
-    @lan_items.Items = Yast.deep_copy(MOCKED_ITEMS)
-  end
-
-  it "removes an existing item" do
-    before_items = nil
-
-    while before_items != @lan_items.Items && !@lan_items.Items.empty?
-      @lan_items.current = 0
-
-      item_name = @lan_items.GetCurrentName
-      before_items = @lan_items.Items
-
-      @lan_items.DeleteItem
-
-      expect(@lan_items.FindAndSelect(item_name)).to be false
-    end
-  end
-
-  xit "removes only the configuration if the item has hwinfo" do
-    before_size = @lan_items.Items.size
-    item_name = "enp0s3"
-
-    expect(@lan_items.FindAndSelect(item_name)).to be true
-
-    @lan_items.DeleteItem
-
-    expect(@lan_items.FindAndSelect(item_name)).to be false
-    expect(@lan_items.Items.size).to eql before_size
   end
 end
 

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -201,7 +201,6 @@ describe Yast::NetworkAutoconfiguration do
       allow(Y2Network::Config).to receive(:find).with(:yast).and_return(yast_config)
       allow(Y2Network::Config).to receive(:find).with(:system).and_return(system_config)
       allow(instance).to receive(:virtual_proposal_required?).and_return(proposal)
-      allow(Yast::LanItems).to receive(:Read)
       allow(yast_config).to receive(:write)
       allow(Yast::Lan).to receive(:connected_and_bridgeable?).and_return(true)
       allow(Yast::PackageSystem).to receive(:Installed).and_return(true)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,7 +66,6 @@ RSpec.configure do |c|
     Yast::Lan.clear_configs
     allow(Yast::NetworkInterfaces).to receive(:Write)
     allow(Y2Network::Hwinfo).to receive(:hwinfo_from_hardware)
-    allow(Yast::Lan).to receive(:system_config).and_return(Y2Network::Config.new(source: :testing))
     Y2Storage::StorageManager.create_test_instance
   end
 end


### PR DESCRIPTION
An attempt to drop unused stuff from `LanItems` module.