### PR TITLE
Fixed the proposal of the virtualization configuration

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 17 10:57:27 UTC 2019 - Knut Andersse <kanderssen@suse.com>
+
+- bsc#1156986
+  - Fixed the creation of network configuration for virtualization
+- 4.2.38
+
+-------------------------------------------------------------------
 Tue Dec 17 10:49:05 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1153198, fate#319639

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.37
+Version:        4.2.38
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/hwinfo.rb
+++ b/src/lib/y2network/hwinfo.rb
@@ -255,6 +255,13 @@ module Y2Network
       !!type
     end
 
+    # Return whether the interface has link
+    #
+    # @return [Boolean]
+    def connected?
+      present? && !!link
+    end
+
     # Returns the MAC adress
     #
     # It usually returns the permanent MAC address (defined in the firmware).  However, when

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -34,6 +34,7 @@ module Y2Network
   # @see Y2Network::PhysicalInterface
   # @see Y2Network::VirtualInterface
   class Interface
+    extend Forwardable
     include Yast::Logger
 
     # @return [String] Device name ('eth0', 'wlan0', etc.)
@@ -48,6 +49,8 @@ module Y2Network
     attr_accessor :renaming_mechanism
     # @return [String,nil]
     attr_reader :old_name
+
+    def_delegators :hardware, :drivers, :connected?
 
     class << self
       # Builds an interface based on a connection
@@ -94,14 +97,6 @@ module Y2Network
     # @return [Hash<String, String>] option, value hash map
     def config
       system_config(name)
-    end
-
-    # Returns the list of kernel modules
-    #
-    # @return [Array<Driver>]
-    # @see Hwinfo#drivers
-    def drivers
-      hardware.drivers
     end
 
     # Renames the interface

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -347,7 +347,13 @@ module Y2Network
 
     # @param [String] value
     def remote_ip=(value)
-      ip_config_default.remote_address = IPAddress.from_string(value)
+      return unless ip_config_default
+
+      ip_config_default.remote_address = if value.nil? || value.empty?
+        nil
+      else
+        IPAddress.from_string(value)
+      end
     end
 
     # Gets Maximum Transition Unit
@@ -365,6 +371,9 @@ module Y2Network
     def configure_as_slave
       self.boot_protocol = "none"
       self.aliases = []
+      self.ip_address = nil
+      self.subnet_prefix = ""
+      self.remote_ip = ""
     end
 
     # @param info [Hash<String,Object>] Hardware information

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -334,7 +334,6 @@ module Y2Network
       @connection_config.hostname = value
     end
 
-    # sets remote ip for ptp connections
     # @return [String]
     def remote_ip
       default = @connection_config.ip
@@ -345,7 +344,10 @@ module Y2Network
       end
     end
 
-    # @param [String] value
+    # Sets remote ip for ptp connections
+    #
+    # @param [String, nil] value
+    # @return [IPAddress, nil]
     def remote_ip=(value)
       return unless ip_config_default
 

--- a/src/lib/y2network/interface_config_builders/bridge.rb
+++ b/src/lib/y2network/interface_config_builders/bridge.rb
@@ -52,6 +52,7 @@ module Y2Network
       def save
         ports.each do |port|
           interface = yast_config.interfaces.by_name(port)
+
           connection = yast_config.connections.by_name(port)
           next if connection && connection.startmode.name == "none"
 
@@ -62,6 +63,13 @@ module Y2Network
         end
 
         super
+      end
+
+      def configure_from(connection)
+        [:bootproto, :ip, :ip_aliases, :startmode, :description,
+         :firewall_zone, :hostname].all? do |method|
+          @connection_config.public_send("#{method}=", connection.public_send(method))
+        end
       end
 
       def_delegators :@connection_config,

--- a/src/lib/y2network/virtualization_config.rb
+++ b/src/lib/y2network/virtualization_config.rb
@@ -79,19 +79,20 @@ module Y2Network
 
   private
 
-    # Convenience method that returns true if the current item has link and can
-    # be enslaved in a bridge.
+    # Convenience method that returns true if the interface given is connected
+    # and can be added as a bridge port.
     #
-    # @return [Boolean] true if it is bridgeable
+    # @param bridge_builder [Y2Network::InterfaceConfigBuilders::Bridge]
+    # @param interface [Y2Network::Interface] bridge candidate member
+    # @return [Boolean] true if it is connected and bridgeable
     def connected_and_bridgeable?(bridge_builder, interface)
       if !bridge_builder.bridgeable_interfaces.map(&:name).include?(interface.name)
         log.info "The interface #{interface.name} cannot be proposed as bridge."
         return false
       end
 
-      hwinfo = interface.hardware
-      if !hwinfo.present? || !hwinfo.link
-        log.warn("Lan item #{interface.inspect} has link:false detected")
+      unless interface.connected?
+        log.warn("The interface #{interface.inspect} does not have link")
         return false
       end
 

--- a/src/lib/y2network/virtualization_config.rb
+++ b/src/lib/y2network/virtualization_config.rb
@@ -1,0 +1,120 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2network/interface_config_builder"
+
+Yast.import "LanItems"
+
+module Y2Network
+  # This class is responsible for creating a bridge configuration for
+  # virtualization from the interfaces that are connected and bridgeable.
+  class VirtualizationConfig
+    # @return [Y2Network::Config]
+    attr_reader :config
+
+    # Constructor
+    #
+    # @param config [Y2Network::Config]
+    def initialize(config)
+      @config = config
+    end
+
+    # Obtains the interfaces that are candidates for being bridgeable
+    #
+    # @return [Array<Y2Network::Interface]
+    def bridgeable_candidates
+      builder = Y2Network::InterfaceConfigBuilder.for("br")
+      builder.name = config.interfaces.free_name("br")
+
+      config.interfaces.select { |i| connected_and_bridgeable?(builder, i) }
+    end
+
+    # Iterates over the bridgeable candidates creating a bridge for each of
+    # them. The connection is copied to the bridge when exist and the
+    # interface is added as a bridge port
+    #
+    # @return [Boolean] true when a new bridge was created
+    def create
+      return false if bridgeable_candidates.empty?
+
+      bridgeable_candidates.each do |interface|
+        bridge_builder = bridge_builder_for(interface)
+
+        connection = config.connections.by_name(interface.name)
+        # The configuration of the connection being slaved is copied to the
+        # bridge when exist
+        bridge_builder.configure_from(connection) if connection
+
+        builder = Y2Network::InterfaceConfigBuilder.for(interface.type, config: connection)
+        builder.name = interface.name
+        builder.configure_as_slave
+        builder.save
+
+        # It adds the connection and the virtual interface
+        bridge_builder.save
+
+        # Move routes from the port member to the bridge (bsc#903889)
+        Yast::LanItems.move_routes(builder.name, bridge_builder.name)
+      end
+
+      true
+    end
+
+  private
+
+    # Convenience method that returns true if the current item has link and can
+    # be enslaved in a bridge.
+    #
+    # @return [Boolean] true if it is bridgeable
+    def connected_and_bridgeable?(bridge_builder, interface)
+      if !bridge_builder.bridgeable_interfaces.map(&:name).include?(interface.name)
+        log.info "The interface #{interface.name} cannot be proposed as bridge."
+        return false
+      end
+
+      hwinfo = interface.hardware
+      if !hwinfo.present? || !hwinfo.link
+        log.warn("Lan item #{interface.inspect} has link:false detected")
+        return false
+      end
+
+      if interface.type.wireless?
+        log.warn("Not proposing WLAN interface for lan item: #{interface.inspect}")
+        return false
+      end
+      true
+    end
+
+    # Convenience method for initializing a new bridge builder with the
+    # interface given as a port member
+    #
+    # @param interface [Y2Network::Interface]
+    def bridge_builder_for(interface)
+      bridge_builder = Y2Network::InterfaceConfigBuilder.for("br")
+      bridge_builder.name = config.interfaces.free_name("br")
+
+      bridge_builder.ports = [interface.name]
+      bridge_builder.startmode = "auto"
+      bridge_builder.boot_protocol = "dhcp"
+
+      bridge_builder
+    end
+  end
+end

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -204,7 +204,8 @@ describe Yast::NetworkAutoconfiguration do
       allow(Y2Network::Config).to receive(:find).with(:system).and_return(system_config)
       allow(instance).to receive(:virtual_proposal_required?).and_return(proposal)
       allow(yast_config).to receive(:write)
-      allow(Yast::Lan).to receive(:connected_and_bridgeable?).and_return(true)
+      allow_any_instance_of(Y2Network::VirtualizationConfig)
+        .to receive(:connected_and_bridgeable?).and_return(true)
       allow(Yast::PackageSystem).to receive(:Installed).and_return(true)
       Yast::Lan.Import(
         "routing" => { "routes" => routes_profile }

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -169,11 +169,11 @@ describe Yast::NetworkAutoconfiguration do
     let(:route) do
       Y2Network::Route.new(to:        :default,
                            gateway:   IPAddr.new("192.168.122.1"),
-                           interface: eth0)
+                           interface: eth5)
     end
-    let(:eth0) { Y2Network::Interface.new("eth0") }
+    let(:eth5) { Y2Network::Interface.new("eth5") }
     let(:br0) { Y2Network::Interface.new("br0") }
-    let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, br0]) }
+    let(:interfaces) { Y2Network::InterfacesCollection.new([eth5, br0]) }
     let(:yast_config) do
       Y2Network::Config.new(interfaces: interfaces, routing: routing, source: :testing)
     end
@@ -219,7 +219,7 @@ describe Yast::NetworkAutoconfiguration do
     end
 
     context "when the proposal is required" do
-      let(:interfaces) { Y2Network::InterfacesCollection.new([eth0]) }
+      let(:interfaces) { Y2Network::InterfacesCollection.new([eth5]) }
       let(:proposal) { true }
 
       it "creates the virtulization proposal config" do
@@ -236,7 +236,7 @@ describe Yast::NetworkAutoconfiguration do
 
       context "and the routing config was modified" do
         it "moves the routes from the enslaved interface to the bridge" do
-          expect { instance.configure_virtuals }.to change { route.interface }.from(eth0).to(br0)
+          expect { instance.configure_virtuals }.to change { route.interface }.from(eth5).to(br0)
         end
 
         it "writes the routing config" do

--- a/test/y2network/hwinfo_test.rb
+++ b/test/y2network/hwinfo_test.rb
@@ -170,6 +170,35 @@ describe Y2Network::Hwinfo do
     end
   end
 
+  describe "#connected?" do
+    context "when the interface is present" do
+      let(:link) { true }
+      subject(:hwinfo) { described_class.new("type" => "eth", "link" => link) }
+
+      context "and has link" do
+        it "return true if has link" do
+          expect(hwinfo.connected?).to eq(true)
+        end
+      end
+
+      context "and does not have link" do
+        let(:link) { false }
+        it "return false" do
+          expect(hwinfo.connected?).to eq(false)
+        end
+      end
+    end
+
+    context "when the interface is not present" do
+      subject(:hwinfo) { described_class.new({}) }
+
+      it "returns false" do
+        expect(hwinfo.connected?).to eq(false)
+      end
+    end
+
+  end
+
   describe "#mac" do
     before do
       allow(hwinfo).to receive(:permanent_mac).and_return(permanent_mac)

--- a/test/y2network/virtualization_config_test.rb
+++ b/test/y2network/virtualization_config_test.rb
@@ -1,0 +1,108 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+require_relative "../test_helper"
+require "y2network/virtualization_config"
+
+describe Y2Network::VirtualizationConfig do
+  let(:virt_config) { described_class.new(config) }
+  let(:config) do
+    Y2Network::Config.new(interfaces: interfaces, connections: connections, source: :testing)
+  end
+  let(:connections) do
+    Y2Network::ConnectionConfigsCollection.new([eth0_conn, eth1_conn])
+  end
+  let(:ip) do
+    Y2Network::ConnectionConfig::IPConfig.new(Y2Network::IPAddress.new("192.168.122.2", 24))
+  end
+  let(:eth0) { Y2Network::Interface.new("eth0") }
+  let(:eth1) { Y2Network::Interface.new("eth1") }
+  let(:eth2) { Y2Network::Interface.new("eth2") }
+  let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, eth1, eth2]) }
+  let(:eth1_conn) do
+    Y2Network::ConnectionConfig::Ethernet.new.tap do |conn|
+      conn.interface = "eth1"
+      conn.name = "eth1"
+      conn.bootproto = :dhcp
+      conn.startmode = Y2Network::Startmode.create("auto")
+    end
+  end
+
+  let(:eth0_conn) do
+    Y2Network::ConnectionConfig::Ethernet.new.tap do |conn|
+      conn.interface = "eth0"
+      conn.name = "eth0"
+      conn.startmode = Y2Network::Startmode.create("auto")
+      conn.bootproto = :static
+      conn.ip = ip
+    end
+  end
+
+  before do
+    allow(virt_config).to receive(:connected_and_bridgeable?).and_return(false)
+    allow(virt_config).to receive(:connected_and_bridgeable?).with(anything, eth0).and_return(true)
+    allow(virt_config).to receive(:connected_and_bridgeable?).with(anything, eth1).and_return(true)
+  end
+
+  describe ".bridgeable_candidates" do
+    it "selects the interfaces that are connected and bridgeable" do
+      candidates = virt_config.bridgeable_candidates
+      expect(candidates.size).to eq(2)
+      expect(candidates).to_not include(eth2)
+      expect(candidates).to include(eth0, eth1)
+    end
+  end
+
+  describe ".create" do
+    before do
+      Y2Network::Config.add(:yast, config)
+    end
+
+    context "when there are some interfaces that are connected and bridgeable" do
+      it "creates a bridge from each of them" do
+        virt_config.create
+        expect(config.connections.size).to eq(4)
+        expect(config.connections.by_name("br0")).to_not be_nil
+      end
+
+      it "copies the connection configuration of the interface to the bridge" do
+        virt_config.create
+        bridge = config.connections.by_name("br0")
+        expect(bridge.name).to eq("br0")
+        expect(bridge.ip.address.to_s).to eq("192.168.122.2/24")
+      end
+
+      it "adds the interface as a port member of the new bridge" do
+        virt_config.create
+        bridge = config.connections.by_name("br1")
+        expect(bridge.ports).to eq(["eth1"])
+      end
+
+      it "returns true" do
+        expect(virt_config.create).to eq(true)
+      end
+    end
+
+    context "when there are no connected and bridgeable interfaces" do
+      it "returns false" do
+        allow(virt_config).to receive(:bridgeable_candidates).and_return([])
+        expect(virt_config.create).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

With network-ng, a regression was introduced in the network virtualization proposal.

That is, if for example there is only one interface configured by dhcp , it is skipped as bridge port candidate because it is already configured (of course same happen with any configured interface):

https://github.com/yast/yast-network/blob/master/src/modules/Lan.rb#L752

Introduced by:

https://github.com/yast/yast-network/commit/4e0a75e588a480bcbe3d5b366e6a20eb65cc65bb#diff-a44342e8d97412ca7486bd2d61e8e429L864

The configuration of the interface should be copied to the bridge and it should be added as a bridge port as it was in the past.

The issue was detected as consequence of these bugs, which has been closed as the crash should not happen with last changes in network-ng but will face the described regression:

- https://bugzilla.suse.com/show_bug.cgi?id=1153373
- https://bugzilla.suse.com/show_bug.cgi?id=1155852


https://trello.com/c/Dh9D0SIi/1443-sles15-sp2-p2-1156986-yast-does-not-propose-configured-interfaces-for-virtualization-bridges

## Solution

The configuration is created again and the logic has been moved to its own class.

## Tests

- Created unit tests and tested manually in a running system with the virtualization client