### PR TITLE
Fix call to remote_address method

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,7 +2,7 @@
 Mon Feb  3 10:44:31 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix connection configuration summary when using a remote
-  ip address (bsc#1162483)
+  IP address (bsc#1162483)
 - 4.2.50
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb  3 10:44:31 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix connection configuration summary when using a remote
+  ip address (bsc#1162483)
+- 4.2.50
+
+-------------------------------------------------------------------
 Fri Jan 31 07:23:15 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not fail when listing the s390 group devices of a given type

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.49
+Version:        4.2.50
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/presenters/interface_status.rb
+++ b/src/lib/y2network/presenters/interface_status.rb
@@ -44,7 +44,7 @@ module Y2Network
             format(
               _("Configured with address %{local} (remote %{remote})"),
               local:  addr,
-              remote: config.remote_address.to_s
+              remote: config.ip.remote_address.to_s
             )
           else
             # TRANSLATORS %s is address

--- a/test/y2network/presenters/interface_summary_test.rb
+++ b/test/y2network/presenters/interface_summary_test.rb
@@ -24,12 +24,13 @@ require "y2network/connection_config"
 require "y2network/connection_configs_collection"
 require "y2network/interface"
 require "y2network/interfaces_collection"
+require "y2network/s390_group_devices_collection"
 require "y2network/presenters/interface_summary"
 
 describe Y2Network::Presenters::InterfaceSummary do
   subject(:presenter) { described_class.new(name, config) }
 
-  let(:name) { "vlan1" }
+  let(:name) { "eth0" }
 
   let(:config) do
     Y2Network::Config.new(
@@ -59,13 +60,29 @@ describe Y2Network::Presenters::InterfaceSummary do
   let(:eth0) do
     config = Y2Network::ConnectionConfig::Ethernet.new.tap(&:propose)
     config.name = "eth0"
+    config.ip = eth0_ip
     config
+  end
+
+  let(:eth0_ip) do
+    Y2Network::ConnectionConfig::IPConfig.new(
+      Y2Network::IPAddress.from_string("192.168.122.1/24"),
+      id: "", broadcast: Y2Network::IPAddress.from_string("192.168.122.255"),
+      remote_address: Y2Network::IPAddress.from_string("192.168.122.254")
+    )
   end
 
   describe "#text" do
     it "returns a summary in text form" do
       text = presenter.text
       expect(text).to be_a(::String)
+    end
+
+    context "when a remote IP address is configured" do
+      it "is shown in the summary" do
+        text = presenter.text
+        expect(text).to include("remote 192.168.122.254")
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

The configuration summary breaks when a remote IP is configured

![RemoteAddressError](https://user-images.githubusercontent.com/7056681/73643185-f63ea600-466a-11ea-9e90-626e8723c3c1.png)

## Solution

Fix method call.

## Tests

- Tested manually
- Added unit test
