### PR TITLE
 Write sysctl settings to /etc/sysctl.d

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct  3 16:34:41 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Place sysctl settings in /etc/sysctl.d/ (jsc#SLE-9077).
+- 4.2.19
+
+-------------------------------------------------------------------
 Thu Oct  3 14:27:53 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix blink positioning in UI (bsc#1119407)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.18
+Version:        4.2.19
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only
@@ -33,8 +33,8 @@ BuildRequires:  yast2-devtools >= 3.1.15
 #for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  yast2-storage-ng
-# Y2Firewall interface zone mapping methods
-BuildRequires:  yast2 >= 4.1.53
+# Yast2::CFA::Sysctl
+BuildRequires:  yast2 >= 4.2.25
 BuildRequires:  yast2-packager >= 4.0.18
 # Product control need xml agent
 BuildRequires:  yast2-xml
@@ -48,7 +48,8 @@ PreReq:         /bin/rm
 Requires:       sysconfig >= 0.80.0
 Requires:       yast2-proxy
 Requires:       yast2-storage-ng
-Requires:       yast2 >= 4.1.53
+# Yast2::CFA::Sysctl
+Requires:       yast2 >= 4.2.25
 # Packages::vnc_packages
 Requires:       yast2-packager >= 4.0.18
 Requires:       rubygem(%rb_default_ruby_abi:cfa) >= 0.6.4

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -33,7 +33,7 @@ BuildRequires:  yast2-devtools >= 3.1.15
 #for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  yast2-storage-ng
-# Yast2::CFA::Sysctl
+# CFA::Sysctl
 BuildRequires:  yast2 >= 4.2.25
 BuildRequires:  yast2-packager >= 4.0.18
 # Product control need xml agent
@@ -48,7 +48,7 @@ PreReq:         /bin/rm
 Requires:       sysconfig >= 0.80.0
 Requires:       yast2-proxy
 Requires:       yast2-storage-ng
-# Yast2::CFA::Sysctl
+# CFA::Sysctl
 Requires:       yast2 >= 4.2.25
 # Packages::vnc_packages
 Requires:       yast2-packager >= 4.0.18

--- a/src/lib/y2network/sysconfig/config_reader.rb
+++ b/src/lib/y2network/sysconfig/config_reader.rb
@@ -17,7 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 require "yast"
-require "yast2/cfa/sysctl"
+require "cfa/sysctl"
 require "y2network/config"
 require "y2network/interface"
 require "y2network/routing"
@@ -47,7 +47,9 @@ module Y2Network
 
         routing_tables = find_routing_tables(interfaces_reader.interfaces)
         routing = Routing.new(
-          tables: routing_tables, forward_ipv4: forward_ipv4?, forward_ipv6: forward_ipv6?
+          tables:       routing_tables,
+          forward_ipv4: sysctl_file.forward_ipv4?,
+          forward_ipv6: sysctl_file.forward_ipv6?
         )
 
         result = Config.new(
@@ -103,20 +105,6 @@ module Y2Network
         file.routes
       end
 
-      # Reads IPv4 forwarding status
-      #
-      # return [Boolean] true when IPv4 forwarding is allowed
-      def forward_ipv4?
-        sysctl_file.forward_ipv4 == "1"
-      end
-
-      # Reads IPv6 forwarding status
-      #
-      # return [Boolean] true when IPv6 forwarding is allowed
-      def forward_ipv6?
-        sysctl_file.forward_ipv6 == "1"
-      end
-
       # Links routes to interfaces objects
       #
       # {Y2Network::Sysconfig::RoutesFile} knows nothing about the already detected interfaces, so it
@@ -142,10 +130,10 @@ module Y2Network
 
       # Returns the Sysctl file class
       #
-      # @return [Yast2::CFA::Sysctl]
+      # @return [CFA::Sysctl]
       def sysctl_file
         return @sysctl_file if @sysctl_file
-        @sysctl_file = Yast2::CFA::Sysctl.new
+        @sysctl_file = CFA::Sysctl.new
         @sysctl_file.load
         @sysctl_file
       end

--- a/src/lib/y2network/sysconfig/config_reader.rb
+++ b/src/lib/y2network/sysconfig/config_reader.rb
@@ -17,6 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 require "yast"
+require "yast2/cfa/sysctl"
 require "y2network/config"
 require "y2network/interface"
 require "y2network/routing"
@@ -106,14 +107,14 @@ module Y2Network
       #
       # return [Boolean] true when IPv4 forwarding is allowed
       def forward_ipv4?
-        Yast::SCR.Read(Yast::Path.new(SYSCTL_IPV4_PATH)) == "1"
+        sysctl_file.forward_ipv4 == "1"
       end
 
       # Reads IPv6 forwarding status
       #
       # return [Boolean] true when IPv6 forwarding is allowed
       def forward_ipv6?
-        Yast::SCR.Read(Yast::Path.new(SYSCTL_IPV6_PATH)) == "1"
+        sysctl_file.forward_ipv6 == "1"
       end
 
       # Links routes to interfaces objects
@@ -137,6 +138,16 @@ module Y2Network
       # @return [Y2Network::DNS]
       def dns
         Y2Network::Sysconfig::DNSReader.new.config
+      end
+
+      # Returns the Sysctl file class
+      #
+      # @return [Yast2::CFA::Sysctl]
+      def sysctl_file
+        return @sysctl_file if @sysctl_file
+        @sysctl_file = Yast2::CFA::Sysctl.new
+        @sysctl_file.load
+        @sysctl_file
       end
     end
   end

--- a/src/lib/y2network/sysconfig/config_writer.rb
+++ b/src/lib/y2network/sysconfig/config_writer.rb
@@ -23,7 +23,7 @@ require "y2network/sysconfig/routes_file"
 require "y2network/sysconfig/dns_writer"
 require "y2network/sysconfig/connection_config_writer"
 require "y2network/sysconfig/interfaces_writer"
-require "yast2/cfa/sysctl"
+require "cfa/sysctl"
 
 Yast.import "Host"
 
@@ -100,20 +100,20 @@ module Y2Network
       #
       # @param routing [Y2Network::Routing] routing configuration
       def write_ip_forwarding(routing)
-        sysctl = Yast2::CFA::Sysctl.new
+        sysctl = CFA::Sysctl.new
         sysctl.load
-        sysctl.forward_ipv4 = routing.forward_ipv4 ? "1" : "0"
-        sysctl.forward_ipv6 = routing.forward_ipv6 ? "1" : "0"
+        sysctl.forward_ipv4 = routing.forward_ipv4
+        sysctl.forward_ipv6 = routing.forward_ipv6
         sysctl.save
 
-        update_ip_forwarding(sysctl.forward_ipv4, :ipv4)
-        update_ip_forwarding(sysctl.forward_ipv6, :ipv6)
+        update_ip_forwarding(sysctl.raw_forward_ipv4, :ipv4)
+        update_ip_forwarding(sysctl.raw_forward_ipv6, :ipv6)
         nil
       end
 
       IP_SYSCTL = {
-        :ipv4 => IPV4_SYSCTL,
-        :ipv6 => IPV6_SYSCTL
+        ipv4: IPV4_SYSCTL,
+        ipv6: IPV6_SYSCTL
       }.freeze
 
       # Updates the IP forwarding configuration of the running kernel

--- a/test/y2network/sysconfig/config_reader_test.rb
+++ b/test/y2network/sysconfig/config_reader_test.rb
@@ -84,34 +84,50 @@ describe Y2Network::Sysconfig::ConfigReader do
   end
 
   describe "#forward_ipv4?" do
+    let(:sysctl_file) { instance_double(Yast2::CFA::Sysctl, forward_ipv4: forward_ipv4).as_null_object }
+
     before do
-      allow(Y2Network::Sysconfig::RoutesFile).to receive(:new).and_return(routes_file)
+      allow(Yast2::CFA::Sysctl).to receive(:new).and_return(sysctl_file)
     end
 
-    it "returns true when IPv4 forwarding is allowed" do
-      expect(reader.config.routing.forward_ipv4).to be true
+    context "when IPv4 forwarding is allowed" do
+      let(:forward_ipv4) { "1" }
+
+      it "returns true" do
+        expect(reader.config.routing.forward_ipv4).to be true
+      end
     end
 
-    it "returns false when IPv4 forwarding is disabled" do
-      allow(Yast::SCR).to receive(:Read).and_return("0")
+    context "when IPv4 forwarding is disabled" do
+      let(:forward_ipv4) { "0" }
 
-      expect(reader.config.routing.forward_ipv4).to be false
+      it "returns false" do
+        expect(reader.config.routing.forward_ipv4).to be false
+      end
     end
   end
 
   describe "#forward_ipv6?" do
+    let(:sysctl_file) { instance_double(Yast2::CFA::Sysctl, forward_ipv6: forward_ipv6).as_null_object }
+
     before do
-      allow(Y2Network::Sysconfig::RoutesFile).to receive(:new).and_return(routes_file)
+      allow(Yast2::CFA::Sysctl).to receive(:new).and_return(sysctl_file)
     end
 
-    it "returns false when IPv6 forwarding is disabled" do
-      allow(Yast::SCR).to receive(:Read).and_return("1")
+    context "when IPv6 forwarding is allowed" do
+      let(:forward_ipv6) { "1" }
 
-      expect(reader.config.routing.forward_ipv6).to be true
+      it "returns true" do
+        expect(reader.config.routing.forward_ipv6).to be true
+      end
     end
 
-    it "returns false when IPv6 forwarding is disabled" do
-      expect(reader.config.routing.forward_ipv6).to be false
+    context "when IPv6 forwarding is disabled" do
+      let(:forward_ipv6) { "0" }
+
+      it "returns false" do
+        expect(reader.config.routing.forward_ipv6).to be false
+      end
     end
   end
 end

--- a/test/y2network/sysconfig/config_reader_test.rb
+++ b/test/y2network/sysconfig/config_reader_test.rb
@@ -84,14 +84,14 @@ describe Y2Network::Sysconfig::ConfigReader do
   end
 
   describe "#forward_ipv4?" do
-    let(:sysctl_file) { instance_double(Yast2::CFA::Sysctl, forward_ipv4: forward_ipv4).as_null_object }
+    let(:sysctl_file) { instance_double(CFA::Sysctl, forward_ipv4?: forward_ipv4).as_null_object }
 
     before do
-      allow(Yast2::CFA::Sysctl).to receive(:new).and_return(sysctl_file)
+      allow(CFA::Sysctl).to receive(:new).and_return(sysctl_file)
     end
 
     context "when IPv4 forwarding is allowed" do
-      let(:forward_ipv4) { "1" }
+      let(:forward_ipv4) { true }
 
       it "returns true" do
         expect(reader.config.routing.forward_ipv4).to be true
@@ -99,7 +99,7 @@ describe Y2Network::Sysconfig::ConfigReader do
     end
 
     context "when IPv4 forwarding is disabled" do
-      let(:forward_ipv4) { "0" }
+      let(:forward_ipv4) { false }
 
       it "returns false" do
         expect(reader.config.routing.forward_ipv4).to be false
@@ -108,14 +108,14 @@ describe Y2Network::Sysconfig::ConfigReader do
   end
 
   describe "#forward_ipv6?" do
-    let(:sysctl_file) { instance_double(Yast2::CFA::Sysctl, forward_ipv6: forward_ipv6).as_null_object }
+    let(:sysctl_file) { instance_double(CFA::Sysctl, forward_ipv6?: forward_ipv6).as_null_object }
 
     before do
-      allow(Yast2::CFA::Sysctl).to receive(:new).and_return(sysctl_file)
+      allow(CFA::Sysctl).to receive(:new).and_return(sysctl_file)
     end
 
     context "when IPv6 forwarding is allowed" do
-      let(:forward_ipv6) { "1" }
+      let(:forward_ipv6) { true }
 
       it "returns true" do
         expect(reader.config.routing.forward_ipv6).to be true
@@ -123,7 +123,7 @@ describe Y2Network::Sysconfig::ConfigReader do
     end
 
     context "when IPv6 forwarding is disabled" do
-      let(:forward_ipv6) { "0" }
+      let(:forward_ipv6) { false }
 
       it "returns false" do
         expect(reader.config.routing.forward_ipv6).to be false

--- a/test/y2network/sysconfig/config_writer_test.rb
+++ b/test/y2network/sysconfig/config_writer_test.rb
@@ -99,12 +99,10 @@ describe Y2Network::Sysconfig::ConfigWriter do
     let(:dns_writer) { instance_double(Y2Network::Sysconfig::DNSWriter, write: nil) }
     let(:interfaces_writer) { instance_double(Y2Network::Sysconfig::InterfacesWriter, write: nil) }
     let(:sysctl_file) do
-      instance_double(
-        Yast2::CFA::Sysctl,
-        forward_ipv4: "0", forward_ipv6: "0",
-        :forward_ipv4= => nil, :forward_ipv6= => nil,
-        load: nil, save: nil
-      )
+      CFA::Sysctl.new do |f|
+        f.forward_ipv4 = false
+        f.forward_ipv6 = false
+      end
     end
 
     before do
@@ -119,7 +117,9 @@ describe Y2Network::Sysconfig::ConfigWriter do
       allow_any_instance_of(Y2Network::Sysconfig::ConnectionConfigWriter).to receive(:write)
       allow(Y2Network::Sysconfig::InterfacesWriter).to receive(:new)
         .and_return(interfaces_writer)
-      allow(Yast2::CFA::Sysctl).to receive(:new).and_return(sysctl_file)
+      allow(CFA::Sysctl).to receive(:new).and_return(sysctl_file)
+      allow(sysctl_file).to receive(:load)
+      allow(sysctl_file).to receive(:save)
     end
 
     it "saves general routes to main routes file" do
@@ -216,8 +216,8 @@ describe Y2Network::Sysconfig::ConfigWriter do
       let(:forward_ipv4) { true }
 
       it "Writes ip forwarding setup for IPv4" do
-        expect(sysctl_file).to receive(:forward_ipv4=).with("1")
-        expect(sysctl_file).to receive(:forward_ipv6=).with("0")
+        expect(sysctl_file).to receive(:forward_ipv4=).with(true).and_call_original
+        expect(sysctl_file).to receive(:forward_ipv6=).with(false).and_call_original
         expect(sysctl_file).to receive(:save)
         writer.write(config)
       end
@@ -227,8 +227,8 @@ describe Y2Network::Sysconfig::ConfigWriter do
       let(:forward_ipv6) { true }
 
       it "Writes ip forwarding setup for IPv6" do
-        expect(sysctl_file).to receive(:forward_ipv4=).with("0")
-        expect(sysctl_file).to receive(:forward_ipv6=).with("1")
+        expect(sysctl_file).to receive(:forward_ipv4=).with(false).and_call_original
+        expect(sysctl_file).to receive(:forward_ipv6=).with(true).and_call_original
         expect(sysctl_file).to receive(:save)
 
         writer.write(config)

--- a/test/y2network/sysconfig/config_writer_test.rb
+++ b/test/y2network/sysconfig/config_writer_test.rb
@@ -35,6 +35,7 @@ describe Y2Network::Sysconfig::ConfigWriter do
   describe "#write" do
     before do
       allow(Yast::Host).to receive(:Write)
+      allow(Yast::SCR).to receive(:Write)
     end
 
     let(:old_config) do
@@ -97,6 +98,14 @@ describe Y2Network::Sysconfig::ConfigWriter do
 
     let(:dns_writer) { instance_double(Y2Network::Sysconfig::DNSWriter, write: nil) }
     let(:interfaces_writer) { instance_double(Y2Network::Sysconfig::InterfacesWriter, write: nil) }
+    let(:sysctl_file) do
+      instance_double(
+        Yast2::CFA::Sysctl,
+        forward_ipv4: "0", forward_ipv6: "0",
+        :forward_ipv4= => nil, :forward_ipv6= => nil,
+        load: nil, save: nil
+      )
+    end
 
     before do
       allow(Y2Network::Sysconfig::RoutesFile).to receive(:new)
@@ -110,6 +119,7 @@ describe Y2Network::Sysconfig::ConfigWriter do
       allow_any_instance_of(Y2Network::Sysconfig::ConnectionConfigWriter).to receive(:write)
       allow(Y2Network::Sysconfig::InterfacesWriter).to receive(:new)
         .and_return(interfaces_writer)
+      allow(Yast2::CFA::Sysctl).to receive(:new).and_return(sysctl_file)
     end
 
     it "saves general routes to main routes file" do
@@ -206,15 +216,9 @@ describe Y2Network::Sysconfig::ConfigWriter do
       let(:forward_ipv4) { true }
 
       it "Writes ip forwarding setup for IPv4" do
-        allow(Yast::SCR).to receive(:Write)
-
-        expect(Yast::SCR)
-          .to receive(:Write)
-          .with(Yast::Path.new(Y2Network::SysconfigPaths::SYSCTL_IPV4_PATH), "1")
-        expect(Yast::SCR)
-          .to receive(:Write)
-          .with(Yast::Path.new(Y2Network::SysconfigPaths::SYSCTL_IPV6_PATH), "0")
-
+        expect(sysctl_file).to receive(:forward_ipv4=).with("1")
+        expect(sysctl_file).to receive(:forward_ipv6=).with("0")
+        expect(sysctl_file).to receive(:save)
         writer.write(config)
       end
     end
@@ -223,14 +227,9 @@ describe Y2Network::Sysconfig::ConfigWriter do
       let(:forward_ipv6) { true }
 
       it "Writes ip forwarding setup for IPv6" do
-        allow(Yast::SCR).to receive(:Write)
-
-        expect(Yast::SCR)
-          .to receive(:Write)
-          .with(Yast::Path.new(Y2Network::SysconfigPaths::SYSCTL_IPV4_PATH), "0")
-        expect(Yast::SCR)
-          .to receive(:Write)
-          .with(Yast::Path.new(Y2Network::SysconfigPaths::SYSCTL_IPV6_PATH), "1")
+        expect(sysctl_file).to receive(:forward_ipv4=).with("0")
+        expect(sysctl_file).to receive(:forward_ipv6=).with("1")
+        expect(sysctl_file).to receive(:save)
 
         writer.write(config)
       end


### PR DESCRIPTION
Adapts sysctl handling to use the new [CFA::Sysctl](https://github.com/yast/yast-yast2/pull/966) class so the configuration is written to a YaST specific file under `/etc/sysctl.d`.