### PR TITLE
Fixed initialization of DNS.dhcp_hostname (bsc#1156106)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan 15 08:14:48 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- bsc#1156106
+  - Fixed the initialization of DNS.dhcp_hostname by the
+    inst_setup_dhcp client
+- 4.2.44
+
+-------------------------------------------------------------------
 Mon Jan  6 11:54:00 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Add a sanity test for CLI error code reporting (bsc#1144351)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.43
+Version:        4.2.44
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/clients/inst_setup_dhcp.rb
+++ b/src/lib/network/clients/inst_setup_dhcp.rb
@@ -62,13 +62,14 @@ module Yast
     # linuxrc sethostname cmdline option if provided or the default value
     # defined in the control file if not.
     def set_dhcp_hostname!
-      DNS.dhcp_hostname =
+      set_dhcp_hostname =
         set_hostname_used? ? set_dhcp_hostname? : DNS.default_dhcp_hostname
 
-      log.info("Write dhcp hostname default: #{DNS.dhcp_hostname}")
+      log.info("Write dhcp hostname default: #{set_dhcp_hostname}")
+      DNS.dhcp_hostname = set_dhcp_hostname ? :any : :none
       SCR.Write(
         Yast::Path.new(".sysconfig.network.dhcp.DHCLIENT_SET_HOSTNAME"),
-        DNS.dhcp_hostname ? "yes" : "no"
+        (DNS.dhcp_hostname == :any) ? "yes" : "no"
       )
       # Flush cache
       SCR.Write(


### PR DESCRIPTION
## Problem

SLE-15 control file enables the set of the hostname by DCHP through the [control file](https://github.com/yast/skelcd-control-leanos/blob/master/control/control.leanos.xml#L21)

That is done by the `inst_setup_dhcp` client

The problem is that it changed from a `Boolean` value to a `Symbol` and now although the option is modified correctly in `/etc/sysconfig/network/dhcp`, in the Hostname/DNS dialog and internally it is set to "no".

![SetHostnameDHCP](https://user-images.githubusercontent.com/7056681/72417500-eec56480-3770-11ea-86af-6cd2553db6ed.png)

https://bugzilla.suse.com/show_bug.cgi?id=1156106

## Solution

Fixed the client for using :any or :none instead of true or false.