### PR TITLE
[bsc#1161234] Do not read missing ifcfg files

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 09:16:03 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not try to read an ifcfg-* file that does not exist
+  (bsc#1161234).
+
+-------------------------------------------------------------------
 Wed Jan 22 16:43:21 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Do not crash if install.inf contains an IP address that cannot

--- a/test/y2network/sysconfig/interface_file_test.rb
+++ b/test/y2network/sysconfig/interface_file_test.rb
@@ -76,7 +76,7 @@ describe Y2Network::Sysconfig::InterfaceFile do
       end
     end
 
-    context "when the file for the given interface exists" do
+    context "when the file for the given interface does not exist" do
       let(:interface) { "em1" }
 
       it "returns false" do

--- a/test/y2network/sysconfig/interface_file_test.rb
+++ b/test/y2network/sysconfig/interface_file_test.rb
@@ -65,6 +65,26 @@ describe Y2Network::Sysconfig::InterfaceFile do
     end
   end
 
+  describe "#exist?" do
+    subject(:file) { described_class.new(interface) }
+
+    context "when the file for the given interface exists" do
+      let(:interface) { "eth0" }
+
+      it "returns true" do
+        expect(file.exist?).to eq(true)
+      end
+    end
+
+    context "when the file for the given interface exists" do
+      let(:interface) { "em1" }
+
+      it "returns false" do
+        expect(file.exist?).to eq(false)
+      end
+    end
+  end
+
   describe "#remove" do
     subject(:file) { described_class.find("eth0") }
 


### PR DESCRIPTION
Do not try to read an `ifcfg-*` file that we know in advance that it is missing. See [bsc#1161234](https://bugzilla.suse.com/show_bug.cgi?id=1161234) for further information.