### PR TITLE
Fixed compatibility between old and new DNS / Hostname code

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan  2 08:54:15 UTC 2020 - Michal Filka <mfilka@suse.com>
+
+- bnc#1153198, fate#319639
+  - fixed internal error caused by incompatibility between new and
+    old DNS / Hostname handling code.
+- 4.2.41
+
+-------------------------------------------------------------------
 Fri Dec 27 11:37:02 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - read properly old wireless auth modes and use new ones instead

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.40
+Version:        4.2.41
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/complex.rb
+++ b/src/include/network/complex.rb
@@ -42,67 +42,6 @@ module Yast
       Builtins.sformat("<a href=\"%1\">%2</a>", href, text)
     end
 
-    def CheckEmptyName(devtype, hwname)
-      return hwname if !hwname.nil? && hwname != ""
-
-      device_names = {
-        # Device type label
-        "contr-pcmcia" => _("PCMCIA ISDN Card"),
-        # Device type label
-        "contr-usb"    => _("USB ISDN Card"),
-        # Device type label
-        "eth-pcmcia"   => _("PCMCIA Ethernet Network Card"),
-        # Device type label
-        "eth-usb"      => _("USB Ethernet Network Card"),
-        # Device type label
-        "fddi-pcmcia"  => _("PCMCIA FDDI Network Card"),
-        # Device type label
-        "fddi-usb"     => _("USB FDDI Network Card"),
-        # Device type label
-        "ippp-pcmcia"  => _("PCMCIA ISDN Connection"),
-        # Device type label
-        "ippp-usb"     => _("USB ISDN Connection"),
-        # Device type label
-        "isdn-pcmcia"  => _("PCMCIA ISDN Connection"),
-        # Device type label
-        "isdn-usb"     => _("USB ISDN Connection"),
-        # Device type label
-        "modem-pcmcia" => _("PCMCIA Modem"),
-        # Device type label
-        "modem-usb"    => _("USB Modem"),
-        # Device type label
-        "ppp-pcmcia"   => _("PCMCIA Modem"),
-        # Device type label
-        "ppp-usb"      => _("USB Modem"),
-        # Device type label
-        "tr-pcmcia"    => _(
-          "PCMCIA Token Ring Network Card"
-        ),
-        # Device type label
-        "tr-usb"       => _("USB Token Ring Network Card"),
-        # Device type label
-        "usb-usb"      => _("USB Network Device"),
-        # Device type label
-        "wlan-pcmcia"  => _("PCMCIA Wireless Network Card"),
-        # Device type label
-        "wlan-usb"     => _("USB Wireless Network Card")
-      }
-
-      return Ops.get_string(device_names, devtype, "") if Builtins.haskey(device_names, devtype)
-
-      descr = NetworkInterfaces.GetDevTypeDescription(devtype, true)
-      return descr if IsNotEmpty(descr)
-
-      if Builtins.haskey(device_names, Ops.add(devtype, "-"))
-        Builtins.y2warning("- device found: %1, %2", devtype, hwname)
-        return Ops.get_string(device_names, Ops.add(devtype, "-"), "")
-      end
-
-      Builtins.y2error("Unknown type: %1", devtype)
-      # Device type label
-      _("Unknown Network Device")
-    end
-
     def HardwareName(hardware, id)
       return "" if id.nil? || id.empty?
       return "" if hardware.nil? || hardware.empty?

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -65,11 +65,16 @@ module Yast
       end
     end
 
-    define_hostname_config_method :hostname
+    define_hostname_config_method :static
     define_dns_config_method :nameservers
     define_dns_config_method :searchlist
     define_hostname_config_method :dhcp_hostname
     define_dns_config_method :resolv_conf_policy
+
+    # for backward compatibility as long as old DNS module is used as an API
+    # for new dns and hostname classes
+    alias_method :hostname, :static
+    alias_method :hostname=, :static=
 
     def main
       Yast.import "UI"

--- a/test/dns_test.rb
+++ b/test/dns_test.rb
@@ -39,7 +39,7 @@ describe Yast::DNS do
     Y2Network::DNS.new
   end
   let(:hostname_config) do
-    Y2Network::Hostname.new(hostname: "install", dhcp_hostname: true)
+    Y2Network::Hostname.new(static: "install", dhcp_hostname: true)
   end
 
   subject { Yast::DNS }
@@ -216,6 +216,23 @@ describe Yast::DNS do
       it "returns false" do
         expect(subject.modified).to eq(false)
       end
+    end
+  end
+
+  describe "#hostname" do
+    it "provides static hostname" do
+      expect(subject.hostname).to eq "install"
+    end
+  end
+
+  describe "#hostname=" do
+    let(:hostname_config) do
+      Y2Network::Hostname.new
+    end
+
+    it "sets static hostname" do
+      subject.hostname = "test"
+      expect(subject.hostname).to eq "test"
     end
   end
 end

--- a/test/routines_test.rb
+++ b/test/routines_test.rb
@@ -61,34 +61,6 @@ describe "#PackagesInstall" do
   end
 end
 
-describe "#ValidNicName" do
-  subject(:routines) { RoutinesTestClass.new }
-
-  it "succeedes for valid names" do
-    expect(routines.ValidNicName("eth0")).to be true
-    expect(routines.ValidNicName("eth_0")).to be true
-    expect(routines.ValidNicName("eth-0")).to be true
-    expect(routines.ValidNicName("eth.0")).to be true
-    expect(routines.ValidNicName("eth:0")).to be true
-  end
-
-  it "fails in case of long name" do
-    expect(routines.ValidNicName("0123456789012345")). to be false
-  end
-
-  it "fails when it contains invalid character" do
-    expect(routines.ValidNicName("eth0?")).to be false
-  end
-
-  it "fails for empty string" do
-    expect(routines.ValidNicName("")).to be false
-  end
-
-  it "fails for newline terminated string" do
-    expect(routines.ValidNicName("eth0\n")).to be false
-  end
-end
-
 describe "#DeviceName" do
   subject(:routines) { RoutinesTestClass.new }
   let(:hwinfo_details) do


### PR DESCRIPTION
## Problem ##

Detected by QA.
When user tried to store hostname and internal error was raised (no method).

Related to https://github.com/yast/yast-network/pull/1010

## Solution ##

Introduced reasonable aliases