### PR TITLE
AY: Fix issue reading interface name

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Oct  1 14:24:42 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- AY: Fix interface name check for using the fallback when not set.
+
+-------------------------------------------------------------------
 Tue Oct  1 09:24:57 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - boo#1152627

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -69,8 +69,15 @@ module Y2Network
 
     private
 
+      def name_from_section(interface_section)
+        # device is just fallback
+        return interface_section.device if interface_section.name.to_s.empty?
+
+        interface_section.name
+      end
+
       def create_config(interface_section)
-        name = interface_section.name || interface_section.device
+        name = name_from_section(interface_section)
         type = TypeDetector.type_of(name, interface_section)
         # TODO: TUN/TAP interface missing for autoyast?
         ConnectionConfig.const_get(type.class_name).new
@@ -78,7 +85,7 @@ module Y2Network
 
       def load_generic(config, interface_section)
         config.bootproto = BootProtocol.from_name(interface_section.bootproto)
-        config.name = interface_section.name || interface_section.device # device is just fallback
+        config.name = name_from_section(interface_section)
         config.interface = config.name # in autoyast name and interface is same
         if config.bootproto == BootProtocol::STATIC
           # TODO: report if ipaddr missing for static config

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -38,8 +38,7 @@ describe Y2Network::Autoinst::InterfacesReader do
         "name"      => "",
         "ipaddr"    => "192.168.10.10",
         "netmask"   => "255.255.255.0",
-        "prefixlen" => "24"
-      },
+        "prefixlen" => "24" },
       {
         "bootproto" => "dhcp",
         "name"      => "eth0",

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -32,6 +32,14 @@ describe Y2Network::Autoinst::InterfacesReader do
 
   let(:interfaces_profile) do
     [
+      { "startmode" => "auto",
+        "bootproto" => "static",
+        "device"    => "eth1",
+        "name"      => "",
+        "ipaddr"    => "192.168.10.10",
+        "netmask"   => "255.255.255.0",
+        "prefixlen" => "24"
+      },
       {
         "bootproto" => "dhcp",
         "name"      => "eth0",
@@ -55,14 +63,17 @@ describe Y2Network::Autoinst::InterfacesReader do
   describe "#config" do
     it "builds a new Y2Network::ConnectionConfigsCollection" do
       expect(subject.config).to be_a Y2Network::ConnectionConfigsCollection
-      expect(subject.config.size).to eq(1)
+      expect(subject.config.size).to eq(2)
     end
 
     it "assign properly all values in profile" do
-      config = subject.config.by_name("eth0")
-      expect(config.startmode).to eq Y2Network::Startmode.create("auto")
-      expect(config.bootproto).to eq Y2Network::BootProtocol.from_name("dhcp")
-      expect(config.ip_aliases.size).to eq 2
+      eth0_config = subject.config.by_name("eth0")
+      expect(eth0_config.startmode).to eq Y2Network::Startmode.create("auto")
+      expect(eth0_config.bootproto).to eq Y2Network::BootProtocol.from_name("dhcp")
+      expect(eth0_config.ip_aliases.size).to eq 2
+      eth1_config = subject.config.by_name("eth1")
+      expect(eth1_config.name).to eq("eth1")
+      expect(eth1_config.ip.address.to_s).to eq("192.168.10.10/24")
     end
   end
 end


### PR DESCRIPTION
The 'InterfaceSection' is initialized with empty string attributes, which means the device name fallback will never happen. Fixed checking if it is an empty string instead.

The increase of version number will be provided by #985 