### PR TITLE
Hostname in installer

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Nov 21 07:13:28 UTC 2019 - Michal Filka <mfilka@suse.com>
 
-- fate#319639
+- bnc#1153198, fate#319639
   - implemented proper hostname setup in installation for the new
     backend
 - 4.2.29

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Nov 21 07:13:28 UTC 2019 - Michal Filka <mfilka@suse.com>
+
+- fate#319639
+  - implemented proper hostname setup in installation for the new
+    backend
+- 4.2.29
+
+-------------------------------------------------------------------
 Tue Nov 19 12:05:21 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Do not crash when wrapping text (bsc#1157161)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.28
+Version:        4.2.29
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -41,15 +41,40 @@ module Yast
     # @param iface [String] network device
     # @return [Array<String>] list of NTP servers
     def parse_ntp_servers(iface)
+      query_wicked(iface, "%{//ntp/server}")
+    end
+
+    # Parses wicked runtime configuration and returns hostname if set
+    #
+    # @param iface [String] network device
+    # @return [String] hostname
+    def parse_hostname(iface)
+      result = query_wicked(iface, "%{//hostname}")
+
+      raise "Malformed wicked runtime configuration" if result.count > 1
+
+      result.first
+    end
+
+    # Parses wicked runtime dhcp lease file for the given query
+    #
+    # It parses both ipv4 and ipv6 lease files at once.
+    #
+    # @param iface [String] queried interface
+    # @param query [String] xpath query
+    # @return [String] result of the query
+    def query_wicked(iface, query)
       raise ArgumentError, "A network device has to be specified" if iface.nil? || iface.empty?
       if !NetworkService.is_wicked
-        raise "Parsing NTP Servers not supported for network service in use"
+        raise "Parsing not supported for network service in use"
       end
 
       lease_files = ["ipv4", "ipv6"].map { |ip| "/var/lib/wicked/lease-#{iface}-dhcp-#{ip}.xml" }
       lease_files.find_all { |f| File.file?(f) }.reduce([]) do |stack, file|
-        result = SCR.Execute(BASH_OUTPUT_PATH,
-          "/usr/sbin/wicked xpath --file #{file.shellescape} \"%{//ntp/server}\"")
+        result = SCR.Execute(
+          BASH_OUTPUT_PATH,
+          "/usr/sbin/wicked xpath --file #{file.shellescape} \"#{query}\""
+        )
 
         stack + result.fetch("stdout", "").split("\n")
       end

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -65,9 +65,7 @@ module Yast
     # @return [String] result of the query
     def query_wicked(iface, query)
       raise ArgumentError, "A network device has to be specified" if iface.nil? || iface.empty?
-      if !NetworkService.is_wicked
-        raise "Parsing not supported for network service in use"
-      end
+      raise "Parsing not supported for network service in use" if !NetworkService.is_wicked
 
       lease_files = ["ipv4", "ipv6"].map { |ip| "/var/lib/wicked/lease-#{iface}-dhcp-#{ip}.xml" }
       lease_files.find_all { |f| File.file?(f) }.reduce([]) do |stack, file|

--- a/src/lib/y2network/dns.rb
+++ b/src/lib/y2network/dns.rb
@@ -25,6 +25,9 @@ module Y2Network
     # @return [String] Hostname (local part)
     attr_accessor :hostname
 
+    # @return [Boolean] Controls if the hostname should be written or not
+    attr_accessor :save_hostname
+
     # @return [Array<IPAddr>] List of nameservers
     attr_accessor :nameservers
 
@@ -49,6 +52,7 @@ module Y2Network
     # @option opts [Boolean] :dhcp_hostname
     def initialize(opts = {})
       @hostname = opts[:hostname]
+      @save_hostname = opts.fetch(:save_hostname, true)
       @nameservers = opts[:nameservers] || []
       @searchlist = opts[:searchlist] || []
       @resolv_conf_policy = opts[:resolv_conf_policy]

--- a/src/lib/y2network/hostname_reader.rb
+++ b/src/lib/y2network/hostname_reader.rb
@@ -37,6 +37,8 @@ module Y2Network
   # @example Read hostname
   #   Y2Network::HostnameReader.new.hostname #=> "foo"
   class HostnameReader
+    attr_reader :install_inf_hostname
+
     include Yast::Logger
     include Yast::Wicked
 
@@ -127,12 +129,12 @@ module Y2Network
     #
     # @return [String] Hostname
     def hostname_for_installer
-      install_inf_hostname = hostname_from_install_inf if Yast::FileUtils.Exists("/etc/install.inf")
+      @install_inf_hostname = hostname_from_install_inf if Yast::FileUtils.Exists("/etc/install.inf")
 
       # the hostname was either explicitly set by the user, obtained from dhcp or implicitly
       # preconfigured by the linuxrc (install). Do not generate random one as we did in the past.
       # See FATE#319639 for details.
-      hostname_from_dhcp || install_inf_hostname || hostname_from_system
+      @install_inf_hostname || hostname_from_dhcp || hostname_from_system
     end
 
     # Runs workflow for querying hostname in the installed system

--- a/src/lib/y2network/hostname_reader.rb
+++ b/src/lib/y2network/hostname_reader.rb
@@ -102,7 +102,7 @@ module Y2Network
       # bcs this can be called during Y2Network::Config initialization and this is
       # acceptable replacement for this case.
       ifaces = Sysconfig::InterfaceFile.all.map(&:interface)
-      dhcp_hostname = ifaces.map { |i| parse_hostname(i) }.first
+      dhcp_hostname = ifaces.map { |i| parse_hostname(i) }.compact.first
 
       log.info("Hostname obtained from DHCP: #{dhcp_hostname}")
 

--- a/src/lib/y2network/hostname_reader.rb
+++ b/src/lib/y2network/hostname_reader.rb
@@ -123,13 +123,13 @@ module Y2Network
       "linux-#{suffix}"
     end
 
-    private
+  private
 
     # Runs workflow for querying hostname in the installer
     #
     # @return [String] Hostname
     def hostname_for_installer
-      @install_inf_hostname = hostname_from_install_inf if Yast::FileUtils.Exists("/etc/install.inf")
+      @install_inf_hostname = hostname_from_install_inf
 
       # the hostname was either explicitly set by the user, obtained from dhcp or implicitly
       # preconfigured by the linuxrc (install). Do not generate random one as we did in the past.

--- a/src/lib/y2network/sysconfig/dns_reader.rb
+++ b/src/lib/y2network/sysconfig/dns_reader.rb
@@ -21,6 +21,8 @@ require "y2network/dns"
 require "y2network/sysconfig/interface_file"
 require "y2network/hostname_reader"
 
+Yast.import "Mode"
+
 module Y2Network
   module Sysconfig
     # Reads DNS configuration from sysconfig files
@@ -34,6 +36,7 @@ module Y2Network
         Y2Network::DNS.new(
           nameservers:        nameservers,
           hostname:           hostname,
+          save_hostname:      !(Yast::Mode.installation || Yast::Mode.autoinst) || hostname_from_install_inf?,
           searchlist:         searchlist,
           resolv_conf_policy: resolv_conf_policy,
           dhcp_hostname:      dhcp_hostname
@@ -75,7 +78,15 @@ module Y2Network
       #
       # @return [String]
       def hostname
-        HostnameReader.new.hostname
+        @hostname_reader = HostnameReader.new
+        @hostname_reader.hostname
+      end
+
+      # Checks whether the hostname was read from install.inf
+      #
+      # @return [Boolean]
+      def hostname_from_install_inf?
+        !@hostname_reader.install_inf_hostname.nil?
       end
 
       # Return the list of search domains

--- a/src/lib/y2network/sysconfig/dns_reader.rb
+++ b/src/lib/y2network/sysconfig/dns_reader.rb
@@ -33,10 +33,11 @@ module Y2Network
       #
       # @return [Y2Network::DnsConfig] DNS configuration
       def config
+        installer = Yast::Mode.installation || Yast::Mode.autoinst
         Y2Network::DNS.new(
           nameservers:        nameservers,
           hostname:           hostname,
-          save_hostname:      !(Yast::Mode.installation || Yast::Mode.autoinst) || hostname_from_install_inf?,
+          save_hostname:      !installer || hostname_from_install_inf?,
           searchlist:         searchlist,
           resolv_conf_policy: resolv_conf_policy,
           dhcp_hostname:      dhcp_hostname

--- a/src/lib/y2network/sysconfig/dns_writer.rb
+++ b/src/lib/y2network/sysconfig/dns_writer.rb
@@ -36,7 +36,7 @@ module Y2Network
         return if old_dns && dns == old_dns
 
         update_sysconfig_dhcp(dns, old_dns)
-        update_hostname(dns)
+        update_hostname(dns) if dns.save_hostname
         update_mta_config
         update_sysconfig_config(dns, netconfig_update: netconfig_update)
       end

--- a/test/y2network/hostname_reader_test.rb
+++ b/test/y2network/hostname_reader_test.rb
@@ -53,8 +53,6 @@ describe Y2Network::HostnameReader do
 
       before do
         allow(Yast::Mode).to receive(:installation).and_return(true)
-        allow(Yast::FileUtils).to receive(:Exists).with("/etc/install.inf")
-          .and_return(install_inf_exists?)
       end
 
       it "reads the hostname from /etc/install.conf" do
@@ -62,7 +60,7 @@ describe Y2Network::HostnameReader do
       end
 
       context "when the /etc/install.inf file does not exists" do
-        let(:install_inf_exists?) { false }
+        let(:install_inf_hostname) { nil }
 
         it "reads the hostname from the system" do
           expect(reader.hostname).to eq("system")
@@ -166,7 +164,10 @@ describe Y2Network::HostnameReader do
     around { |e| change_scr_root(File.join(DATA_PATH, "scr_read"), &e) }
 
     it "returns name provided as part of dhcp configuration when available on any interface" do
-      allow(File).to receive(:file?).with("/var/lib/wicked/lease-eth4-dhcp-ipv4.xml").and_return(true)
+      allow(File)
+        .to receive(:file?)
+        .with("/var/lib/wicked/lease-eth4-dhcp-ipv4.xml")
+        .and_return(true)
       allow(Yast::SCR).to receive(:Execute).and_return("stdout" => "tumbleweed\n")
 
       expect(reader.hostname_from_dhcp).to eql "tumbleweed"


### PR DESCRIPTION
Fate319639

Hotfix for network-ng to set hostname according to the fate above in the installer. It was only partly implemented in the code before network-ng. It basically means that:
- if no other way is used the hostname is set to a default (currently install)
- if a hostname is provided via dhcp then it is used (completely new functionality )
- if a hostname is provided via linuxrc's hostname option then it is used (was not working in network-ng)

The hostname is set in order described above. Also, the hostname is written to the target only in third case (when set using hostname option).

Yast2-network cooperates with linuxrc here bcs linuxrc is e.g. the one who sets the default hostname and so on.

What should be done next:
- in the old code the hostname and dns handling was mixed together. As this features are not fully related it would be nice  to have it in separate classes in network-ng (will follow)