### PR TITLE
AY: Export ip address and prefixlen correctly

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct  2 22:02:30 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- bsc#1152840
+  - Fix interface ipaddr and prefixlen in the cloned profile.
+- 4.2.17
+
+-------------------------------------------------------------------
 Wed Oct  2 09:05:14 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapt network CLI to new data model with improved error reporting

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.16
+Version:        4.2.17
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -281,8 +281,8 @@ module Y2Network
         @bootproto = config.bootproto.name
         @name = config.name
         if config.bootproto == BootProtocol::STATIC && config.ip
-          @ipaddr = config.ip.address.to_s
-          @prefixlen = config.ip.address.address.to_s
+          @ipaddr = config.ip.address.address.to_s
+          @prefixlen = config.ip.address.prefix.to_s
           @remote_ipaddr = config.ip.remote_address.address.to_s if config.ip.remote_address
           @broadcast = config.ip.broadcast.address.to_s if config.ip.broadcast
         end

--- a/test/y2network/autoinst_profile/interface_section_test.rb
+++ b/test/y2network/autoinst_profile/interface_section_test.rb
@@ -33,7 +33,7 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
         c.firewall_zone = "DMZ"
         c.ethtool_options = "test=1"
         c.interface = "eth0"
-        c.ip = Y2Network::ConnectionConfig::IPConfig.new(Y2Network::IPAddress.new("10.100.0.1/24"))
+        c.ip = Y2Network::ConnectionConfig::IPConfig.new(Y2Network::IPAddress.from_string("10.100.0.1/24"))
         c.ip_aliases = [
           Y2Network::ConnectionConfig::IPConfig.new(Y2Network::IPAddress.from_string("10.100.0.1/24"), label: "test"),
           Y2Network::ConnectionConfig::IPConfig.new(Y2Network::IPAddress.from_string("10.100.0.2/24"), label: "test1")
@@ -44,6 +44,8 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
     it "initializes values properly" do
       section = described_class.new_from_network(config)
       expect(section.bootproto).to eq("static")
+      expect(section.ipaddr).to eq("10.100.0.1")
+      expect(section.prefixlen).to eq("24")
       expect(section.aliases).to eq(
         "alias0" => { "IPADDR" => "10.100.0.1", "PREFIXLEN" => "24", "LABEL" => "test" },
         "alias1" => { "IPADDR" => "10.100.0.2", "PREFIXLEN" => "24", "LABEL" => "test1" }


### PR DESCRIPTION
Issue: The current ifcfg configuration is exported as:

```xml
      <interface>
        <aliases/>
        <bootproto>static</bootproto>
        <ipaddr>192.168.10.10/24</ipaddr>
        <name>eth1</name>
        <prefixlen>192.168.10.10</prefixlen>
        <startmode>auto</startmode>
      </interface>
```