### PR TITLE
Test that ruby-bindings and CommandLine.rb propagate errors

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan  6 11:54:00 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Add a sanity test for CLI error code reporting (bsc#1144351)
+- 4.2.43
+
+-------------------------------------------------------------------
 Fri Jan  3 10:11:52 UTC 2020 - Michal Filka <mfilka@suse.com>
 
 - bnc#1159970 

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.42
+Version:        4.2.43
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/t/exit-codes.t
+++ b/t/exit-codes.t
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+# a TAP compatible test
+
+# quick and dirty: fail early
+set -eu
+
+# test plan
+echo 1..1
+
+# usage:
+#  foo || tapfail
+#  echo "ok"
+# this will tell TAP "not ok" IF foo has failed
+tapfail() {
+  echo -n "not "
+}
+
+YAST=/usr/sbin/yast
+
+TEST="1 An unknown command produces an error exit code"
+echo "# $TEST"
+! $YAST lan nosuchcommand || tapfail
+echo "ok $TEST"


### PR DESCRIPTION
Related to https://github.com/yast/yast-ruby-bindings/pull/237

I put it here because it would get run by openQA out of the box: https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/2a5be2f7b668279c5db275de190e7d5cd92c24f7/tests/console/yast2_cmdline.pm