### PR TITLE
Fixed internal error in AY's second stage

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Dec  4 09:51:38 UTC 2019 - Michal Filka <mfilka@suse.com>
+
+- bnc#1158122
+  - fixed internal error when incorrectly querying for hostname in
+    AY's second stage
+- 4.2.35 
+
+-------------------------------------------------------------------
 Tue Nov 26 15:16:04 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - Drop support for obsolete network device types (jsc#SLE-7753)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.34
+Version:        4.2.35
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/hostname_reader.rb
+++ b/src/lib/y2network/hostname_reader.rb
@@ -25,7 +25,7 @@ require "network/wicked"
 Yast.import "FileUtils"
 Yast.import "Hostname"
 Yast.import "IP"
-Yast.import "Mode"
+Yast.import "Stage"
 Yast.import "NetHwDetection"
 
 module Y2Network
@@ -49,7 +49,7 @@ module Y2Network
     #
     # @return [String]
     def hostname
-      if Yast::Mode.installation || Yast::Mode.autoinst
+      if Yast::Stage.initial
         hostname_for_installer
       else
         hostname_for_running_system

--- a/test/y2network/hostname_reader_test.rb
+++ b/test/y2network/hostname_reader_test.rb
@@ -54,7 +54,7 @@ describe Y2Network::HostnameReader do
       let(:install_inf_exists?) { true }
 
       before do
-        allow(Yast::Mode).to receive(:installation).and_return(true)
+        allow(Yast::Stage).to receive(:initial).and_return(true)
       end
 
       it "reads the hostname from /etc/install.conf" do


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1158122

OpenSUSE and SLED (?) specific issue.

Caused by https://github.com/yast/yast-network/pull/1000 when AY's second stage was incorrectly handled as first stage. It caused the internal error as described in the bug - an exception which was raised when a code specific for wicked (and for first stage) was invoked when running with NetworkManager.