### PR TITLE
Fix error while creating bridge under virtualization

### DIFF
--- a/src/lib/y2network/virtualization_config.rb
+++ b/src/lib/y2network/virtualization_config.rb
@@ -27,6 +27,7 @@ module Y2Network
   # virtualization from the interfaces that are connected and bridgeable.
   class VirtualizationConfig
     # @return [Y2Network::Config]
+    include Yast::Logger
     attr_reader :config
 
     # Constructor


### PR DESCRIPTION
connected_and_bridgeable is using log functions. So, class
VirtualizationConfig needs to include Yast::Logger in order to use
log.* functions, else it bugs with:

Caller: 
/usr/share/YaST2/lib/y2network/virtualization_config.rb:100:in `connected_and_bridgeable?'
undefined local variable or method `log' for #Did you mean? load