### PR TITLE
Live instalation: Make network more useful

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Fri Nov  8 13:15:15 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Live installation:
+  - Do not try to configure dhcp when NetworkManager is in use.
+  - Show the general tab in the lan client allowing to switch
+    between backends when systemd is running.
+  - Do not do a netconfig update during an installation for not
+    breaking the current resolv configuration.
+- 4.2.25
+
+-------------------------------------------------------------------
 Fri Nov  1 08:43:31 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - fix typo in remote desktop file (thanks for contribution 

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -35,7 +35,7 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  yast2-storage-ng
 # NetworkService check if Systemd is running for determining
 # the current network backend
-BuildRequires:  yast2 >= 4.2.29
+BuildRequires:  yast2 >= 4.2.28
 BuildRequires:  yast2-packager >= 4.0.18
 # Product control need xml agent
 BuildRequires:  yast2-xml

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -33,8 +33,9 @@ BuildRequires:  yast2-devtools >= 3.1.15
 #for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  yast2-storage-ng
-# CFA::Sysctl
-BuildRequires:  yast2 >= 4.2.25
+# NetworkService check if Systemd is running for determining
+# the current network backend
+BuildRequires:  yast2 >= 4.2.29
 BuildRequires:  yast2-packager >= 4.0.18
 # Product control need xml agent
 BuildRequires:  yast2-xml

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -35,7 +35,7 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  yast2-storage-ng
 # NetworkService check if Systemd is running for determining
 # the current network backend
-BuildRequires:  yast2 >= 4.2.28
+BuildRequires:  yast2 >= 4.2.31
 BuildRequires:  yast2-packager >= 4.0.18
 # Product control need xml agent
 BuildRequires:  yast2-xml

--- a/src/clients/inst_lan.rb
+++ b/src/clients/inst_lan.rb
@@ -35,6 +35,7 @@ module Yast
       Yast.import "UI"
       Yast.import "Lan"
       Yast.import "GetInstArgs"
+      Yast.import "NetworkService"
 
       Yast.include self, "network/lan/wizards.rb"
 
@@ -49,7 +50,8 @@ module Yast
       # keep network configuration state in @@conf_net to gurantee same
       # behavior when walking :back in installation workflow
       if !defined?(@@network_configured)
-        @@network_configured = !Yast::Lan.yast_config.connections.empty?
+        @@network_configured =
+          NetworkService.network_manager? ? true : !Lan.yast_config.connections.empty?
       end
 
       log.info("Configured network found: #{@@network_configured}")

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -55,6 +55,7 @@ module Yast
       Yast.import "CWMTab"
       Yast.import "Stage"
       Yast.import "LanItems"
+      Yast.import "Systemd"
 
       Yast.include include_target, "network/routines.rb"
       Yast.include include_target, "network/lan/help.rb"
@@ -258,7 +259,7 @@ module Yast
       caption = _("Network Settings")
       widget_descr = {
         "tab" => CWMTab.CreateWidget(
-          "tab_order"    => if Stage.normal
+          "tab_order"    => if Stage.normal || Systemd.Running
                               ["global", "overview", "resolv", "route"]
                             else
                               ["overview", "resolv", "route"]

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -259,7 +259,7 @@ module Yast
       caption = _("Network Settings")
       widget_descr = {
         "tab" => CWMTab.CreateWidget(
-          "tab_order"    => if Stage.normal || Systemd.Running
+          "tab_order"    => if Systemd.Running
                               ["global", "overview", "resolv", "route"]
                             else
                               ["overview", "resolv", "route"]

--- a/src/lib/network/clients/inst_setup_dhcp.rb
+++ b/src/lib/network/clients/inst_setup_dhcp.rb
@@ -33,7 +33,7 @@ module Yast
       nac = NetworkAutoconfiguration.instance
       set_dhcp_hostname! if Stage.initial
 
-      if wicked_backend?
+      if Yast::NetworkService.wicked?
         if !nac.any_iface_active?
           nac.configure_dhcp
         else
@@ -56,11 +56,6 @@ module Yast
       set_hostname = Linuxrc.InstallInf("SetHostname")
       log.info("SetHostname: #{set_hostname}")
       set_hostname != "0"
-    end
-
-    def wicked_backend?
-      Yast::NetworkService.Read
-      Yast::NetworkService.wicked?
     end
 
     # Write the DHCLIENT_SET_HOSTNAME in /etc/sysconfig/network/dhcp based on

--- a/src/lib/network/clients/inst_setup_dhcp.rb
+++ b/src/lib/network/clients/inst_setup_dhcp.rb
@@ -21,6 +21,8 @@ require "network/network_autoconfiguration"
 
 Yast.import "Linuxrc"
 Yast.import "DNS"
+Yast.import "Systemd"
+Yast.import "NetworkService"
 
 module Yast
   class SetupDhcp
@@ -31,10 +33,14 @@ module Yast
       nac = NetworkAutoconfiguration.instance
       set_dhcp_hostname! if Stage.initial
 
-      if !nac.any_iface_active?
-        nac.configure_dhcp
+      if wicked_backend?
+        if !nac.any_iface_active?
+          nac.configure_dhcp
+        else
+          log.info("Automatic DHCP configuration not started - an interface is already configured")
+        end
       else
-        log.info("Automatic DHCP configuration not started - an interface is already configured")
+        log.info("Network is not managed by wicked, skipping DHCP setup")
       end
 
       # if this is not wrapped in a def, ruby -cw says
@@ -50,6 +56,11 @@ module Yast
       set_hostname = Linuxrc.InstallInf("SetHostname")
       log.info("SetHostname: #{set_hostname}")
       set_hostname != "0"
+    end
+
+    def wicked_backend?
+      Yast::NetworkService.Read
+      Yast::NetworkService.wicked?
     end
 
     # Write the DHCLIENT_SET_HOSTNAME in /etc/sysconfig/network/dhcp based on

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -81,6 +81,7 @@ module Yast
 
     ETC = "/etc/".freeze
     SYSCONFIG = "/etc/sysconfig/network/".freeze
+    NETWORK_MANAGER = "/etc/NetworkManager/".freeze
 
     def CopyConfiguredNetworkFiles
       return if Mode.autoinst && !NetworkAutoYast.instance.keep_net_config?
@@ -98,6 +99,10 @@ module Yast
         { dir: ETC + "wicked/", file: "common.xml" },
         { dir: ETC, file: DNSClass::HOSTNAME_FILE }
       ]
+
+      if Y2Network::ProposalSettings.instance.network_service == :network_manager
+        copy_recipes << { dir: NETWORK_MANAGER + "/system-connections/", file: "*" }
+      end
 
       # just copy files
       copy_recipes.each do |recipe|

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -34,6 +34,7 @@ module Yast
     Yast.import "Lan"
     Yast.import "LanItems"
     Yast.import "NetworkInterfaces"
+    Yast.import "NetworkService"
     Yast.import "Package"
     Yast.import "DNS"
     Yast.import "Arch"
@@ -45,11 +46,11 @@ module Yast
     #
     # returns [Boolean] true when at least one interface is active
     def any_iface_active?
+      Yast::Lan.Read(:cache)
       config.interfaces.any? { |c| config.connections.by_name(c.name) && active_config?(c.name) }
     end
 
     def configure_dhcp
-      Yast::Lan.Read(:cache)
       Yast.include self, "network/routines.rb" # TODO: needed only for phy_connected
 
       # find out network devices suitable for dhcp autoconfiguration.
@@ -114,7 +115,7 @@ module Yast
     def configure_dns
       DNS.Read # handles NetworkConfig too
       log.info("NetworkAutoconfiguration: proposing DNS / Hostname configuration")
-      DNS.Write
+      DNS.Write(netconfig_update: false)
     end
 
     # Proposes updates for /etc/hosts

--- a/src/lib/y2network/sysconfig/dns_writer.rb
+++ b/src/lib/y2network/sysconfig/dns_writer.rb
@@ -30,13 +30,15 @@ module Y2Network
       #
       # @param dns [Y2Network::DNS] DNS configuration
       # @param old_dns [Y2Network::DNS] Old DNS configuration
+      # @param netconfig_update [Boolean] Whether 'netconfig update' should be
+      #   called after writing the DNS configuration or not
       def write(dns, old_dns, netconfig_update: true)
         return if old_dns && dns == old_dns
 
         update_sysconfig_dhcp(dns, old_dns)
         update_hostname(dns)
         update_mta_config
-        update_sysconfig_config(dns, netconfig: netconfig_update)
+        update_sysconfig_config(dns, netconfig_update: netconfig_update)
       end
 
     private
@@ -92,7 +94,9 @@ module Y2Network
       # Updates /etc/sysconfig/network/config
       #
       # @param dns [Y2Network::DNS]
-      def update_sysconfig_config(dns, netconfig: true)
+      # @param netconfig_update [Boolean] Whether 'netconfig update' should be
+      #   called after writing the DNS configuration or not
+      def update_sysconfig_config(dns, netconfig_update: true)
         Yast::SCR.Write(
           Yast::Path.new(".sysconfig.network.config.NETCONFIG_DNS_POLICY"),
           dns.resolv_conf_policy
@@ -107,7 +111,7 @@ module Y2Network
         )
         Yast::SCR.Write(Yast::Path.new(".sysconfig.network.config"), nil)
 
-        Yast::Execute.on_target!("/sbin/netconfig", "update") if netconfig
+        Yast::Execute.on_target!("/sbin/netconfig", "update") if netconfig_update
       end
     end
   end

--- a/src/lib/y2network/sysconfig/dns_writer.rb
+++ b/src/lib/y2network/sysconfig/dns_writer.rb
@@ -30,13 +30,13 @@ module Y2Network
       #
       # @param dns [Y2Network::DNS] DNS configuration
       # @param old_dns [Y2Network::DNS] Old DNS configuration
-      def write(dns, old_dns)
+      def write(dns, old_dns, netconfig_update: true)
         return if old_dns && dns == old_dns
 
         update_sysconfig_dhcp(dns, old_dns)
         update_hostname(dns)
         update_mta_config
-        update_sysconfig_config(dns)
+        update_sysconfig_config(dns, netconfig: netconfig_update)
       end
 
     private
@@ -92,7 +92,7 @@ module Y2Network
       # Updates /etc/sysconfig/network/config
       #
       # @param dns [Y2Network::DNS]
-      def update_sysconfig_config(dns)
+      def update_sysconfig_config(dns, netconfig: true)
         Yast::SCR.Write(
           Yast::Path.new(".sysconfig.network.config.NETCONFIG_DNS_POLICY"),
           dns.resolv_conf_policy
@@ -107,7 +107,7 @@ module Y2Network
         )
         Yast::SCR.Write(Yast::Path.new(".sysconfig.network.config"), nil)
 
-        Yast::Execute.on_target!("/sbin/netconfig", "update")
+        Yast::Execute.on_target!("/sbin/netconfig", "update") if netconfig
       end
     end
   end

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -192,8 +192,8 @@ module Yast
     def Write(_gui: true, netconfig_update: true)
       writer = Y2Network::Sysconfig::DNSWriter.new
       writer.write(Yast::Lan.yast_config.dns,
-                   Yast::Lan.system_config.dns,
-                   netconfig_update: netconfig_update)
+        Yast::Lan.system_config.dns,
+        netconfig_update: netconfig_update)
       true
     end
 

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -188,8 +188,10 @@ module Yast
     # Write new DNS and hostname settings
     # Includes Host,NetworkConfig::Write
     # @todo Update GUI
+    # @param netconfig_update [Boolean] Whether 'netconfig update' should be
+    #   called after writing the DNS configuration or not
     # @return true if success
-    def Write(_gui: true, netconfig_update: true)
+    def Write(netconfig_update: true)
       writer = Y2Network::Sysconfig::DNSWriter.new
       writer.write(Yast::Lan.yast_config.dns,
         Yast::Lan.system_config.dns,

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -189,9 +189,11 @@ module Yast
     # Includes Host,NetworkConfig::Write
     # @todo Update GUI
     # @return true if success
-    def Write(_gui: true)
+    def Write(_gui: true, netconfig_update: true)
       writer = Y2Network::Sysconfig::DNSWriter.new
-      writer.write(Yast::Lan.yast_config.dns, Yast::Lan.system_config.dns)
+      writer.write(Yast::Lan.yast_config.dns,
+                   Yast::Lan.system_config.dns,
+                   netconfig_update: netconfig_update)
       true
     end
 

--- a/test/dns_test.rb
+++ b/test/dns_test.rb
@@ -186,7 +186,7 @@ describe Yast::DNS do
     end
 
     it "writes DNS settings" do
-      expect(dns_writer).to receive(:write).with(yast_config.dns, system_config.dns)
+      expect(dns_writer).to receive(:write).with(yast_config.dns, system_config.dns, netconfig_update: true)
       subject.Write
     end
   end

--- a/test/dns_test.rb
+++ b/test/dns_test.rb
@@ -186,7 +186,8 @@ describe Yast::DNS do
     end
 
     it "writes DNS settings" do
-      expect(dns_writer).to receive(:write).with(yast_config.dns, system_config.dns, netconfig_update: true)
+      expect(dns_writer).to receive(:write)
+        .with(yast_config.dns, system_config.dns, netconfig_update: true)
       subject.Write
     end
   end


### PR DESCRIPTION
## Problem

- In a live installation we assumes that wicked is the network service by default which is completely wrong. The point is that we can check the network backend in use as systemd is running.
- The network client "lan" only shows the "general tab" in a running system which means that it always tries to configure the network assuming it uses wicked which is also wrong.
- At the end of the installation "save_network" configures the dns, which calls `netconfig update`. Netconfig checks internally the link of the network.service for determining which resolv.conf configuration should use (NM or wicked) overriding the one from the instsys and in many cases breaking the names resolution.

- https://trello.com/c/qvY7Oygp/1375-3-osdistribution-p1-1151291-build-1330-openqa-test-fails-in-awaitinstall-yast-breaks-network-during-install

## Solution

- When Systemd is running determine the backend in use (https://github.com/yast/yast-yast2/pull/972) and show the general tab in the "network" configuration dialog.
- Skip the network configuration when NetworkManager is in use.
- Do not call netconfig update if the NetworkService is not wicked.
- It depends on yast/yast-yast2#972 (That is, yast2-4.2.31) 
  - Will update the spec with the requirement once approved and merged that PR just for not breaking dependencies when travis is run