### PR TITLE
Skip not valid udev rule parts when reading drivers

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Nov 25 08:34:55 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Ignores invalid udev rules parts (bsc#1157361)
+- 4.2.31
+
+-------------------------------------------------------------------
 Thu Nov 21 10:57:33 UTC 2019 - Knut Alejandro Anderssen González <knut.anderssen@suse.com>
 
 - Firsboot dhcp: Ensure the network configuration has been read

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.30
+Version:        4.2.31
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -192,7 +192,7 @@ module Y2Network
 
         rules_map = Yast::SCR.Read(Yast::Path.new(".udev_persistent.#{group}")) || {}
         @all[group] = rules_map.values.map do |parts|
-          udev_parts = parts.map { |p| UdevRulePart.from_string(p) }
+          udev_parts = parts.map { |p| UdevRulePart.from_string(p) }.compact
           new(udev_parts)
         end
       end

--- a/src/lib/y2network/udev_rule_part.rb
+++ b/src/lib/y2network/udev_rule_part.rb
@@ -17,12 +17,15 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast"
+
 module Y2Network
   # Simple class to represent a key-value pair in a {UdevRule}.
   #
   # This class does not check whether operators or keys/values are valid or not. We can implement
   # that logic later if required.
   class UdevRulePart
+    include Yast::Logger
     # Regular expression to match a udev rule part
     PART_REGEXP = Regexp.new("\\A(?<key>[A-Za-z\{\}]+)(?<operator>[^\"]+)\"(?<value>.+)\"\\Z")
 
@@ -45,7 +48,11 @@ module Y2Network
       # @return [UdevRulePart] udev rule object
       def from_string(str)
         match = PART_REGEXP.match(str)
-        return if match.nil?
+
+        if match.nil?
+          log.info("Not matching udev rule: #{str}")
+          return
+        end
 
         new(match[:key], match[:operator], match[:value])
       end

--- a/test/y2network/udev_rule_part_test.rb
+++ b/test/y2network/udev_rule_part_test.rb
@@ -34,6 +34,11 @@ describe Y2Network::UdevRulePart do
       expect(part.operator).to eq("==")
       expect(part.value).to eq("add")
     end
+
+    it "returns nil in case of an invalid udev rule" do
+      part = described_class.from_string("ENV{MODALIAS}==\"\"")
+      expect(part).to be_nil
+    end
   end
 
   describe "#to_s" do


### PR DESCRIPTION
## Problem

When reading the existent udev rules, the parts assigned to the udev rule could have 'nil' entries corresponding to invalid udev rule parts.

- https://bugzilla.suse.com/show_bug.cgi?id=1157361

## Solution

Skip not valid udev rule parts when reading drivers



