### PR TITLE
Update only needed info when an interface already have an udev rule (bsc#1158025)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ Metrics/BlockLength:
   Max: 86
   Exclude:
     - "test/**/*"
+    - "src/include/network/routines.rb"
 
 # Offense count: 5
 # Configuration parameters: CountComments.

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Wed Jan 15 09:55:05 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- bsc#1158025
+  - When touching existent udev rules, modify only the parts that
+    are relevant or have changed.
+  - When the hardware is read, use the parent_bus_id as the busid
+    for virtio netcards.
+- 4.2.45
+
+-------------------------------------------------------------------
 Wed Jan 15 08:14:48 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - bsc#1156106

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.44
+Version:        4.2.45
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -535,7 +535,12 @@ module Yast
 
           one["bus"] = bus
           one["busid"] = card["sysfs_bus_id"] || ""
-          one["parent_busid"] = one["sysfs_id"].split("/")[-2] if one["busid"].start_with?("virtio")
+
+          if one["busid"].start_with?("virtio")
+            one["sub_device_busid"] = one["busid"]
+            one["busid"] = one["sysfs_id"].split("/")[-2]
+          end
+
           one["mac"] = Ops.get_string(resource, ["hwaddr", 0, "addr"], "")
           one["permanent_mac"] = Ops.get_string(resource, ["phwaddr", 0, "addr"], "")
           # is the cable plugged in? nil = don't know

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -45,6 +45,8 @@ module Y2Network
     attr_accessor :type
     # @return [HwInfo]
     attr_reader :hardware
+    # @return [UdevRule]
+    attr_accessor :udev_rule
     # @return [Symbol] Mechanism to rename the interface (:none -no rename-, :bus_id or :mac)
     attr_accessor :renaming_mechanism
     # @return [String,nil]

--- a/src/lib/y2network/sysconfig/interfaces_reader.rb
+++ b/src/lib/y2network/sysconfig/interfaces_reader.rb
@@ -124,6 +124,7 @@ module Y2Network
       # @param hwinfo [Hash] hardware information
       def build_physical_interface(hwinfo)
         Y2Network::PhysicalInterface.new(hwinfo.dev_name, hardware: hwinfo).tap do |iface|
+          iface.udev_rule = UdevRule.find_for(iface.name)
           iface.renaming_mechanism = renaming_mechanism_for(iface)
           iface.custom_driver = custom_driver_for(iface)
           iface.type = InterfaceType.from_short_name(hwinfo.type) ||
@@ -154,7 +155,7 @@ module Y2Network
       # @param iface [PhysicalInterface] Interface
       # @return [Symbol] :mac (MAC address), :bus_id (BUS ID) or :none (no renaming)
       def renaming_mechanism_for(iface)
-        rule = UdevRule.find_for(iface.name)
+        rule = iface.udev_rule
         return :none unless rule
 
         if rule.parts.any? { |p| p.key == "ATTR{address}" }

--- a/src/lib/y2network/sysconfig/interfaces_writer.rb
+++ b/src/lib/y2network/sysconfig/interfaces_writer.rb
@@ -34,6 +34,7 @@ module Y2Network
     #
     # @see Y2Network::InterfacesCollection
     class InterfacesWriter
+      include Yast::Logger
       # Writes interfaces hardware configuration and refreshes udev
       #
       # @param interfaces [Y2Network::InterfacesCollection] Interfaces collection
@@ -49,6 +50,8 @@ module Y2Network
       # @param iface [Interface] Interface to generate the udev rule for
       # @return [UdevRule,nil] udev rule or nil if it is not needed
       def renaming_udev_rule_for(iface)
+        log.info("Generating a new udev rule for #{iface.name} based on: " \
+                 "#{iface.renaming_mechanism.inspect}")
         case iface.renaming_mechanism
         when :mac
           Y2Network::UdevRule.new_mac_based_rename(iface.name, iface.hardware.mac)
@@ -77,8 +80,33 @@ module Y2Network
         reload_udev_rules
       end
 
+      # Updates the given iface udev rule depending on the renaming mechanism
+      # selected
+      #
+      # @param iface [Interface] Interface to update the udev rule for
+      # @return [UdevRule] udev rule
+      def update_renaming_udev_rule(iface)
+        case iface.renaming_mechanism
+        when :mac
+          iface.udev_rule.rename_by_mac(iface.name, iface.hardware.mac)
+        when :bus_id
+          iface.udev_rule.rename_by_bus_id(iface.name, iface.hardware.busid,
+            iface.hardware.dev_port)
+        end
+
+        iface.udev_rule
+      end
+
+      # Writes down the current interfaces udev rules and the custom rules that
+      # were present when read and that are still valid
+      #
+      # @see Y2Network::UdevRule#write_net_rules
       def update_renaming_udev_rules(interfaces)
-        udev_rules = interfaces.map { |i| renaming_udev_rule_for(i) }.compact
+        udev_rules = interfaces.map do |iface|
+          update_renaming_udev_rule(iface) if iface.udev_rule
+          iface.udev_rule ||= renaming_udev_rule_for(iface)
+        end.compact
+
         known_names = interfaces.known_names
         custom_rules = Y2Network::UdevRule.naming_rules.reject do |u|
           known_names.include?(u.device)
@@ -86,6 +114,7 @@ module Y2Network
         Y2Network::UdevRule.write_net_rules(custom_rules + udev_rules)
       end
 
+      # @see Y2Network::UdevRule#write_drivers_rules
       def update_drivers_udev_rules(interfaces)
         udev_rules = interfaces.map { |i| driver_udev_rule_for(i) }.compact
         Y2Network::UdevRule.write_drivers_rules(udev_rules)

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -169,7 +169,7 @@ module Y2Network
       # @param udev_rules [Array<UdevRule>] List of udev rules
       def write_drivers_rules(udev_rules)
         rules_hash = udev_rules.each_with_object({}) do |rule, hash|
-          driver = rule.part_value_for("ENV{MODALIAS}", "=")
+          driver = rule.driver
           next unless driver
 
           hash[driver] = rule.parts.map(&:to_s)
@@ -330,6 +330,13 @@ module Y2Network
     # @return [String,nil] Original modalias or nil if not found
     def driver
       part_value_for("ENV{MODALIAS}", "=")
+    end
+
+    # Returns the drivers mentioned in the rule (if any)
+    #
+    # @return [String,nil] drivers or nil if not found
+    def drivers
+      part_value_for("DRIVERS", "==")
     end
   end
 end

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -276,7 +276,9 @@ module Y2Network
       part.key = "ATTR{address}" if part
 
       replace_part("ATTR{address}", "==", address) if mac != address
-      replace_part("NAME", "=", name) if device != name
+      ## Ensure the name is always at the end of the rule
+      parts.delete_if { |p| p.dev_port? || p.name? }
+      add_part("NAME", "=", name)
     end
 
     # Convenience method which takes care of modifing the udev rule using the
@@ -288,7 +290,9 @@ module Y2Network
 
       replace_part("KERNELS", "==", bus_id_value) if bus_id != bus_id_value
       replace_part("ATTR{dev_port}", "==", dev_port_value) if dev_port != dev_port_value
-      replace_part("NAME", "=", name) if device != name
+      ## Ensure the name is always at the end of the rule
+      parts.delete_if(&:name?)
+      add_part("NAME", "=", name)
     end
 
     # Returns the BUS ID in the udev rule

--- a/src/lib/y2network/udev_rule_part.rb
+++ b/src/lib/y2network/udev_rule_part.rb
@@ -112,5 +112,12 @@ module Y2Network
     def mac?
       (key == "ATTR{address}") && (operator == "==")
     end
+
+    # Return whether the udev rule part is the interface name or not
+    #
+    # @return [Boolean]
+    def name?
+      (key == "NAME") && (operator == "=")
+    end
   end
 end

--- a/src/lib/y2network/udev_rule_part.rb
+++ b/src/lib/y2network/udev_rule_part.rb
@@ -92,5 +92,25 @@ module Y2Network
     def to_s
       "#{key}#{operator}\"#{value}\""
     end
+
+    # Return whether the udev rule part is the interface bus_id or not
+    # @return [Boolean]
+    def bus_id?
+      (key == "KERNELS") && (operator == "==")
+    end
+
+    # Return whether the udev rule part is the interface dev_port or not
+    #
+    # @return [Boolean]
+    def dev_port?
+      (key == "ATTR{dev_port}") && (operator == "==")
+    end
+
+    # Return whether the udev rule part is the interface MAC address or not
+    #
+    # @return [Boolean]
+    def mac?
+      (key == "ATTR{address}") && (operator == "==")
+    end
   end
 end

--- a/test/data/hardware.yml
+++ b/test/data/hardware.yml
@@ -19,8 +19,8 @@
   module: virtio_net
   options: ''
   bus: Virtio
-  busid: virtio0
-  parent_busid: '0000:01:00.0'
+  busid: '0000:01:00.0'
+  sub_device_busid: virtio0
   mac: 52:54:00:68:54:fb
   permanent_mac: 52:54:00:68:54:fb
   link: true

--- a/test/y2network/sysconfig/interfaces_reader_test.rb
+++ b/test/y2network/sysconfig/interfaces_reader_test.rb
@@ -82,6 +82,11 @@ describe Y2Network::Sysconfig::InterfacesReader do
       expect(eth0.renaming_mechanism).to eq(:mac)
     end
 
+    it "sets each interface udev rule" do
+      eth0 = reader.interfaces.by_name("eth0")
+      expect(eth0.udev_rule).to eq(udev_rule)
+    end
+
     it "reads wifi interfaces"
     it "reads bridge interfaces"
     it "reads bonding interfaces"

--- a/test/y2network/udev_rule_part_test.rb
+++ b/test/y2network/udev_rule_part_test.rb
@@ -80,4 +80,69 @@ describe Y2Network::UdevRulePart do
       end
     end
   end
+
+  describe "#mac?" do
+    context "when the part is a MAC address" do
+      let(:key) { "ATTR{address}" }
+
+      it "returns true" do
+        expect(part.mac?).to eq(true)
+      end
+    end
+
+    context "otherwise" do
+      it "returns false" do
+        expect(part.mac?).to eq(false)
+      end
+    end
+  end
+
+  describe "#bus_id?" do
+    context "when the part is a BUS ID" do
+      let(:key) { "KERNELS" }
+
+      it "returns true" do
+        expect(part.bus_id?).to eq(true)
+      end
+    end
+
+    context "otherwise" do
+      it "returns false" do
+        expect(part.bus_id?).to eq(false)
+      end
+    end
+  end
+
+  describe "#dev_port?" do
+    context "when the part is a dev port" do
+      let(:key) { "ATTR{dev_port}" }
+
+      it "returns true" do
+        expect(part.dev_port?).to eq(true)
+      end
+    end
+
+    context "otherwise" do
+      it "returns false" do
+        expect(part.dev_port?).to eq(false)
+      end
+    end
+  end
+
+  describe "#name?" do
+    context "when the part is a device name" do
+      let(:key) { "NAME" }
+      let(:operator) { "=" }
+
+      it "returns true" do
+        expect(part.name?).to eq(true)
+      end
+    end
+
+    context "otherwise" do
+      it "returns false" do
+        expect(part.name?).to eq(false)
+      end
+    end
+  end
 end

--- a/test/y2network/udev_rule_test.rb
+++ b/test/y2network/udev_rule_test.rb
@@ -152,6 +152,24 @@ describe Y2Network::UdevRule do
     end
   end
 
+  describe "#replace_part" do
+    let(:rule_part) { Y2Network::UdevRulePart.new("ATTR{address}", "==", "01:23:45:67:89:ab") }
+    context "when there is no udev part for the given 'key' and 'operator'" do
+      it "adds a new part with the given options" do
+        expect { udev_rule.replace_part("ATTR{address}", "==", "01:23:45:67:89:ab") }
+          .to change { udev_rule.parts }.from([]).to([rule_part])
+      end
+    end
+
+    context "when there is a udev part to be replaced by" do
+      it "replaces  the value of the part with the one given" do
+        udev_rule.add_part("NAME", "=", "eth0")
+        udev_rule.replace_part("NAME", "=", "eth1")
+        expect(udev_rule.device).to eq("eth1")
+      end
+    end
+  end
+
   describe "#to_s" do
     let(:parts) do
       [


### PR DESCRIPTION
## Problem

When there is some `change` in the network `configuration` state, **YaST** writes the `udev` rules in its **own form**, that is, we get rid of some of the parts.

For example, the rules created by `write_net_rules` are:

```
# PCI device 0x1af4:0x1041 (virtio-pci)
SUBSYSTEM=="net", ACTION=="add", DRIVERS=="virtio-pci", ATTR{dev_id}=="0x0", KERNELS=="0000:01:00.0", ATTR{type}=="1", KERNEL=="eth*", NAME="eth0"

# PCI device 0x8086:0x10d3 (e1000e)
SUBSYSTEM=="net", ACTION=="add", DRIVERS=="e1000e", ATTR{dev_id}=="0x0", KERNELS=="0000:07:00.0", ATTR{type}=="1", KERNEL=="eth*", NAME="eth1"
```

And after changing some general configuration in network the rules are **rewritten** as:

```
SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{type}=="1", KERNELS=="0000:07:00.0", NAME="eth1"
SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{type}=="1", KERNELS=="virtio0", NAME="eth0"
```

Especially when a `virtio` netcard, YaST overwrites existing udev rules **based on** `busid` with the hwinfo `busid` which is `virtio`, but in that case it should use the `parent_bus_id` "0000:01:00.0". That could be handle by `hwinfo`.

So, in general the bug is about not removing default udev parts created by the udev rule generator if it is not strictly necessary.

- Trello Card: https://trello.com/c/gf2QyfLL
- https://bugzilla.suse.com/show_bug.cgi?id=1158025

## Solution

- Only the udev rule parts that has changed or need to be replaced are now touched.
- When the hardware is read, we use the parent_bus_id as the busid for virtio netcards. The busid exported by hwinfo is stored as a `sub_device_busid`.

## Test

- Added unit test
- Tested manually **(In Build 122.1 with a dud)**