### PR TITLE
Wireless: fix auth_mode initialization

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Nov 25 15:02:38 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
-- Use symbols for wireless mode (bsc#1157394)
+- Fix wireless mode and auth_mode initialization (bsc#1157394)
 - 4.2.33
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Nov 25 15:02:38 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Use symbols for wireless mode (bsc#1157394)
+- 4.2.33
+
+-------------------------------------------------------------------
 Mon Nov 25 09:36:43 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - Added a special type for the "Unknown" interfaces omitting them

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.32
+Version:        4.2.33
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/connection_config/wireless.rb
+++ b/src/lib/y2network/connection_config/wireless.rb
@@ -26,8 +26,8 @@ module Y2Network
       # wireless options
       #
       # FIXME: Consider an enum
-      # @return [Symbol] (:ad-hoc, :managed, :master)
-      attr_accessor :mode
+      # @return [String] (ad-hoc, managed, master)
+      attr_reader :mode
       # @return [String]
       attr_accessor :essid
       # @return [String] Network ID
@@ -77,7 +77,7 @@ module Y2Network
       def initialize
         super
 
-        self.mode = :managed
+        self.mode = "managed"
         self.essid = ""
         self.nwid = ""
         self.auth_mode = :open
@@ -101,6 +101,11 @@ module Y2Network
          :client_key].all? do |method|
           public_send(method) == other.public_send(method)
         end
+      end
+
+      # @param wireless_mode [String]
+      def mode=(wireless_mode)
+        @mode = wireless_mode.to_s.downcase
       end
     end
   end

--- a/src/lib/y2network/connection_config/wireless.rb
+++ b/src/lib/y2network/connection_config/wireless.rb
@@ -26,7 +26,7 @@ module Y2Network
       # wireless options
       #
       # FIXME: Consider an enum
-      # @return [String] (Ad-hoc, Managed, Master)
+      # @return [Symbol] (:ad-hoc, :managed, :master)
       attr_accessor :mode
       # @return [String]
       attr_accessor :essid
@@ -77,7 +77,7 @@ module Y2Network
       def initialize
         super
 
-        self.mode = "Managed"
+        self.mode = :managed
         self.essid = ""
         self.nwid = ""
         self.auth_mode = :open

--- a/src/lib/y2network/sysconfig/interface_file.rb
+++ b/src/lib/y2network/sysconfig/interface_file.rb
@@ -228,8 +228,8 @@ module Y2Network
       define_variable(:wireless_auth_mode, :symbol)
 
       # @!attribute [r] wireless_mode
-      #  @return [Symbol] Operating mode for the device (:managed, :ad_hoc or :master)
-      define_variable(:wireless_mode, :symbol)
+      #  @return [String] Operating mode for the device (managed, ad-hoc or master)
+      define_variable(:wireless_mode, :string)
 
       # @!attribute [r] wireless_wpa_password
       #  @return [String] Password as configured on the RADIUS server (for WPA-EAP)

--- a/src/lib/y2network/widgets/wireless.rb
+++ b/src/lib/y2network/widgets/wireless.rb
@@ -66,10 +66,10 @@ module Y2Network
         encryption_widget.enable
         case auth_mode_widget.value
         when "wpa-eap"
-          mode_widget.value = "Managed"
+          mode_widget.value = "managed"
           encryption_widget.disable
         when "wpa-psk"
-          mode_widget.value = "Managed"
+          mode_widget.value = "managed"
         when "wep"
           encryption_widget.disable
           wep_keys_widget.enable

--- a/src/lib/y2network/widgets/wireless_auth_mode.rb
+++ b/src/lib/y2network/widgets/wireless_auth_mode.rb
@@ -29,7 +29,7 @@ module Y2Network
       end
 
       def init
-        self.value = @settings.auth_mode
+        self.value = @settings.auth_mode.to_s if @settings.auth_mode
       end
 
       def label
@@ -58,7 +58,7 @@ module Y2Network
       end
 
       def store
-        @settings.auth_mode = value
+        @settings.auth_mode = value.to_sym
       end
     end
   end

--- a/src/lib/y2network/widgets/wireless_mode.rb
+++ b/src/lib/y2network/widgets/wireless_mode.rb
@@ -34,7 +34,7 @@ module Y2Network
       end
 
       def init
-        self.value = @config.mode.to_s if @config.mode
+        self.value = @config.mode
       end
 
       # notify when mode change as it affect other elements
@@ -43,7 +43,7 @@ module Y2Network
       end
 
       def store
-        @config.mode = value.to_sym
+        @config.mode = value
       end
 
       def items

--- a/src/lib/y2network/widgets/wireless_mode.rb
+++ b/src/lib/y2network/widgets/wireless_mode.rb
@@ -34,7 +34,7 @@ module Y2Network
       end
 
       def init
-        self.value = @config.mode
+        self.value = @config.mode.to_s if @config.mode
       end
 
       # notify when mode change as it affect other elements
@@ -43,13 +43,13 @@ module Y2Network
       end
 
       def store
-        @config.mode = value
+        @config.mode = value.to_sym
       end
 
       def items
         [
           ["ad-hoc", _("Ad-hoc")],
-          ["Managed", _("Managed")],
+          ["managed", _("Managed")],
           ["master", _("Master")]
         ]
       end

--- a/test/y2network/sysconfig/connection_config_readers/wireless_test.rb
+++ b/test/y2network/sysconfig/connection_config_readers/wireless_test.rb
@@ -48,7 +48,7 @@ describe Y2Network::Sysconfig::ConnectionConfigReaders::Wireless do
       wlan = handler.connection_config
       expect(wlan).to have_attributes(
         interface:    "wlan0",
-        mode:         :managed,
+        mode:         "managed",
         essid:        "example_ssid",
         ap_scanmode:  "1",
         auth_mode:    :eap,
@@ -110,7 +110,7 @@ describe Y2Network::Sysconfig::ConnectionConfigReaders::Wireless do
       wlan = handler.connection_config
       expect(wlan).to have_attributes(
         auth_mode: :open,
-        mode:      :managed
+        mode:      "managed"
       )
     end
   end


### PR DESCRIPTION
## Problem

There is some type mismatch when reading existing wireless interface files and when initializing the wireless mode widget because of different types used. In some cases we use strings and in others we use symbols.

- https://bugzilla.opensuse.org/show_bug.cgi?id=1157394

## Solution

Use strings for `wireless mode` by now as the 'ad-hoc' mode needs some special handling in the interface file in case of symbol. By now we just ensure the mode is downcased when assigned to the connection config.

## Test

- Tested manually configuring a wireless interface with different modes verifying attributes are written correctly and also not lost when the client is called again with an existing wireless configuration.