### PR TITLE
[SLE-7188] Add an NtpServer class

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 19 11:52:25 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add a class to represent NTP servers (jsc#SLE-7188).
+- 4.2.55
+
+-------------------------------------------------------------------
 Fri Feb  7 17:31:31 UTC 2020 - Michal Filka <mfilka@suse.com>
 
 - bsc#1162271

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.54
+Version:        4.2.55
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/ntp_server.rb
+++ b/src/lib/y2network/ntp_server.rb
@@ -1,0 +1,85 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yaml"
+
+Yast.import "Product"
+
+module Y2Network
+  # Represents an NTP server
+  #
+  # It includes basic information about NTP servers. It could be extended
+  # in the future as needed.
+  class NtpServer
+    # @return [String] Server's hostname
+    attr_reader :hostname
+    # @return [String,nil] Country code where the server is located
+    attr_reader :country
+    # @return [String,nil] Server's location
+    attr_reader :location
+
+    class << self
+      DEFAULT_SERVERS = 4
+      DEFAULT_SUBDOMAIN = "pool.ntp.org".freeze
+
+      private_constant :DEFAULT_SUBDOMAIN, :DEFAULT_SERVERS
+
+      # Determines the default servers
+      #
+      # The content of this list depends on the base product.
+      #
+      # @param products [Array<Hash>] List of base products
+      # @return [Array<NtpServer>] Default NTP servers
+      def default_servers(products = nil)
+        base_products = products || Yast::Product.FindBaseProducts
+
+        host =
+          if base_products.any? { |p| p["name"] =~ /openSUSE/i }
+            "opensuse"
+          else
+            "suse"
+          end
+
+        (0..DEFAULT_SERVERS - 1).map { |i| new("#{i}.#{host}.#{DEFAULT_SUBDOMAIN}") }
+      end
+    end
+
+    # Constructor
+    #
+    # @param hostname [String] Server's hostname
+    # @param country  [String] Country code (e.g., "DE")
+    # @param location [String] Server's location
+    def initialize(hostname, country: nil, location: nil)
+      @hostname = hostname
+      @country = country
+      @location = location
+    end
+
+    # Determines when two servers are the same
+    #
+    # @param other [NtpServer] Object to compare with
+    # @return [Boolean] true if both objects contain the same information; false otherwise
+    def ==(other)
+      hostname == other.hostname && country == other.country && location == other.location
+    end
+
+    alias_method :eql?, :==
+  end
+end

--- a/test/data/ntp_servers.yml
+++ b/test/data/ntp_servers.yml
@@ -1,0 +1,9 @@
+---
+
+- access_policy: open access
+  address: ntp.cgi.cz
+  country: CZ
+  exact_location: Prague, The Czech Republic
+  location: Czech Republic
+  stratum: '2'
+  synchronization: NTP V4 secondary (stratum 2), PC/FreeBSD

--- a/test/y2network/ntp_server_test.rb
+++ b/test/y2network/ntp_server_test.rb
@@ -1,0 +1,114 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "y2network/ntp_server"
+
+describe Y2Network::NtpServer do
+  describe ".default_servers" do
+    before do
+      allow(Yast::Product).to receive(:FindBaseProducts)
+        .and_return(products)
+    end
+
+    context "when running in an openSUSE system" do
+      let(:products) do
+        [{ "name" => "openSUSE" }]
+      end
+
+      it "returns a set of opensuse.pool.ntp.org servers" do
+        domain = "opensuse.pool.ntp.org"
+        expect(described_class.default_servers.map(&:hostname)).to eq(
+          ["0.#{domain}", "1.#{domain}", "2.#{domain}", "3.#{domain}"]
+        )
+      end
+    end
+
+    context "when not running in an openSUSE system" do
+      let(:products) do
+        [{ "name" => "SLES" }]
+      end
+
+      it "returns a set of suse.pool.ntp.org servers" do
+        domain = "suse.pool.ntp.org"
+        expect(described_class.default_servers.map(&:hostname)).to eq(
+          ["0.#{domain}", "1.#{domain}", "2.#{domain}", "3.#{domain}"]
+        )
+      end
+    end
+
+    context "when a list of base product is given" do
+      let(:products) do
+        [{ "name" => "openSUSE" }]
+      end
+
+      it "returns the set of servers for that product" do
+        domain = "opensuse.pool.ntp.org"
+        expect(Yast::Product).to_not receive(:FindBaseProducts)
+        servers = described_class.default_servers(products)
+        expect(servers.map(&:hostname)).to eq(
+          ["0.#{domain}", "1.#{domain}", "2.#{domain}", "3.#{domain}"]
+        )
+      end
+    end
+  end
+
+  describe "#==" do
+    subject { Y2Network::NtpServer.new("suse.pool.ntp.org", country: "DE", location: "Germany") }
+
+    let(:other) do
+      Y2Network::NtpServer.new(other_hostname, country: other_country, location: other_location)
+    end
+    let(:other_hostname) { subject.hostname }
+    let(:other_country) { subject.country }
+    let(:other_location) { subject.location }
+
+    context "when both objects contain the same information" do
+      it "returns true" do
+        expect(subject).to eq(other)
+      end
+    end
+
+    context "when the hostname is different" do
+      let(:other_hostname) { "opensuse.pool.ntp.org" }
+
+      it "returns false" do
+        expect(subject).to_not eq(other)
+      end
+    end
+
+    context "when the country is different" do
+      let(:other_country) { "ES" }
+
+      it "returns false" do
+        expect(subject).to_not eq(other)
+      end
+    end
+
+    context "when the hostname is different" do
+      let(:other_location) { "Spain" }
+
+      it "returns false" do
+        expect(subject).to_not eq(other)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
This PRs adds a `NtpServer` class so it can be used by other modules. The main problem it tries to solve is moving the logic to calculate the default servers to a single point.

**Related PRs:**
* https://github.com/yast/yast-installation/pull/838
* https://github.com/yast/yast-country/pull/243
* https://github.com/yast/yast-ntp-client/pull/155
* https://github.com/yast/yast-caasp/pull/44

**Trello card:** https://trello.com/c/lbOwsD5J