### PR TITLE
Add interface dialog: centered and added title (jsc#SLE-7753)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,10 +1,17 @@
 -------------------------------------------------------------------
+Mon Dec 16 08:43:36 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Centered and added title to the add interface dialog
+  (jsc#SLE-7753)
+- 4.2.36
+
+-------------------------------------------------------------------
 Wed Dec  4 09:51:38 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1158122
   - fixed internal error when incorrectly querying for hostname in
     AY's second stage
-- 4.2.35 
+- 4.2.35
 
 -------------------------------------------------------------------
 Tue Nov 26 15:16:04 UTC 2019 - Knut Anderssen <kanderssen@suse.com>

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.35
+Version:        4.2.36
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/dialogs/add_interface.rb
+++ b/src/lib/y2network/dialogs/add_interface.rb
@@ -38,7 +38,7 @@ module Y2Network
 
       def title
         # Translators: Add interface dialog label
-        _("Add interface configuration")
+        _("Add Interface Configuration")
       end
 
       def contents

--- a/src/lib/y2network/dialogs/add_interface.rb
+++ b/src/lib/y2network/dialogs/add_interface.rb
@@ -32,9 +32,12 @@ module Y2Network
     class AddInterface < CWM::Dialog
       def initialize(default: nil)
         @type_widget = Widgets::InterfaceType.new(default: default ? default.short_name : nil)
+
+        textdomain "network"
       end
 
       def title
+        # Translators: Add interface dialog label
         _("Add interface configuration")
       end
 

--- a/src/lib/y2network/dialogs/add_interface.rb
+++ b/src/lib/y2network/dialogs/add_interface.rb
@@ -34,9 +34,17 @@ module Y2Network
         @type_widget = Widgets::InterfaceType.new(default: default ? default.short_name : nil)
       end
 
+      def title
+        _("Add interface configuration")
+      end
+
       def contents
-        HBox(
-          @type_widget
+        HVCenter(
+          HSquash(
+            HBox(
+              @type_widget
+            )
+          )
         )
       end
 

--- a/src/lib/y2network/dialogs/add_interface.rb
+++ b/src/lib/y2network/dialogs/add_interface.rb
@@ -37,7 +37,7 @@ module Y2Network
       end
 
       def title
-        # Translators: Add interface dialog label
+        # Translators: Dialog headline: adding a configuration of a network interface
         _("Add Interface Configuration")
       end
 


### PR DESCRIPTION
Alternative **one** for the improvement of the "add interface" dialog.

|   Qt    | Ncurses 80x24 | Ncurses 132x43 | Installation |
| :---:   |     :---:     |    :---:       | :---: |
| ![CenterDialogQt](https://user-images.githubusercontent.com/7056681/70439201-5bb95080-1a87-11ea-8d79-eae2b669208d.png)  | ![CenterDialogNcurses80x24](https://user-images.githubusercontent.com/7056681/70439198-5b20ba00-1a87-11ea-9582-56eba127cd83.png) | ![CenterDialogNcurses134x43](https://user-images.githubusercontent.com/7056681/70439200-5b20ba00-1a87-11ea-990a-e502b03539ab.png) | ![Installation](https://user-images.githubusercontent.com/7056681/70458122-608efc00-1aa9-11ea-9382-4962ff3c9ebf.png) |

The context and description can be found in #1012 