### PR TITLE
Fix wpa psk config

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Sun Nov 10 09:28:14 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Wireless: Fix wpa auth modes selection removing the prefix from
+  the combobox value which is not used when writing the config.
+  (bsc#1155639)
+- 4.2.26
+
+-------------------------------------------------------------------
 Fri Nov  8 13:15:15 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - Live installation:

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.24
+Version:        4.2.26
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/wireless_auth.rb
+++ b/src/lib/y2network/widgets/wireless_auth.rb
@@ -71,8 +71,8 @@ module Y2Network
         case auth_mode_widget.value
         when "no-encryption" then replace_widget.replace(empty_auth_widget)
         when "sharedkey", "open" then replace_widget.replace(wep_keys_widget)
-        when "wpa-psk" then replace_widget.replace(encryption_widget)
-        when "wpa-eap" then replace_widget.replace(eap_widget)
+        when "psk" then replace_widget.replace(encryption_widget)
+        when "eap" then replace_widget.replace(eap_widget)
         else
           raise "invalid value #{auth_mode_widget.value.inspect}"
         end

--- a/src/lib/y2network/widgets/wireless_auth_mode.rb
+++ b/src/lib/y2network/widgets/wireless_auth_mode.rb
@@ -45,8 +45,8 @@ module Y2Network
           ["no-encryption", _("No Encryption")],
           ["open", _("WEP - Open")],
           ["sharedkey", _("WEP - Shared Key")],
-          ["wpa-psk", _("WPA-PSK (\"home\")")],
-          ["wpa-eap", _("WPA-EAP (\"Enterprise\")")]
+          ["psk", _("WPA-PSK (\"home\")")],
+          ["eap", _("WPA-EAP (\"Enterprise\")")]
         ]
       end
 

--- a/test/y2network/widgets/wireless_auth_mode_test.rb
+++ b/test/y2network/widgets/wireless_auth_mode_test.rb
@@ -1,0 +1,31 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "cwm/rspec"
+
+require "y2network/widgets/wireless_auth_mode"
+require "y2network/interface_config_builder"
+
+describe Y2Network::Widgets::WirelessAuthMode do
+  let(:builder) { Y2Network::InterfaceConfigBuilder.for("wlan") }
+  subject { described_class.new(builder) }
+
+  include_examples "CWM::ComboBox"
+end


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1155639

## Problem

When choosing the wireless WPA PSK auth mode, the config is expected to have a method `write_wpa-psk_auth_settings(conn)' but it is defined omitting WPA which is already implicit known.

See https://github.com/yast/yast-network/blob/master/src/lib/y2network/sysconfig/connection_config_writers/wireless.rb#L74

## Solution

- We could downcase the auth mode selection and rename the`wpa-psk` method but as we also omit `WPA` prefix in the file attribute I preferred to just omit the prefix completely from the Combo Box option values.

- see https://github.com/yast/yast-network/blob/master/src/lib/y2network/connection_config/wireless.rb#L35

With this changes the WPA PSK config is written correctly