### PR TITLE
Do not crash with an exception when editing the hardware of a new unplugged connection

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 19 07:34:39 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not crash with an exception when editing the hardware
+  configuration of a new unplugged connection (bsc#1162679)
+
+-------------------------------------------------------------------
 Fri Feb  7 17:31:31 UTC 2020 - Michal Filka <mfilka@suse.com>
 
 - bsc#1162271

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -127,7 +127,7 @@ module Y2Network
 
       yast_config.rename_interface(@old_name, name, renaming_mechanism) if renamed_interface?
       yast_config.add_or_update_connection_config(@connection_config)
-      # Assign the new added interface in case of a new connection for an
+      # Assign the newly added interface in case of a new connection for an
       # unplugged one (bsc#1162679)
       self.interface = find_interface unless interface
 

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -125,12 +125,16 @@ module Y2Network
         end
       end
 
+      yast_config.rename_interface(@old_name, name, renaming_mechanism) if renamed_interface?
+      yast_config.add_or_update_connection_config(@connection_config)
+      # Assign the new added interface in case of a new connection for an
+      # unplugged one (bsc#1162679)
+      self.interface = find_interface unless interface
+
       if interface.respond_to?(:custom_driver)
         interface.custom_driver = driver_auto? ? nil : driver.name
         yast_config.add_or_update_driver(driver) unless driver_auto?
       end
-      yast_config.rename_interface(@old_name, name, renaming_mechanism) if renamed_interface?
-      yast_config.add_or_update_connection_config(@connection_config)
 
       nil
     end
@@ -245,7 +249,7 @@ module Y2Network
     def driver
       return @driver if @driver
 
-      if @interface.custom_driver
+      if @interface&.custom_driver
         @driver = yast_config.drivers.find { |d| d.name == @interface.custom_driver }
       end
       @driver ||= :auto

--- a/test/y2network/interface_config_builder_test.rb
+++ b/test/y2network/interface_config_builder_test.rb
@@ -110,6 +110,19 @@ describe Y2Network::InterfaceConfigBuilder do
       subject.save
     end
 
+    context "when the new connection config is for an unplugged interface" do
+      subject(:config_builder) do
+        res = Y2Network::InterfaceConfigBuilder.for("eth")
+        res.name = "eth1"
+        res
+      end
+
+      it "assigns the added interface to the builder" do
+        subject.save
+        expect(subject.interface.name).to eq("eth1")
+      end
+    end
+
     context "when interface was renamed" do
       before do
         subject.rename_interface("eth2")


### PR DESCRIPTION
## Problem

An exception is raised when editing the hardware tab of a new unplugged connection.

- https://trello.com/c/GrlhLUb3/1641-2-sles15-sp2-p2-1162679-exception-is-thrown-when-open-hardware-tab-while-adding-new-device

## Solution

- Get the driver from the interface only when there is an interface present.
- When adding a new connection for an unplugged interface, assign the new interface to the builder before modifying the driver config. Otherwise, changes done in the widget get lost.

## Tests

- Tested manually