### PR TITLE
Use a popup instead of a dialog (add interface config)

### DIFF
--- a/src/lib/y2network/dialogs/add_interface.rb
+++ b/src/lib/y2network/dialogs/add_interface.rb
@@ -17,7 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/dialog"
+require "cwm/popup"
 require "y2network/widgets/interface_type"
 require "y2network/interface_config_builder"
 
@@ -29,13 +29,17 @@ Yast.import "NetworkInterfaces"
 module Y2Network
   module Dialogs
     # Dialog which starts new device creation
-    class AddInterface < CWM::Dialog
+    class AddInterface < CWM::Popup
       def initialize(default: nil)
         @type_widget = Widgets::InterfaceType.new(default: default ? default.short_name : nil)
       end
 
+      def title
+        _("Add interface configuration")
+      end
+
       def contents
-        HBox(
+        MarginBox(1, 0.4,
           @type_widget
         )
       end


### PR DESCRIPTION
## Problem

With the refactorization of network-ng, some workflows and dialogs have changed a little bit. That is the case of the dialog for adding a new interface configuration. 

During the review of #1009 , it was proposed to enhance the current dialog which looks ugly specially in big screens.

| pre_network-ng Qt|   Qt    | Ncurses 80x24 | Ncurses 132x43 |
|   :---:      | :---:   |     :---:     |    :---:       |
| ![PreviousRefactorizationQt](https://user-images.githubusercontent.com/7056681/70426400-e3449680-1a6a-11ea-94cf-87202a9a632f.png) | ![CurrentQtBigScreen](https://user-images.githubusercontent.com/7056681/70217783-bbd38e00-1739-11ea-8975-68f0588076fa.png) | ![CurrentNcursesBigScreen](https://user-images.githubusercontent.com/7056681/70217792-c0984200-1739-11ea-9456-b5a097952025.png) | ![CurrentNcurses80x24](https://user-images.githubusercontent.com/7056681/70217803-c2fa9c00-1739-11ea-812f-ff117925b6e5.png) |

Bear in mind that it is mainly for not present or virtual interfaces as interfaces which are already present but not configured will be recognized by the type read from the hardware information. Thus, the workflow is the same as editing a configured interface.

- https://trello.com/c/3myTtYoM/1478-3-enhance-the-selection-of-the-interface-type-in-network

## Solution

This PR implements one **(option 2)** of the proposed alternatives and also expose others with screenshots and descriptions in order to select the preferable one. There are probably other ways and maybe better alternatives to improve the current dialog, so suggestions are welcomed.

## Alternatives

Adding a new interface configuration is somehow an expert action. In that context the interface type name is already self descriptive. Therefore, it seems that improving the current description could be nice as part of the help dialog but not so relevant for clarifying the option to be chosen. Alternatives **(1, 2 & 5)**  are based on that opinion, while alternatives **(3 & 4)** shows screenshots using the new SingleItemSelector.

### 1. Current dialog but adding a title and centering the content horizontally and veritically

|   Qt    | Ncurses 80x24 | Ncurses 132x43 | Installation |
| :---:   |     :---:     |    :---:       | :---: |
| ![CenterDialogQt](https://user-images.githubusercontent.com/7056681/70439201-5bb95080-1a87-11ea-8d79-eae2b669208d.png)  | ![CenterDialogNcurses80x24](https://user-images.githubusercontent.com/7056681/70439198-5b20ba00-1a87-11ea-9582-56eba127cd83.png) | ![CenterDialogNcurses134x43](https://user-images.githubusercontent.com/7056681/70439200-5b20ba00-1a87-11ea-990a-e502b03539ab.png) | ![Installation](https://user-images.githubusercontent.com/7056681/70458122-608efc00-1aa9-11ea-9382-4962ff3c9ebf.png) |

### 2. Popup dialog with radio buttons

#### Adding ad MarginBox and a title (this PR changes)

|   Qt    | Ncurses 80x24 | Ncurses 132x43 | Installation |
| :---:   |     :---:     |    :---:       |   :---:      |
| ![OnlyMargin_Qt](https://user-images.githubusercontent.com/7056681/70219926-98124700-173d-11ea-9ff2-6802b95a8759.png) | ![OnlyMargin_Ncurses80x24](https://user-images.githubusercontent.com/7056681/70220217-2090e780-173e-11ea-8aff-cdbf31af0028.png) | ![OnlyMargin_Ncurses132x43](https://user-images.githubusercontent.com/7056681/70220219-2090e780-173e-11ea-97b9-9ec039b4d4c3.png) | ![OnlyMarginInstallation_Qt](https://user-images.githubusercontent.com/7056681/70224419-2938ec00-1745-11ea-824c-f8d5ad409d2e.png) |

#### With MarginBox & HVSquash

|   Qt    | Ncurses 80x24 | Ncurses 132x43 |
| :---:   |     :---:     |    :---:       |
|         | ![OnlyMargin_Ncurses80x24](https://user-images.githubusercontent.com/7056681/70219913-95175680-173d-11ea-8e1d-7cbe0ec7a85f.png) | ![OnlyMargin_Ncurses132x43](https://user-images.githubusercontent.com/7056681/70219921-96488380-173d-11ea-8792-b364b545d618.png) |

### 3. Use the new SingleItemSelector

#### The current dialog but using the new SingleItemSelector

|   Qt    | Ncurses 80x24 | Ncurses 132x43 |
| :---:   |     :---:     |    :---:       |
| ![SingleItemSelectorQt](https://user-images.githubusercontent.com/7056681/70250840-708ba080-1776-11ea-900b-d1d89a24305d.png) | | ![SingleItemSelectorNcurses](https://user-images.githubusercontent.com/7056681/70250839-708ba080-1776-11ea-94c6-67e3ed4a01f9.png) |

#### The current dialog but using the new SingleItemSelector and Squashing the content horizontally

|   Qt    | Ncurses 80x24 | Ncurses 132x43 |
| :---:   |     :---:     |    :---:       |
| ![SingleItemSelector_Qt_HSquash](https://user-images.githubusercontent.com/7056681/70244230-e8080280-176b-11ea-82df-6207ee12289a.png) | ![HSquash_SingleItemSelector_ncurses80x24](https://user-images.githubusercontent.com/7056681/70243619-da05b200-176a-11ea-83e7-bd0f0b681d3b.png) | ![HSquash_SingleItemSelector_ncurses_full_screen](https://user-images.githubusercontent.com/7056681/70243626-db36df00-176a-11ea-97f5-5c8c5b34a2c3.png)

#### The current dialog but using the new SingleItemSelector and Squashing the content horizontally and verically

|   Qt    | Ncurses 80x24 | Ncurses 132x43 |
| :---:   |     :---:     |    :---:       |
| ![SingleItemSelector_Qt_HVSquash](https://user-images.githubusercontent.com/7056681/70244241-ecccb680-176b-11ea-9ad2-bca3d8a332cc.png) | | |

### 4. Use SingleItemSelector in a popup dialog
    
|   Qt    | Ncurses 80x24 | Ncurses 132x43 |
| :---:   |     :---:     |    :---:       |
| ![PopupSingleItemSelectorQt](https://user-images.githubusercontent.com/7056681/70252740-da597980-1779-11ea-8bfe-0da0b2a5c0db.png) | | ![PopupSingleItemSelectorNcurses132x43](https://user-images.githubusercontent.com/7056681/70252739-d9c0e300-1779-11ea-8a8a-08629f064d6d.png) |
    
### 5. Use a menu button instead of a separate dialog for selecting the interface type to configure.

#### example from storage-ng

![MenuButton](https://user-images.githubusercontent.com/7056681/70225326-b7fa3880-1746-11ea-98be-f8ab616efbf6.png)


## NOTES

- In the ncurses popup, the buttons do not respect the order and are not aligned as in the wizard, something that is ok in the Qt.
- When running the client in Gnome with xdg-su, the style is basically lost, and frames do not use a background or border in QT.
