### PR TITLE
NetworkAutoconfiguration#setup_dchp: Ensure network configuration is read before dealing with it

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 21 10:57:33 UTC 2019 - Knut Alejandro Anderssen González <knut.anderssen@suse.com>
+
+- Firsboot dhcp: Ensure the network configuration has been read
+  before trying to configure it by dhcp (bsc#1157429)
+- 4.2.30
+
+-------------------------------------------------------------------
 Thu Nov 21 07:13:28 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1153198, fate#319639

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.29
+Version:        4.2.30
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -51,6 +51,7 @@ module Yast
     end
 
     def configure_dhcp
+      Yast::Lan.Read(:cache)
       Yast.include self, "network/routines.rb" # TODO: needed only for phy_connected
 
       # find out network devices suitable for dhcp autoconfiguration.


### PR DESCRIPTION
## Problem

While the installation dhcp setup client do more checks and configuration, the firstboot client calls directly  the `Yast::NetworkAutoconfiguration.instace.setup_dhcp`method ([see](https://github.com/yast/yast-firstboot/blob/master/src/clients/firstboot_setup_dhcp.rb#L4)) which has been modified recently (https://github.com/yast/yast-network/pull/997).

We basically moved the read of the configuration to another method.

https://github.com/yast/yast-network/pull/997/files#diff-fd690548c8d9ccc25675e4b0e82a0b49L52

- https://bugzilla.opensuse.org/show_bug.cgi?id=1157429

## Solution

Just add back the read of the configuration ensuring it has been read before checking it.