### PR TITLE
Add unknown interface type

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 25 09:36:43 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Added a special type for the "Unknown" interfaces omitting them
+  from the interfaces list (bsc#1156285)
+- 4.2.32
+
+-------------------------------------------------------------------
 Mon Nov 25 08:34:55 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - Ignores invalid udev rules parts (bsc#1157361)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.31
+Version:        4.2.32
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/interface_type.rb
+++ b/src/lib/y2network/interface_type.rb
@@ -149,7 +149,7 @@ module Y2Network
     IRDA = new(N_("Infrared"), "irda")
     # Loopback
     LO = new(N_("Loopback"), "lo")
-    # Not supported interfaces
-    UNSUPPORTED = new(N_("Unsupported"), "unsupported")
+    # Unknown interfaces
+    UNKNOWN = new(N_("Unknown"), "unknown")
   end
 end

--- a/src/lib/y2network/interface_type.rb
+++ b/src/lib/y2network/interface_type.rb
@@ -149,5 +149,7 @@ module Y2Network
     IRDA = new(N_("Infrared"), "irda")
     # Loopback
     LO = new(N_("Loopback"), "lo")
+    # Not supported interfaces
+    UNSUPPORTED = new(N_("Unsupported"), "unsupported")
   end
 end

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -83,7 +83,7 @@ module Y2Network
 
         physical_interfaces = Hwinfo.netcards.each_with_object([]) do |hwinfo, interfaces|
           physical_interface = build_physical_interface(hwinfo)
-          next if physical_interface.type == InterfaceType::UNSUPPORTED
+          next if physical_interface.type == InterfaceType::UNKNOWN
 
           interfaces << physical_interface
         end
@@ -127,7 +127,7 @@ module Y2Network
           iface.renaming_mechanism = renaming_mechanism_for(iface)
           iface.custom_driver = custom_driver_for(iface)
           iface.type = InterfaceType.from_short_name(hwinfo.type) ||
-            TypeDetector.type_of(iface.name) || InterfaceType::UNSUPPORTED
+            TypeDetector.type_of(iface.name) || InterfaceType::UNKNOWN
         end
       end
 

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -81,9 +81,13 @@ module Y2Network
       def find_physical_interfaces
         return if @interfaces
 
-        physical_interfaces = Hwinfo.netcards.map do |h|
-          build_physical_interface(h)
+        physical_interfaces = Hwinfo.netcards.each_with_object([]) do |hwinfo, interfaces|
+          physical_interface = build_physical_interface(hwinfo)
+          next if physical_interface.type == InterfaceType::UNSUPPORTED
+
+          interfaces << physical_interface
         end
+
         @interfaces = Y2Network::InterfacesCollection.new(physical_interfaces)
       end
 
@@ -123,7 +127,7 @@ module Y2Network
           iface.renaming_mechanism = renaming_mechanism_for(iface)
           iface.custom_driver = custom_driver_for(iface)
           iface.type = InterfaceType.from_short_name(hwinfo.type) ||
-            TypeDetector.type_of(iface.name)
+            TypeDetector.type_of(iface.name) || InterfaceType::UNSUPPORTED
         end
       end
 

--- a/src/lib/y2network/sysconfig/type_detector.rb
+++ b/src/lib/y2network/sysconfig/type_detector.rb
@@ -31,6 +31,8 @@ module Y2Network
         # Checks wheter iface type can be recognized by interface configuration
         def type_by_config(iface)
           iface_file = Y2Network::Sysconfig::InterfaceFile.find(iface)
+          return unless iface_file
+
           iface_file.load
           iface_file.type
         end


### PR DESCRIPTION
## Problem

With the re-factorization of yast2-network, we have not implemented support for some network interfaces that were marked as deprecated (i.e s390 IUCV).

When the physical interfaces present in the system are read, we determine the interface type, which, in this case, is provided by hwinfo. But if there is the InterfaceType is not declared we try to infer it from the interface name. 

In the case of an IUCV interface, as we are not supporting it and the `device_name` exported by ReadHardware is nil, the lan client basically crashes.

- https://trello.com/c/wGKdDJAo/1437-1-ostumbleweed-p5-1156285-s390x-yast-lan-crashes-when-there-are-iucv-interfaces-deprecated
- https://bugzilla.suse.com/show_bug.cgi?id=1156285

## Solution

Added a special type for the "Unknown" ones, which basically are omited from the interfaces list.

## To discuss

- Shall we ignore the **unknowns** from the list of the interfaces or shall we add it and then just do not list in the interfaces table?

- Shall we try to detect all the cards available and infer the type also for not supporting ones being able to show them but maybe as disabled? 

  For example, now we do not support **IUVC** intercaces but a `ifcfg-iucv0` file could exist, it probably will add a physical interface as not present because we didn't add it to the list because of unsupported.

