### PR TITLE
Fix how text is wrapped

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 19 12:05:21 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Do not crash when wrapping text (bsc#1157161)
+- 4.2.28
+
+-------------------------------------------------------------------
 Tue Nov 12 13:35:02 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - fix importing dhclient_set_hostname key from autoyast profile

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.27
+Version:        4.2.28
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/bond_slave.rb
+++ b/src/lib/y2network/widgets/bond_slave.rb
@@ -220,9 +220,8 @@ module Y2Network
       # mapping to an array of device names
       # @return [Boolean] true if continue with duplicates, otherwise false
       def continue_with_duplicates?(physical_ports)
-        message = physical_ports.map do |port, slave|
-          label = "PhysicalPortID (#{port}): "
-          wrap_text(slave.join(", "), 76, prepend_text: label)
+        message = physical_ports.map do |port, slaves|
+          wrap_text("PhysicalPortID (#{port}): #{slaves.join(", ")}")
         end.join("\n")
 
         Yast::Popup.YesNoHeadline(


### PR DESCRIPTION
## Problem

`preprend_text` is not longer available since improvments introduced at https://github.com/yast/yast-yast2/pull/980


* Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1157161


## Solution

To provide directly the final text to the `wrap_text` helper.

