### PR TITLE
S390 activation dialog

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 30 12:37:03 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Bring back the s390 group device activation dialog when editing
+  an offline s390 group device (bsc#1160997)
+- 4.2.48
+
+-------------------------------------------------------------------
 Thu Jan 23 09:16:03 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not try to read an ifcfg-* file that does not exist

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.47
+Version:        4.2.48
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -47,6 +47,8 @@ module Y2Network
     attr_accessor :interfaces
     # @return [ConnectionConfigsCollection]
     attr_accessor :connections
+    # @return [S390GroupDevicesCollection]
+    attr_accessor :s390_devices
     # @return [Routing] Routing configuration
     attr_accessor :routing
     # @return [DNS] DNS configuration
@@ -109,6 +111,7 @@ module Y2Network
     def initialize(source:, **opts)
       @interfaces = opts.fetch(:interfaces, InterfacesCollection.new)
       @connections = opts.fetch(:connections, ConnectionConfigsCollection.new)
+      @s390_devices = opts.fetch(:s390_devices, S390GroupDevicesCollection.new)
       @drivers = opts.fetch(:drivers, [])
       @routing = opts.fetch(:routing, Routing.new)
       @dns = opts.fetch(:dns, DNS.new)
@@ -139,7 +142,8 @@ module Y2Network
         routing == other.routing &&
         dns == other.dns &&
         hostname == other.hostname &&
-        connections == other.connections
+        connections == other.connections &&
+        s390_devices == other.s390_devices
     end
 
     # Renames a given interface and the associated connections

--- a/src/lib/y2network/connection_config/ctc.rb
+++ b/src/lib/y2network/connection_config/ctc.rb
@@ -76,6 +76,13 @@ module Y2Network
 
         [read_channel, write_channel].join(":")
       end
+
+      # Sets the read and write channel from the s390 group device id
+      #
+      # @param id [String] s390 group device id
+      def device_id=(id)
+        @read_channel, @write_channel = id.split(":")
+      end
     end
   end
 end

--- a/src/lib/y2network/connection_config/ctc.rb
+++ b/src/lib/y2network/connection_config/ctc.rb
@@ -81,7 +81,7 @@ module Y2Network
       #
       # @param id [String] s390 group device id
       def device_id=(id)
-        @read_channel, @write_channel = id.split(":")
+        @read_channel, @write_channel = id.to_s.split(":")
       end
     end
   end

--- a/src/lib/y2network/connection_config/lcs.rb
+++ b/src/lib/y2network/connection_config/lcs.rb
@@ -72,6 +72,14 @@ module Y2Network
 
         [read_channel, write_channel].join(":")
       end
+
+      # Sets the read and write channel from the s390 group device id
+      #
+      # @param id [String] s390 group device id
+      def device_id=(id)
+        @read_channel, @write_channel = id.split(":")
+      end
+
     end
   end
 end

--- a/src/lib/y2network/connection_config/lcs.rb
+++ b/src/lib/y2network/connection_config/lcs.rb
@@ -77,7 +77,7 @@ module Y2Network
       #
       # @param id [String] s390 group device id
       def device_id=(id)
-        @read_channel, @write_channel = id.split(":")
+        @read_channel, @write_channel = id.to_s.split(":")
       end
     end
   end

--- a/src/lib/y2network/connection_config/lcs.rb
+++ b/src/lib/y2network/connection_config/lcs.rb
@@ -79,7 +79,6 @@ module Y2Network
       def device_id=(id)
         @read_channel, @write_channel = id.split(":")
       end
-
     end
   end
 end

--- a/src/lib/y2network/connection_config/qeth.rb
+++ b/src/lib/y2network/connection_config/qeth.rb
@@ -80,6 +80,13 @@ module Y2Network
 
         [read_channel, write_channel, data_channel].join(":")
       end
+
+      # Sets the read, write and data channel from the device id
+      #
+      # @param id [String] s390 group device id
+      def device_id=(id)
+        @read_channel, @write_channel, @data_channel = id.split(":")
+      end
     end
   end
 end

--- a/src/lib/y2network/dialogs/s390_device_activation.rb
+++ b/src/lib/y2network/dialogs/s390_device_activation.rb
@@ -80,26 +80,21 @@ module Y2Network
       end
 
       def run
-        ret = nil
-        loop do
-          ret = super
-          if ret == :next
-            _stdout, stderr, status = activator.configure
-            configured = status.zero?
+        ret = super
+        if ret == :next
+          _stdout, stderr, status = activator.configure
+          configured = status.zero?
 
-            if configured
-              interface_name = activator.configured_interface
-              builder.name = interface_name
-              add_interface(interface_name)
-            end
-
-            if !configured || builder.name.empty?
-              show_activation_error(stderr)
-              ret = :redraw
-            end
+          if configured
+            interface_name = activator.configured_interface
+            builder.name = interface_name
+            add_interface(interface_name)
           end
 
-          break if ret != :redraw
+          if !configured || builder.name.empty?
+            show_activation_error(stderr)
+            return run
+          end
         end
 
         ret
@@ -130,8 +125,7 @@ module Y2Network
       end
 
       def add_interface(name)
-        interface = reader.interfaces.by_name(name)
-        config.interfaces << interface if interface
+        config.interfaces << reader.interfaces.by_name(name)
       end
     end
   end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -64,6 +64,8 @@ module Y2Network
     attr_writer :renaming_mechanism
     # @return [Y2Network::Interface,nil] Underlying interface if it exists
     attr_reader :interface
+    # @return [Boolean] True when it is a new connection
+    attr_accessor :newly_added
 
     def_delegators :@connection_config,
       :startmode, :ethtool_options, :ethtool_options=

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -65,7 +65,7 @@ module Y2Network
     # @return [Y2Network::Interface,nil] Underlying interface if it exists
     attr_reader :interface
     # @return [Boolean] True when it is a new connection
-    attr_accessor :newly_added
+    attr_writer :newly_added
 
     def_delegators :@connection_config,
       :startmode, :ethtool_options, :ethtool_options=

--- a/src/lib/y2network/interface_config_builders/ctc.rb
+++ b/src/lib/y2network/interface_config_builders/ctc.rb
@@ -32,7 +32,8 @@ module Y2Network
       def_delegators :@connection_config,
         :read_channel, :read_channel=,
         :write_channel, :write_channel=,
-        :protocol, :protocol=
+        :protocol, :protocol=,
+        :device_id, :device_id=
     end
   end
 end

--- a/src/lib/y2network/interface_config_builders/lcs.rb
+++ b/src/lib/y2network/interface_config_builders/lcs.rb
@@ -33,7 +33,8 @@ module Y2Network
         :read_channel, :read_channel=,
         :write_channel, :write_channel=,
         :protocol, :protocol=,
-        :timeout, :timeout=
+        :timeout, :timeout=,
+        :device_id, :device_id=
     end
   end
 end

--- a/src/lib/y2network/interface_config_builders/qeth.rb
+++ b/src/lib/y2network/interface_config_builders/qeth.rb
@@ -44,7 +44,7 @@ module Y2Network
         :lladdress, :lladdress=,
         :ipa_takeover, :ipa_takeover=,
         :attributes, :attributes=,
-        :device_id
+        :device_id, :device_id=
     end
   end
 end

--- a/src/lib/y2network/presenters/s390_group_device_summary.rb
+++ b/src/lib/y2network/presenters/s390_group_device_summary.rb
@@ -45,12 +45,10 @@ module Y2Network
 
       def text
         device = @config.s390_devices.by_id(@name)
-        busid = device.id.split(":").first
-
         hardware = device.hardware
         descr = hardware ? hardware.description : ""
 
-        rich = Yast::HTML.Bold(descr) + "<br><br>"
+        rich = Yast::HTML.Bold(descr) + "<br>"
         rich << "<b>ID: </b>" << device.id << "<br>"
         rich << "<b>Type: </b>" << device.type.short_name << "<br><br>"
 

--- a/src/lib/y2network/presenters/s390_group_device_summary.rb
+++ b/src/lib/y2network/presenters/s390_group_device_summary.rb
@@ -1,0 +1,65 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+Yast.import "Summary"
+Yast.import "HTML"
+
+module Y2Network
+  module Presenters
+    # This class converts a connection config configuration object into a string to be used
+    # in an AutoYaST summary or in a table.
+    class S390GroupDeviceSummary
+      include Yast::I18n
+      include InterfaceStatus
+
+      # @return [String]
+      attr_reader :name
+
+      # Constructor
+      #
+      # @param name [String] name of device to describe
+      # @param config [Y2Network::Config]
+      def initialize(name, config)
+        textdomain "network"
+        @name = name
+        @config = config
+      end
+
+      def text
+        device = @config.s390_devices.by_id(@name)
+        busid = device.id.split(":").first
+
+        hardware = device.hardware
+        descr = hardware ? hardware.description : ""
+
+        rich = Yast::HTML.Bold(descr) + "<br><br>"
+        rich << "<b>ID: </b>" << device.id << "<br>"
+        rich << "<b>Type: </b>" << device.type.short_name << "<br><br>"
+
+        rich << "<p>"
+        rich << _("The device is not enable. Press <b>Edit</b>\nto enable it.\n")
+        rich << "</p>"
+
+        rich
+      end
+    end
+  end
+end

--- a/src/lib/y2network/s390_device_activator.rb
+++ b/src/lib/y2network/s390_device_activator.rb
@@ -78,7 +78,8 @@ module Y2Network
       cmd = [CONFIGURE_CMD, type.short_name, device_id, "-e"].concat(configure_attributes)
 
       log.info("Activating s390 device: #{device_id}")
-      Yast::Execute.on_target!(*cmd, allowed_exitstatus: 0..255).zero?
+      Yast::Execute.on_target!(*cmd, stdout: :capture, stderr: :capture,
+                               allowed_exitstatus: 0..255)
     end
 
     # Obtains the enabled interface name associated with the device id

--- a/src/lib/y2network/s390_device_activator.rb
+++ b/src/lib/y2network/s390_device_activator.rb
@@ -31,7 +31,7 @@ module Y2Network
     # Command for displaying configuration of z Systems specific devices
     LIST_CMD = "/sbin/lszdev".freeze
 
-    def_delegators :@builder, :type
+    def_delegators :@builder, :type, :device_id
 
     attr_accessor :builder
 
@@ -67,25 +67,6 @@ module Y2Network
     # @return [Array<String>]
     def configure_attributes
       []
-    end
-
-    # The device id to be used by lszdev or chzdev commands
-    #
-    # @return [String, nil]
-    def device_id
-      nil
-    end
-
-    # Returns the complete device id which contains the given channel
-    #
-    # @param channel [String]
-    # @return [String]
-    def device_id_from(channel)
-      cmd = [LIST_CMD, type.short_name, "-c", "id", "-n"]
-
-      Yast::Execute.stdout.on_target!(cmd).split("\n").find do |d|
-        d.include? channel
-      end
     end
 
     # It tries to enable the interface with the configured device id

--- a/src/lib/y2network/s390_device_activators/ctc.rb
+++ b/src/lib/y2network/s390_device_activators/ctc.rb
@@ -28,12 +28,6 @@ module Y2Network
         :write_channel, :write_channel=,
         :hwinfo, :protocol
 
-      def device_id
-        return if read_channel.to_s.empty?
-
-        [read_channel, write_channel].join(":")
-      end
-
       def configure_attributes
         return [] unless builder.protocol
 
@@ -42,7 +36,7 @@ module Y2Network
 
       # Modifies the read and write channel from the the device id
       def propose_channels
-        id = device_id_from(hwinfo.busid)
+        id = builder.name
         return unless id
 
         self.read_channel, self.write_channel = id.split(":")

--- a/src/lib/y2network/s390_device_activators/ctc.rb
+++ b/src/lib/y2network/s390_device_activators/ctc.rb
@@ -36,10 +36,7 @@ module Y2Network
 
       # Modifies the read and write channel from the the device id
       def propose_channels
-        id = builder.name
-        return unless id
-
-        self.read_channel, self.write_channel = id.split(":")
+        builder.device_id = builder.name
       end
 
       def propose!

--- a/src/lib/y2network/s390_device_activators/qeth.rb
+++ b/src/lib/y2network/s390_device_activators/qeth.rb
@@ -29,7 +29,7 @@ module Y2Network
         :write_channel, :write_channel=,
         :data_channel, :data_channel=,
         :layer2, :port_number, :ipa_takeover,
-        :hwinfo, :attributes, :device_id
+        :attributes
 
       # Return a list of the options to be set when activating the device. The
       # list is composed by the attributes configured and the attributes that
@@ -57,7 +57,7 @@ module Y2Network
 
       # Modifies the read, write and data channel from the the device id
       def propose_channels
-        id = device_id_from(hwinfo.busid)
+        id = builder.name
         return unless id
 
         self.read_channel, self.write_channel, self.data_channel = id.split(":")

--- a/src/lib/y2network/s390_group_device.rb
+++ b/src/lib/y2network/s390_group_device.rb
@@ -1,0 +1,101 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/execute"
+require "y2network/interface_type"
+require "y2network/hwinfo"
+
+module Y2Network
+  # This class represents z Systems network devices which requires the use of
+  # multiple I/O subchannels as 'QETH', 'CTC' and 'LCS' devices.
+  class S390GroupDevice
+    include Yast::Logger
+
+    # Command for configuring z Systems specific devices
+    CONFIGURE_CMD = "/sbin/chzdev".freeze
+    # Command for displaying configuration of z Systems specific devices
+    LIST_CMD = "/sbin/lszdev".freeze
+    SUPPORTED_TYPES = ["qeth", "lcs", "ctc"].freeze
+
+    # @return [Y2Network::InterfaceType]
+    attr_accessor :type
+    # @return [String] the device id
+    attr_accessor :id
+    # @return [Y2Network::Interface)
+    attr_accessor :interface
+
+    alias_method :name, :id
+
+    # @param type [String]
+    # @param id [String]
+    # @param interface [Y2Network::Interface]
+    def initialize(type, id, interface)
+      @type = Y2Network::InterfaceType.from_short_name(type)
+      @id = id
+      @interface = interface
+    end
+
+    # Obtains the hwinfo associated with the read channel
+    def hardware
+      Y2Network::Hwinfo.netcards.find { |h| h.busid == id.to_s.split(":").first }
+    end
+
+    # Check whether the device is online or not
+    def online?
+      cmd = [LIST_CMD, id, "-c", "on", "-n"]
+
+      Yast::Execute.stdout.on_target!(cmd).split("\n").first == "yes"
+    end
+
+    class << self
+      # Returns the list of S390 group devices of the given type
+      #
+      # @param type [String] s390 group device type (qeth, ctc or lcs)
+      # @param offline [Boolean] whether should return only offline devices or
+      #   not
+      # @return [Array<Y2Network::S390GroupDevice>] list of s390 group devices
+      def list(type, offline = true)
+        cmd = [LIST_CMD, type, "-c", "id,names", "-n"]
+        cmd << "--offline" if offline
+
+        Yast::Execute.stdout.on_target!(cmd).split("\n").map do |device|
+          id, names = device.split(" ")
+          new(type, id, names)
+        end
+      end
+
+      # Convenience method to obtain the all the supported types s390 group
+      # devices.
+      #
+      # @param offline [Boolean] whether should return only offline devices or
+      #   not
+      # @return [Array<Y2Network::S390GroupDevice>] list of s390 group devices
+      def all(offline: false)
+        SUPPORTED_TYPES.map { |t| list(t, offline) }.flatten
+      end
+
+      # Convenience method to obtain the all the offline s390 network group
+      # devices.
+      def offline
+        all(offline: true)
+      end
+    end
+  end
+end

--- a/src/lib/y2network/s390_group_device.rb
+++ b/src/lib/y2network/s390_group_device.rb
@@ -38,15 +38,15 @@ module Y2Network
     attr_accessor :type
     # @return [String] the device id
     attr_accessor :id
-    # @return [Y2Network::Interface)
+    # @return [Y2Network::Interface,nil)
     attr_accessor :interface
 
     alias_method :name, :id
 
     # @param type [String]
     # @param id [String]
-    # @param interface [Y2Network::Interface]
-    def initialize(type, id, interface)
+    # @param interface [String, nil]
+    def initialize(type, id, interface = nil)
       @type = Y2Network::InterfaceType.from_short_name(type)
       @id = id
       @interface = interface
@@ -75,9 +75,9 @@ module Y2Network
         cmd = [LIST_CMD, type, "-c", "id,names", "-n"]
         cmd << "--offline" if offline
 
-        Yast::Execute.stdout.on_target!(cmd).split("\n").map do |device|
-          id, names = device.split(" ")
-          new(type, id, names)
+        Yast::Execute.locally!(*cmd, stdout: :capture).split("\n").map do |device|
+          id, iface_name = device.split(" ")
+          new(type, id, iface_name)
         end
       end
 

--- a/src/lib/y2network/s390_group_devices_collection.rb
+++ b/src/lib/y2network/s390_group_devices_collection.rb
@@ -64,7 +64,7 @@ module Y2Network
     # @param type [String] device type
     # @return [S390GroupDevicesCollection] list of found devices
     def by_type(type)
-      S390GroupDevicesCollection.new(devices.select { |d| d.type == type })
+      S390GroupDevicesCollection.new(devices.select { |d| d.type.short_name == type })
     end
 
     # Deletes elements which meet a given condition

--- a/src/lib/y2network/s390_group_devices_collection.rb
+++ b/src/lib/y2network/s390_group_devices_collection.rb
@@ -56,7 +56,7 @@ module Y2Network
     # @param id [String] s390 group device id ("eth0", "br1", ...)
     # @return [S390GroupDevice,nil] S390GroupDevice with the given id or nil if not found
     def by_id(id)
-      devices.find { |device| device.id = id }
+      devices.find { |device| device.id == id }
     end
 
     # Returns list of devices of given type

--- a/src/lib/y2network/s390_group_devices_collection.rb
+++ b/src/lib/y2network/s390_group_devices_collection.rb
@@ -1,0 +1,88 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2network/s390_group_device"
+require "y2network/can_be_copied"
+require "forwardable"
+
+module Y2Network
+  # A container for network devices.
+  #
+  # Objects of this class are able to keep a list of s390 group devices and
+  # perform simple queries on such a list.
+  #
+  # @example Finding s390 group device by its id
+  #   devices = Y2Network::S390GroupDevicesCollection.new([qeth_700, qeth_800])
+  #   devices.by_id("0.0.0700:0.0.0701:0.0.0702") #=> qeth_700
+  #
+  class S390GroupDevicesCollection
+    extend Forwardable
+    include Yast::Logger
+    include CanBeCopied
+
+    # @return [Array<S390GroupDevice>] List of devices
+    attr_reader :devices
+    alias_method :to_a, :devices
+
+    def_delegators :@devices, :each, :push, :<<, :reject!, :map, :flat_map, :any?, :size,
+      :select, :find
+
+    # Constructor
+    #
+    # @param devices [Array<S390GroupDevice>] List of devices
+    def initialize(devices = [])
+      @devices = devices
+    end
+
+    # Returns an s390 group device with the given id if present
+    #
+    # @param id [String] s390 group device id ("eth0", "br1", ...)
+    # @return [S390GroupDevice,nil] S390GroupDevice with the given id or nil if not found
+    def by_id(id)
+      devices.find { |device| device.id = id }
+    end
+
+    # Returns list of devices of given type
+    #
+    # @param type [String] device type
+    # @return [S390GroupDevicesCollection] list of found devices
+    def by_type(type)
+      S390GroupDevicesCollection.new(devices.select { |d| d.type == type })
+    end
+
+    # Deletes elements which meet a given condition
+    #
+    # @return [S390GroupDevicesCollection]
+    def delete_if(&block)
+      devices.delete_if(&block)
+      self
+    end
+
+    # Compares S390GroupDevicesCollections
+    #
+    # @return [Boolean] true when both collections contain only equal devices,
+    #                   false otherwise
+    def ==(other)
+      ((devices - other.devices) + (other.devices - devices)).empty?
+    end
+
+    alias_method :eql?, :==
+  end
+end

--- a/src/lib/y2network/sysconfig/config_reader.rb
+++ b/src/lib/y2network/sysconfig/config_reader.rb
@@ -54,14 +54,14 @@ module Y2Network
         )
 
         result = Config.new(
-          interfaces:  interfaces_reader.interfaces,
-          connections: interfaces_reader.connections,
+          interfaces:   interfaces_reader.interfaces,
+          connections:  interfaces_reader.connections,
           s390_devices: interfaces_reader.s390_devices,
-          drivers:     interfaces_reader.drivers,
-          routing:     routing,
-          dns:         dns,
-          hostname:    hostname,
-          source:      :sysconfig
+          drivers:      interfaces_reader.drivers,
+          routing:      routing,
+          dns:          dns,
+          hostname:     hostname,
+          source:       :sysconfig
         )
 
         log.info "Sysconfig reader result: #{result.inspect}"

--- a/src/lib/y2network/sysconfig/config_reader.rb
+++ b/src/lib/y2network/sysconfig/config_reader.rb
@@ -56,6 +56,7 @@ module Y2Network
         result = Config.new(
           interfaces:  interfaces_reader.interfaces,
           connections: interfaces_reader.connections,
+          s390_devices: interfaces_reader.s390_devices,
           drivers:     interfaces_reader.drivers,
           routing:     routing,
           dns:         dns,

--- a/src/lib/y2network/sysconfig/connection_config_readers/qeth.rb
+++ b/src/lib/y2network/sysconfig/connection_config_readers/qeth.rb
@@ -50,7 +50,7 @@ module Y2Network
           id = device_id_from(conn)
           return unless id
 
-          conn.read_channel, conn.write_channel, conn.data_channel = id.split(":")
+          conn.device_id = id
         end
 
         def update_layer2(conn)

--- a/src/lib/y2network/widgets/s390_channels.rb
+++ b/src/lib/y2network/widgets/s390_channels.rb
@@ -63,6 +63,7 @@ module Y2Network
       # @see CWM::AbstractWidget
       def init
         self.value = @settings.read_channel
+        disable
       end
 
       # @see CWM::AbstractWidget
@@ -94,6 +95,7 @@ module Y2Network
       # @see CWM::AbstractWidget
       def init
         self.value = @settings.write_channel
+        disable
       end
 
       # @see CWM::AbstractWidget
@@ -125,6 +127,7 @@ module Y2Network
       # @see CWM::AbstractWidget
       def init
         self.value = @settings.data_channel
+        disable
       end
 
       # @see CWM::AbstractWidget

--- a/test/y2network/dialogs/s390_device_activation_test.rb
+++ b/test/y2network/dialogs/s390_device_activation_test.rb
@@ -45,6 +45,7 @@ describe Y2Network::Dialogs::S390DeviceActivation do
     before do
       allow(activator).to receive(:configure).and_return(configured)
       allow(activator).to receive(:configured_interface).and_return("eth4")
+      allow(subject).to receive(:add_interface)
       allow(subject).to receive(:cwm_show).and_return(dialog_action)
     end
 
@@ -58,6 +59,11 @@ describe Y2Network::Dialogs::S390DeviceActivation do
         it "sets the builder name with the associated interface" do
           subject.run
           expect(builder.name).to eql("eth4")
+        end
+
+        it "adds the new interface to the config" do
+          expect(subject).to receive(:add_interface).with("eth4")
+          subject.run
         end
 
         it "returns :next" do

--- a/test/y2network/s390_device_activators/ctc_test.rb
+++ b/test/y2network/s390_device_activators/ctc_test.rb
@@ -78,26 +78,8 @@ describe Y2Network::S390DeviceActivators::Ctc do
     end
   end
 
-  describe "#device_id_from" do
-    context "given the read or write device id" do
-      let(:device_id) { "0.0.0800:0.0.0801" }
-      let(:write_channel) { "0.0.0801" }
-      let(:hwinfo) { Y2Network::Hwinfo.new("busid" => write_channel) }
-      before do
-        allow(builder).to receive(:hwinfo).and_return(hwinfo)
-        allow(executor).to receive(:on_target!)
-          .with(["/sbin/lszdev", "ctc", "-c", "id", "-n"])
-          .and_return(device_id)
-      end
-
-      it "obtains the triplet device ids listed by lszdev" do
-        expect(subject.device_id_from(hwinfo.busid)).to eq(device_id)
-      end
-    end
-  end
-
   describe "#device_id" do
-    it "returns the read and write channel device ids joined by ':'" do
+    it "returns the s390 group device id" do
       expect(subject.device_id).to eql("0.0.0900:0.0.0901")
     end
   end

--- a/test/y2network/s390_device_activators/ctc_test.rb
+++ b/test/y2network/s390_device_activators/ctc_test.rb
@@ -35,6 +35,7 @@ describe Y2Network::S390DeviceActivators::Ctc do
 
   let(:executor) { double("Yast::Execute", on_target!: "") }
   let(:initialize_channels) { true }
+  let(:chzdev_output) { ["", "", 0] }
 
   before do
     allow(Yast::Execute).to receive(:stdout).and_return(executor)
@@ -45,24 +46,18 @@ describe Y2Network::S390DeviceActivators::Ctc do
   describe "#configure" do
     it "tries to activate the group device associated with the defined device id" do
       expect(Yast::Execute).to receive(:on_target!)
-        .with("/sbin/chzdev", "ctc", subject.device_id, "-e",
-          "protocol=#{builder.protocol}", allowed_exitstatus: 0..255)
-        .and_return(0)
+        .with("/sbin/chzdev", "ctc", subject.device_id, "-e", "protocol=#{builder.protocol}",
+          stdout: :capture, stderr: :capture, allowed_exitstatus: 0..255)
       subject.configure
     end
 
-    context "when activated succesfully" do
-      it "returns true" do
-        expect(Yast::Execute).to receive(:on_target!).and_return(0)
-        expect(subject.configure).to eq(true)
-      end
-    end
+    it "returns an array with the stdout, stderr, and command status" do
+      expect(Yast::Execute).to receive(:on_target!)
+        .with("/sbin/chzdev", "ctc", subject.device_id, "-e", "protocol=#{builder.protocol}",
+          stdout: :capture, stderr: :capture, allowed_exitstatus: 0..255)
+        .and_return(chzdev_output)
 
-    context "when failed the activation and returned a non zero return code" do
-      it "returns false" do
-        expect(Yast::Execute).to receive(:on_target!).and_return(34)
-        expect(subject.configure).to eq(false)
-      end
+      expect(subject.configure).to eq(chzdev_output)
     end
   end
 

--- a/test/y2network/s390_device_activators/ctc_test.rb
+++ b/test/y2network/s390_device_activators/ctc_test.rb
@@ -35,10 +35,10 @@ describe Y2Network::S390DeviceActivators::Ctc do
 
   let(:executor) { double("Yast::Execute", on_target!: "") }
   let(:initialize_channels) { true }
+
   before do
     allow(Yast::Execute).to receive(:stdout).and_return(executor)
-    builder.read_channel = "0.0.0900" if initialize_channels
-    builder.write_channel = "0.0.0901" if initialize_channels
+    builder.device_id = builder.name = "0.0.0900:0.0.0901" if initialize_channels
     builder.protocol = 0
   end
 
@@ -89,11 +89,12 @@ describe Y2Network::S390DeviceActivators::Ctc do
       let(:initialize_channels) { false }
       let(:device_id) { "0.0.0800:0.0.0801" }
       let(:write_channel) { "0.0.0801" }
+
       let(:hwinfo) { Y2Network::Hwinfo.new("busid" => write_channel) }
 
       before do
-        allow(subject).to receive(:device_id_from).with(write_channel).and_return(device_id)
         allow(builder).to receive(:hwinfo).and_return(hwinfo)
+        builder.name = device_id
       end
 
       it "initializes them from the given busid" do
@@ -105,6 +106,7 @@ describe Y2Network::S390DeviceActivators::Ctc do
   describe "#propose!" do
     context "when no device id has been initialized" do
       let(:initialize_channels) { false }
+
       it "proposes the channel device ids to be used" do
         expect(subject).to receive(:propose_channels)
         subject.propose!
@@ -118,5 +120,4 @@ describe Y2Network::S390DeviceActivators::Ctc do
       end
     end
   end
-
 end

--- a/test/y2network/s390_device_activators/qeth_test.rb
+++ b/test/y2network/s390_device_activators/qeth_test.rb
@@ -35,6 +35,8 @@ describe Y2Network::S390DeviceActivators::Qeth do
 
   let(:executor) { double("Yast::Execute", on_target!: "") }
   let(:initialize_channels) { true }
+  let(:chzdev_output) { ["", "", 0] }
+
   before do
     allow(Yast::Execute).to receive(:stdout).and_return(executor)
     if initialize_channels
@@ -48,23 +50,17 @@ describe Y2Network::S390DeviceActivators::Qeth do
     it "tries to activate the group device associated with the defined device id" do
       expect(Yast::Execute).to receive(:on_target!)
         .with("/sbin/chzdev", "qeth", subject.device_id, "-e",
-          allowed_exitstatus: 0..255)
-        .and_return(0)
+          stdout: :capture, stderr: :capture, allowed_exitstatus: 0..255)
       subject.configure
     end
 
-    context "when activated succesfully" do
-      it "returns true" do
-        expect(Yast::Execute).to receive(:on_target!).and_return(0)
-        expect(subject.configure).to eq(true)
-      end
-    end
+    it "returns an array with the stdout, stderr, and command status" do
+      expect(Yast::Execute).to receive(:on_target!)
+        .with("/sbin/chzdev", "qeth", subject.device_id, "-e",
+          stdout: :capture, stderr: :capture, allowed_exitstatus: 0..255)
+        .and_return(chzdev_output)
 
-    context "when failed the activation and returned a non zero return code" do
-      it "returns false" do
-        expect(Yast::Execute).to receive(:on_target!).and_return(34)
-        expect(subject.configure).to eq(false)
-      end
+      expect(subject.configure).to eq(chzdev_output)
     end
   end
 

--- a/test/y2network/s390_device_activators/qeth_test.rb
+++ b/test/y2network/s390_device_activators/qeth_test.rb
@@ -80,24 +80,6 @@ describe Y2Network::S390DeviceActivators::Qeth do
     end
   end
 
-  describe "#device_id_from" do
-    context "given the read or write device id" do
-      let(:device_id) { "0.0.0800:0.0.0801:0.0.0802" }
-      let(:write_channel) { "0.0.0801" }
-      let(:hwinfo) { Y2Network::Hwinfo.new("busid" => write_channel) }
-      before do
-        allow(builder).to receive(:hwinfo).and_return(hwinfo)
-        allow(executor).to receive(:on_target!)
-          .with(["/sbin/lszdev", "qeth", "-c", "id", "-n"])
-          .and_return(device_id)
-      end
-
-      it "obtains the triplet device ids listed by lszdev" do
-        expect(subject.device_id_from(hwinfo.busid)).to eq(device_id)
-      end
-    end
-  end
-
   describe "#device_id" do
     it "returns the read and write channel device ids joined by ':'" do
       expect(subject.device_id).to eql("0.0.0700:0.0.0701:0.0.0702")
@@ -112,8 +94,8 @@ describe Y2Network::S390DeviceActivators::Qeth do
       let(:hwinfo) { Y2Network::Hwinfo.new("busid" => write_channel) }
 
       before do
-        allow(subject).to receive(:device_id_from).with(write_channel).and_return(device_id)
         allow(builder).to receive(:hwinfo).and_return(hwinfo)
+        builder.name = device_id
       end
 
       it "initializes them from the given busid" do

--- a/test/y2network/s390_group_device_test.rb
+++ b/test/y2network/s390_group_device_test.rb
@@ -1,0 +1,36 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2network/s390_group_device"
+
+describe Y2Network::S390GroupDevice do
+  subject(:device) do
+    described_class.new("qeth", "0.0.0700:0.0.0701:0.0.0702")
+  end
+
+  describe "#offline?" do
+  end
+
+  describe ".all" do
+  end
+
+  describe ".list" do
+  end
+end

--- a/test/y2network/s390_group_devices_collection_test.rb
+++ b/test/y2network/s390_group_devices_collection_test.rb
@@ -1,0 +1,81 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2network/s390_group_devices_collection"
+
+describe Y2Network::S390GroupDevicesCollection do
+  subject(:collection) { described_class.new(devices) }
+
+  let(:qeth_0700) { Y2Network::S390GroupDevice.new("qeth", "0.0.0700:0.0.0701:0.0.0702") }
+  let(:qeth_0800) { Y2Network::S390GroupDevice.new("qeth", "0.0.0800:0.0.0801:0.0.0802", "eth0") }
+  let(:devices) { [qeth_0700, qeth_0800] }
+
+  describe "#by_id" do
+    it "returns the s390 group device with the given id" do
+      expect(collection.by_id("0.0.0700:0.0.0701:0.0.0702")).to eq(qeth_0700)
+    end
+  end
+
+  describe "#by_type" do
+    it "returns a collection with all the devices with the given type" do
+      expect(collection.by_type("qeth")).to eq(collection)
+    end
+  end
+
+  describe "#delete_if" do
+    it "deletes elements which meet a condition" do
+      expect(collection.by_id(qeth_0700.id)).to eq(qeth_0700)
+      collection.delete_if { |i| i.id == qeth_0700.id }
+      expect(collection.by_id(qeth_0700.id)).to be_nil
+    end
+
+    it "returns the collection" do
+      same_collection = collection.delete_if { |i| i.id == qeth_0700 }
+      expect(same_collection).to eq(collection)
+    end
+  end
+
+  describe "#==" do
+    context "when the given collection contains the same interfaces" do
+      let(:other) { described_class.new([qeth_0700, qeth_0800]) }
+
+      it "returns true" do
+        expect(collection).to eq(other)
+      end
+    end
+
+    context "when the given collection does not contain the same interfaces" do
+      let(:other) { described_class.new([qeth_0700]) }
+
+      it "returns false" do
+        expect(collection).to_not eq(other)
+      end
+    end
+  end
+
+  describe "#push" do
+    let(:ctc_c000) { Y2Network::S390GroupDevice.new("ctc", "0.0.c000:0.0.c001") }
+
+    it "adds an interface to the list" do
+      collection.push(ctc_c000)
+      expect(collection.by_id(ctc_c000.id)).to eq(ctc_c000)
+    end
+  end
+end

--- a/test/y2network/sysconfig/config_reader_test.rb
+++ b/test/y2network/sysconfig/config_reader_test.rb
@@ -28,6 +28,7 @@ describe Y2Network::Sysconfig::ConfigReader do
   let(:interfaces) { [eth0, wlan0] }
   let(:eth0_config) { instance_double(Y2Network::ConnectionConfig::Ethernet) }
   let(:connections) { [eth0_config] }
+  let(:s390_devices) { [] }
   let(:drivers) { Y2Network::Driver.new("virtio_net", "") }
   let(:routes_file) { instance_double(Y2Network::Sysconfig::RoutesFile, load: nil, routes: []) }
   let(:dns_reader) { instance_double(Y2Network::Sysconfig::DNSReader, config: dns) }
@@ -35,9 +36,10 @@ describe Y2Network::Sysconfig::ConfigReader do
   let(:interfaces_reader) do
     instance_double(
       Y2Network::Sysconfig::InterfacesReader,
-      interfaces:  Y2Network::InterfacesCollection.new(interfaces),
-      connections: connections,
-      drivers:     drivers
+      interfaces:   Y2Network::InterfacesCollection.new(interfaces),
+      connections:  connections,
+      s390_devices: s390_devices,
+      drivers:      drivers
     )
   end
 

--- a/test/y2network/widgets/interfaces_table_test.rb
+++ b/test/y2network/widgets/interfaces_table_test.rb
@@ -54,7 +54,7 @@ describe Y2Network::Widgets::InterfacesTable do
 
   before do
     allow(Yast::Lan).to receive(:yast_config)
-      .and_return(double(interfaces: interfaces, connections: connections))
+      .and_return(double(interfaces: interfaces, connections: connections, s390_devices: []))
     allow(Yast::UI).to receive(:QueryWidget).and_return([])
     allow(subject).to receive(:value).and_return("eth0")
   end


### PR DESCRIPTION
## Problem

When the new interfaces table widget was introduced, the [call](https://github.com/yast/yast-network/pull/926/files#diff-da30c24a016201e350c6d2d9e78a978bL471) for activating the group devices was accidentally removed and it goes directly to the connection config configuration.

Apart of that, the interfaces table shows one line per group device channel. The interfaces are basically read by a `hwinfo --netcard` call although no of them have a name yet (it was the interfaces table id). Which means that in case of editing it will find the first interface without a name instead of the one selected.

![InterfacesPerChannel](https://user-images.githubusercontent.com/7056681/73440057-8cf82380-4348-11ea-957d-82727842e303.png)

Last but not least, the internal config was not refreshed when one of the interfaces was selected and enabled with the activation dialog. That is, the new interface should be shown and the channel devices needed to be removed.

- https://trello.com/c/dWOFuHGr/1584-sles15-sp2-p2-1160997-sles-15-sp2-beta1-cannot-configure-additional-network-interfaces-during-installation-yast
- https://bugzilla.suse.com/show_bug.cgi?id=1160997

## Solution

- S390 offline group devices are shown in the overview dialog and can be enabled pressing 'Edit'. Only the s390 group device is listed (in the past it listed a line per device channel)

![OverviewOfflineS390Devices](https://user-images.githubusercontent.com/7056681/73430638-78ab2b00-4336-11ea-9976-c554ed586d92.png)
![S390ActivationDialog](https://user-images.githubusercontent.com/7056681/73430637-78ab2b00-4336-11ea-844e-01c0f5209329.png)

- When a device is activated the overview (Interfaces Table) is refreshed even if canceled in the connection config sequence.

![OverviewAfterActivation](https://user-images.githubusercontent.com/7056681/73430964-2d454c80-4337-11ea-9c88-7d25d9f5c47a.png)

- Activation errors details will be shown in the popup.

![WrongChannelGiven](https://user-images.githubusercontent.com/7056681/73430634-78129480-4336-11ea-83aa-aa078ec2bbf6.png)
![WrongOptionsGiven](https://user-images.githubusercontent.com/7056681/73430635-78ab2b00-4336-11ea-86c4-39c5914e4f90.png)
![ActivationErrorDetails](https://user-images.githubusercontent.com/7056681/73430636-78ab2b00-4336-11ea-9c93-dd4109c71f4b.png)

## Tests

- Added unit tests
- Tested manually

## TODO

- In case of a connection config exist for the activated interface (for example ifcfg-eth1). It should be merged with the one created for S390 group device. It is already a problem in previous SLE versions so no new because of network-ng. See the image below from SLE-12-SP4 configuration:
![SLE-12-SP4_s390_activation_with_existent_ifcfg-file](https://user-images.githubusercontent.com/7056681/73442984-bf584f80-434d-11ea-86b0-131d6142a07a.png)
 - Having a button at the right or somewhere for showing the s390 group devices summary would be nice to have as we have for DASD (separate installation step). That maybe could permit to activate or deactivate s390 group devices (currently only activate is permitted)

![DASDActivation](https://user-images.githubusercontent.com/7056681/73440058-8cf82380-4348-11ea-90a1-5e396c518006.png)