### PR TITLE
Do not assign interface section empty values (bsc#1162671)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  6 15:48:23 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Prevent assignation of values not defined in the AutoYaST profile
+  when reading the interfaces section (bsc#1162671)
+- 4.2.52
+
+-------------------------------------------------------------------
 Tue Feb  4 19:06:52 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not break when reading interface config files with trailing

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.51
+Version:        4.2.52
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -91,8 +91,10 @@ module Y2Network
           # TODO: report if ipaddr missing for static config
           ipaddr = IPAddress.from_string(interface_section.ipaddr)
           # Assign first netmask, as prefixlen has precedence so it will overwrite it
-          ipaddr.netmask = interface_section.netmask if interface_section.netmask
-          ipaddr.prefix = interface_section.prefixlen.to_i if interface_section.prefixlen
+          ipaddr.netmask = interface_section.netmask if !interface_section.netmask.to_s.empty?
+          if !interface_section.prefixlen.to_s.empty?
+            ipaddr.prefix = interface_section.prefixlen.to_i
+          end
           if !interface_section.broadcast.empty?
             broadcast = IPAddress.new(interface_section.broadcast)
           end
@@ -112,17 +114,17 @@ module Y2Network
           ipaddr.prefix = alias_h["PREFIXLEN"].delete("/").to_i if alias_h["PREFIXLEN"]
           config.ip_aliases << ConnectionConfig::IPConfig.new(ipaddr, label: alias_h["LABEL"])
         end
-        if interface_section.startmode
+        if !interface_section.startmode.to_s.empty?
           config.startmode = Startmode.create(interface_section.startmode)
         end
-        if config.startmode.name == "ifplugd" && interface_section.ifplugd_priority
+        if config.startmode.name == "ifplugd" && !interface_section.ifplugd_priority.to_s.empty?
           config.startmode.priority = interface_section.ifplugd_priority
         end
-        config.mtu = interface_section.mtu.to_i if interface_section.mtu
+        config.mtu = interface_section.mtu.to_i if !interface_section.mtu.to_s.empty?
         if interface_section.ethtool_options
           config.ethtool_options = interface_section.ethtool_options
         end
-        config.firewall_zone = interface_section.zone if interface_section.zone
+        config.firewall_zone = interface_section.zone if !interface_section.zone.to_s.empty?
         if !interface_section.dhclient_set_hostname.empty?
           config.dhclient_set_hostname = interface_section.dhclient_set_hostname == "yes"
         end
@@ -131,44 +133,55 @@ module Y2Network
       end
 
       def load_wireless(config, interface_section)
-        config.mode = interface_section.wireless_mode if interface_section.wireless_mode
-        config.ap = interface_section.wireless_ap if interface_section.wireless_ap
-        if interface_section.wireless_bitrate
+        if !interface_section.wireless_mode.to_s.empty?
+          config.mode = interface_section.wireless_mode
+        end
+        config.ap = interface_section.wireless_ap if !interface_section.wireless_ap.to_s.empty?
+        if !interface_section.wireless_bitrate.to_s.empty?
           config.bitrate = interface_section.wireless_bitrate.to_f
         end
         config.ca_cert = interface_section.wireless_ca_cert if interface_section.wireless_ca_cert
-        if interface_section.wireless_channel
+        if !interface_section.wireless_channel.to_s.empty?
           config.channel = interface_section.wireless_channel.to_i
         end
-        if interface_section.wireless_client_cert
+        if !interface_section.wireless_client_cert.to_s.empty?
           config.client_cert = interface_section.wireless_client_cert
         end
-        if interface_section.wireless_client_key
+        if !interface_section.wireless_client_key.to_s.empty?
           config.client_key = interface_section.wireless_client_key
         end
         config.essid = interface_section.wireless_essid if interface_section.wireless_essid
         if interface_section.wireless_auth_mode
           config.auth_mode = interface_section.wireless_auth_mode.to_sym
         end
-        config.nick = interface_section.wireless_nick if interface_section.wireless_nick
-        config.nwid = interface_section.wireless_nwid if interface_section.wireless_nwid
-        if interface_section.wireless_wpa_anonid
+        if !interface_section.wireless_nick.to_s.empty?
+          config.nick = interface_section.wireless_nick
+        end
+        if !interface_section.wireless_nwid.to_s.empty?
+          config.nwid = interface_section.wireless_nwid
+        end
+
+        if !interface_section.wireless_wpa_anonid.to_s.empty?
           config.wpa_anonymous_identity = interface_section.wireless_wpa_anonid
         end
-        if interface_section.wireless_wpa_identity
+        if !interface_section.wireless_wpa_identity.to_s.empty?
           config.wpa_identity = interface_section.wireless_wpa_identity
         end
-        if interface_section.wireless_wpa_password
+        if !interface_section.wireless_wpa_password.to_s.empty?
           config.wpa_password = interface_section.wireless_wpa_password
         end
-        config.wpa_psk = interface_section.wireless_wpa_psk if interface_section.wireless_wpa_psk
+        if !interface_section.wireless_wpa_psk.to_s.empty?
+          config.wpa_psk = interface_section.wireless_wpa_psk
+        end
         config.keys = []
         (0..3).each do |i|
           key = interface_section.public_send(:"wireless_key#{i}")
           config.keys << key if key && !key.empty?
         end
-        config.default_key = interface_section.wireless_key.to_i if interface_section.wireless_key
-        if interface_section.wireless_key_length
+        if !interface_section.wireless_key.to_s.empty?
+          config.default_key = interface_section.wireless_key.to_i
+        end
+        if !interface_section.wireless_key_length.to_s.empty?
           config.key_length = interface_section.wireless_key_length.to_i
         end
 
@@ -176,14 +189,16 @@ module Y2Network
       end
 
       def load_vlan(config, interface_section)
-        config.vlan_id = interface_section.vlan_id.to_i if interface_section.vlan_id
+        config.vlan_id = interface_section.vlan_id.to_i if !interface_section.vlan_id.to_s.empty?
         config.parent_device = interface_section.etherdevice
       end
 
       def load_bridge(config, interface_section)
         config.ports = interface_section.bridge_ports.split
-        config.stp = interface_section.bridge_stp == "on" if interface_section.bridge_stp
-        if interface_section.bridge_forward_delay
+        if !interface_section.bridge_stp.to_s.empty?
+          config.stp = interface_section.bridge_stp == "on"
+        end
+        if !interface_section.bridge_forward_delay.to_s.empty?
           config.forward_delay = interface_section.bridge_forward_delay.to_i
         end
 
@@ -191,7 +206,7 @@ module Y2Network
       end
 
       def load_bonding(config, interface_section)
-        if interface_section.bonding_module_opts
+        if !interface_section.bonding_module_opts.empty?
           config.options = interface_section.bonding_module_opts
         end
         config.slaves = []

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -259,6 +259,9 @@ module Y2Network
       def initialize(*_args)
         super
 
+        # TODO: Initializing all the attributes to an empty string makes
+        # hard to know whether the value was defined or not at all. We probably
+        # should ommit this initialization
         self.class.attributes.each do |attr|
           # init everything to empty string
           public_send(:"#{attr[:name]}=", "")

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -38,7 +38,6 @@ describe Y2Network::Autoinst::InterfacesReader do
         "device"                => "eth1",
         "name"                  => "",
         "ipaddr"                => "192.168.10.10",
-        "netmask"               => "255.255.255.0",
         "dhclient_set_hostname" => "no",
         "prefixlen"             => "24"
       },


### PR DESCRIPTION
## Problem

When AutoYaST interfaces_section reader tries to initialize some connection config attributes it checks whether the value if defined in the section. The problem is that all the attributes are initialized to an empty string and the check becomes useless.

https://github.com/yast/yast-network/blob/master/src/lib/y2network/autoinst_profile/interface_section.rb#L264

- https://trello.com/c/YHW3GY5E/1627-sles15-sp2-p1-1162671-sles-15-sp2-beta2-internal-error-during-autoyast-install-leads-to-unfinished-installation

## Solution

For the time being, we just check whether the value to be assigned from the interfaces_section is empty or not only assigning it in case of not empty.

It probably would be better to not initialize all the interfaces_section attributes to an empty string but marked as `TODO` to be done later.