### PR TITLE
Do not offer empty name devices as VLAN etherdevice candidates (bsc#1136934)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 24 09:58:00 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- bsc#1136934
+  - Do not offer empty name devices as VLAN etherdevice candidates.
+- 4.1.53
+
+-------------------------------------------------------------------
 Tue Sep 10 07:40:04 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1149234


### PR DESCRIPTION
## Problem

Not activate S390 devices are offered as the raw device when configuring a VLAN. The problem is that them do not have an associated interface, that is, the interface name is empty. When there are many of them, the selection list could hide some valid interfaces.

- https://bugzilla.suse.com/show_bug.cgi?id=1136934

## Solution

Filter out interfaces with an empty name from the etherdevice list.
