### PR TITLE
Return output even if listing s390 group devices by type fails

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 31 07:23:15 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not fail when listing the s390 group devices of a given type
+  and no one is present (bsc#1160997)
+- 4.2.49
+
+-------------------------------------------------------------------
 Thu Jan 30 12:37:03 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Bring back the s390 group device activation dialog when editing

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.48
+Version:        4.2.49
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/s390_group_device.rb
+++ b/src/lib/y2network/s390_group_device.rb
@@ -61,8 +61,22 @@ module Y2Network
     def online?
       cmd = [LIST_CMD, id, "-c", "on", "-n"]
 
-      Yast::Execute.stdout.on_target!(cmd).split("\n").first == "yes"
+      Yast::Execute.stdout.locally!(cmd).split("\n").first == "yes"
     end
+
+    # Determines whether two s390 group devices are the same
+    #
+    # @param other [S390GroupDevice] device to compare with
+    # @return [Boolean]
+    def ==(other)
+      return false unless other.is_a?(S390GroupDevice)
+
+      id == other.id
+    end
+
+    # eql? (hash key equality) should alias ==, see also
+    # https://ruby-doc.org/core-2.3.3/Object.html#method-i-eql-3F
+    alias_method :eql?, :==
 
     class << self
       # Returns the list of S390 group devices of the given type
@@ -75,7 +89,7 @@ module Y2Network
         cmd = [LIST_CMD, type, "-c", "id,names", "-n"]
         cmd << "--offline" if offline
 
-        Yast::Execute.locally!(*cmd, stdout: :capture).split("\n").map do |device|
+        Yast::Execute.stdout.locally!(*cmd).split("\n").map do |device|
           id, iface_name = device.split(" ")
           new(type, id, iface_name)
         end

--- a/test/y2network/s390_group_device_test.rb
+++ b/test/y2network/s390_group_device_test.rb
@@ -21,16 +21,83 @@ require_relative "../test_helper"
 require "y2network/s390_group_device"
 
 describe Y2Network::S390GroupDevice do
-  subject(:device) do
-    described_class.new("qeth", "0.0.0700:0.0.0701:0.0.0702")
+  let(:qeth_0700_id) { "0.0.0700:0.0.0701:0.0.0702" }
+  let(:qeth_0800_id) { "0.0.0800:0.0.0801:0.0.0802" }
+  let(:ctc_c000_id) { "0.0.c000:0.0.c001" }
+  let(:qeth_0700) { described_class.new("qeth", qeth_0700_id) }
+  let(:qeth_0800) { described_class.new("qeth", qeth_0800_id, "eth0") }
+  let(:ctc0) { described_class.new("ctc", ctc_c000_id) }
+  subject(:device) { qeth_0700 }
+
+  let(:executor) { double("Yast::Execute", locally!: "") }
+  before do
+    allow(Yast::Execute).to receive(:stdout).and_return(executor)
   end
 
-  describe "#offline?" do
+  describe "#online?" do
+    context "when the s390 group device is online according to lszdev" do
+      it "returns true" do
+        expect(executor).to receive(:locally!).and_return("yes\n")
+
+        expect(device.online?).to eq(true)
+      end
+    end
+
+    context "when the s390 group device is offline according to lszdev" do
+      it "returns false" do
+        expect(executor).to receive(:locally!).and_return("no\n")
+        expect(device.online?).to eq(false)
+      end
+    end
   end
 
-  describe ".all" do
+  describe "#==" do
+    context "given a s390 group device with the same id" do
+      it "returns true" do
+        expect(device).to eq(qeth_0700)
+      end
+    end
+
+    context "given a s390 group device with a different id" do
+      it "returns false" do
+        expect(device).to_not eq(qeth_0800)
+      end
+    end
   end
 
   describe ".list" do
+    let(:qeth_0700_lszdev) { "#{qeth_0700_id}  \n" }
+    let(:qeth_0800_lszdev) { "#{qeth_0800_id}  eth0\n" }
+    let(:lszdev_output) { qeth_0700_lszdev + qeth_0800_lszdev }
+    before do
+      allow(executor).to receive(:locally!).and_return(lszdev_output)
+    end
+
+    it "returns an array with the existent s390 group devices of the given type" do
+      expect(described_class.list("qeth")).to eq([device, qeth_0800])
+    end
+
+    context "when no interface of the given type is listed" do
+      let(:lszdev_output) { "" }
+      it "returns an empty array" do
+        expect(described_class.list("lcs")).to eq([])
+      end
+    end
+  end
+
+  describe ".all" do
+    let(:qeth_devices) { [qeth_0700, qeth_0800] }
+    let(:ctc_devices) { [ctc0] }
+    let(:lcs_devices) { [] }
+
+    before do
+      allow(described_class).to receive(:list).with("qeth", false).and_return(qeth_devices)
+      allow(described_class).to receive(:list).with("ctc", false).and_return(ctc_devices)
+      allow(described_class).to receive(:list).with("lcs", false).and_return([])
+    end
+
+    it "returns an array with all the supported s390 group devices" do
+      expect(described_class.all).to eq(qeth_devices + ctc_devices)
+    end
   end
 end


### PR DESCRIPTION
## Problem

There was some last change in #1029 that was not verified. Basically, the call to stdout method when listing s390 group devices was replaced by the `stdout: :capture` parameter, but stdout method also force an output in case of failing.

![NoLCSdevicesPresent](https://user-images.githubusercontent.com/7056681/73521602-57157680-43fe-11ea-9f87-968180c05ca6.png)

## Solution

Bring back the call to the stdout method

## Test

- Added missing tests to the s390GroupDevice class.
- Tested manually

![NetworkOverview](https://user-images.githubusercontent.com/7056681/73521872-04888a00-43ff-11ea-87d1-327c9c998062.png)