### PR TITLE
Added supported interface types.

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 26 15:16:04 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Drop support for obsolete network device types (jsc#SLE-7753)
+- 4.2.34
+
+-------------------------------------------------------------------
 Mon Nov 25 15:02:38 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix wireless mode and auth_mode initialization (bsc#1157394)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.33
+Version:        4.2.34
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/interface_type.rb
+++ b/src/lib/y2network/interface_type.rb
@@ -19,6 +19,8 @@
 
 require "yast"
 
+Yast.import "Arch"
+
 module Y2Network
   # This class represents the interface types which are supported.
   # Class have helpers to check if given type is what needed. It check name and also short name:
@@ -38,6 +40,13 @@ module Y2Network
         @all ||= InterfaceType.constants
           .map { |c| InterfaceType.const_get(c) }
           .select { |c| c.is_a?(InterfaceType) }
+      end
+
+      # Returns all the supported interfaces for the current architecture
+      #
+      # @return [Array<InterfaceType>] Interface types
+      def supported
+        SUPPORTED_COMMON + (Yast::Arch.s390 ? SUPPORTED_S390 : UNSUPPORTED_S390)
       end
 
       # Returns the interface type with a given short name
@@ -151,5 +160,9 @@ module Y2Network
     LO = new(N_("Loopback"), "lo")
     # Unknown interfaces
     UNKNOWN = new(N_("Unknown"), "unknown")
+
+    SUPPORTED_COMMON = [ETHERNET, VLAN, BRIDGE, TUN, TAP, BONDING].freeze
+    SUPPORTED_S390 = [HSI, CTC, FICON, QETH, LCS].freeze
+    UNSUPPORTED_S390 = [DUMMY, WIRELESS, INFINIBAND].freeze
   end
 end

--- a/src/lib/y2network/widgets/interface_type.rb
+++ b/src/lib/y2network/widgets/interface_type.rb
@@ -19,8 +19,7 @@
 
 require "yast"
 require "cwm/common_widgets"
-
-Yast.import "NetworkInterfaces"
+require "y2network/interface_type"
 
 module Y2Network
   module Widgets
@@ -49,8 +48,8 @@ module Y2Network
       end
 
       def items
-        Yast::NetworkInterfaces.GetDeviceTypes.map do |type|
-          [type, Yast::NetworkInterfaces.GetDevTypeDescription(type, _long_desc = false)]
+        Y2Network::InterfaceType.supported.map do |type|
+          [type.short_name, type.to_human_string]
         end
       end
 

--- a/test/y2network/interface_type_test.rb
+++ b/test/y2network/interface_type_test.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require_relative "../test_helper"
+require "y2network/interface_type"
 
 describe Y2Network::InterfaceType do
   subject(:ethernet) { described_class.from_short_name("eth") }
@@ -33,6 +34,35 @@ describe Y2Network::InterfaceType do
     it "returns all known interface types" do
       expect(described_class.all).to_not be_empty
       expect(described_class.all.first).to be_a described_class
+    end
+  end
+
+  describe ".supported" do
+
+    before do
+      allow(Yast::Arch).to receive(:s390).and_return(on_s390)
+    end
+
+    context "when not running on s390 architecture" do
+      let(:on_s390) { false }
+
+      it "returns all supported interface types except the s390 specific" do
+        supported_interfaces = described_class.supported
+        expect(supported_interfaces).to include(Y2Network::InterfaceType::ETHERNET)
+        expect(supported_interfaces).to include(Y2Network::InterfaceType::DUMMY)
+        expect(supported_interfaces).to_not include(Y2Network::InterfaceType::QETH)
+      end
+    end
+
+    context "when running on s390 architecture" do
+      let(:on_s390) { true }
+
+      it "returns s390 supported interface types" do
+        supported_interfaces = described_class.supported
+        expect(supported_interfaces).to include(Y2Network::InterfaceType::QETH)
+        expect(supported_interfaces).to include(Y2Network::InterfaceType::VLAN)
+        expect(supported_interfaces).to_not include(Y2Network::InterfaceType::WIRELESS)
+      end
     end
   end
 


### PR DESCRIPTION
##  Problem

There are many network interfaces that are rarely used or the support in SUSE has been deprecated. As we do not plant to support them in network-ng we should remove them in order to not be offered when adding a new connection.

The current list is obtained by the 'Yast::NetworkInterfaces.GetDeviceTypes' method.. see https://github.com/yast/yast-yast2/pull/981

In that PR, it was [recommended](https://github.com/yast/yast-yast2/pull/981/files#r348982058) to remove the dependency moving it to ther InterfaceType class.

Trello Card: https://trello.com/c/qg8k5n8y/1379-3-feature-jscsle-7753-drop-deprecated-network-technologies-in-yast2

## Solution

Define in the InterfaceType class the supported interfaces and remove the dependency on Yast::NetworkInterfaces for adding new connections.

## Test

- Added unit test for the new `Y2Network::InterfaceType.supported` class method.
- Tested manually

## Screenshots

![Add Interface](https://user-images.githubusercontent.com/7056681/69649197-97eeb900-1064-11ea-8919-287233a89af8.png)

![Add Interface Ncurses](https://user-images.githubusercontent.com/7056681/69649352-d4221980-1064-11ea-9207-639f86cdab33.png)

