### PR TITLE
Add missing import

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 21 09:53:25 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not crash when checking if a given 'host' is local or not
+  (bsc#1163305)
+- 4.2.56
+
+-------------------------------------------------------------------
 Wed Feb 19 11:52:25 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add a class to represent NTP servers (jsc#SLE-7188).

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.55
+Version:        4.2.56
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/connection_configs_collection.rb
+++ b/src/lib/y2network/connection_configs_collection.rb
@@ -37,7 +37,7 @@ module Y2Network
     alias_method :to_a, :connection_configs
 
     def_delegators :@connection_configs, :each, :find, :push, :<<, :reject!, :map, :flat_map,
-      :any?, :size, :first, :empty?
+      :any?, :size, :first, :empty?, :each_with_object
 
     # Constructor
     #

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -239,7 +239,13 @@ module Yast
       # loopback interface or localhost hostname
       return true if ["127.0.0.1", "::1", "localhost", "localhost.localdomain"].include?(check_host)
 
-      ip_addresses = connections.map { |c| c.all_ips.map { |i| i&.address&.address.to_s } }.flatten
+      ip_addresses = []
+      connections.each do |conn|
+        conn.all_ips.each do |ip|
+          address = ip&.address&.address.to_s
+          ip_addresses << address if !address.empty? && !ip_addresses.include?(address)
+        end
+      end
 
       # IPv4 address
       if IP.Check4(check_host)

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -80,6 +80,7 @@ module Yast
       Yast.import "UI"
       textdomain "network"
 
+      Yast.import "Lan"
       Yast.import "Arch"
       Yast.import "Hostname"
       Yast.import "IP"

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -239,11 +239,10 @@ module Yast
       # loopback interface or localhost hostname
       return true if ["127.0.0.1", "::1", "localhost", "localhost.localdomain"].include?(check_host)
 
-      ip_addresses = []
-      connections.each do |conn|
-        conn.all_ips.each do |ip|
+      ip_addresses = connections.each_with_object([]) do |conn, res|
+        conn.all_ips.each_with_object(res) do |ip, ips|
           address = ip&.address&.address.to_s
-          ip_addresses << address if !address.empty? && !ip_addresses.include?(address)
+          ips << address if !address.empty? && !ips.include?(address)
         end
       end
 

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -84,7 +84,6 @@ module Yast
       Yast.import "Arch"
       Yast.import "Hostname"
       Yast.import "IP"
-      Yast.import "NetworkInterfaces"
       Yast.import "ProductFeatures"
       Yast.import "Progress"
       Yast.import "Service"
@@ -224,16 +223,14 @@ module Yast
     # NOTE: used in yast2-nis-server, yast2-samba-server, yast2-dhcp-server
     def IsHostLocal(check_host)
       Read()
-      NetworkInterfaces.Read
-      dhcp_data = {}
+      current_dhcp_data = {}
+      connections = Yast::Lan.yast_config.connections
 
-      if Ops.greater_than(
-        Builtins.size(NetworkInterfaces.Locate("BOOTPROTO", "dhcp")),
-        0
-      ) || dhcp_hostname
-        dhcp_data = dhcp_data()
-        Builtins.y2milestone("Got DHCP-configured data: %1", dhcp_data)
+      if connections.any?(:dhcp?) || dhcp_hostname
+        current_dhcp_data = dhcp_data
+        log.info("Got DHCP-configured data: #{current_dhcp_data.inspect}")
       end
+
       # FIXME: May not work properly in following situations:
       #   - multiple addresses per interface
       #     - aliases in /etc/hosts
@@ -242,29 +239,19 @@ module Yast
       # loopback interface or localhost hostname
       return true if ["127.0.0.1", "::1", "localhost", "localhost.localdomain"].include?(check_host)
 
+      ip_addresses = connections.map { |c| c.all_ips.map { |i| i&.address&.address.to_s } }.flatten
+
       # IPv4 address
       if IP.Check4(check_host)
-        if Ops.greater_than(
-          Builtins.size(NetworkInterfaces.Locate("IPADDR", check_host)),
-          0
-        ) ||
-            Ops.get(dhcp_data, "ip", "") == check_host
-          return true
-        end
+        return true if ip_addresses.include?(check_host) || current_dhcp_data["ip"] == check_host
       # IPv6 address
       elsif IP.Check6(check_host)
-        Builtins.y2debug(
-          "TODO make it similar to IPv4 after other code adapted to IPv6"
-        )
-      # short hostname
-      elsif Builtins.findfirstof(check_host, ".").nil?
-        if Builtins.tolower(check_host) == Builtins.tolower(@hostname) ||
-            Ops.get(dhcp_data, "hostname_short", "") == check_host
-          return true
-        end
-      elsif Builtins.tolower(check_host) ==
-          Builtins.tolower(Ops.add(Ops.add(@hostname, "."), @domain)) ||
-          Ops.get(dhcp_data, "hostname_fq", "") == check_host
+        log.debug("TODO make it similar to IPv4 after other code adapted to IPv6")
+      # short hostname or FQDN
+      elsif check_host.downcase == hostname.to_s.downcase ||
+          current_dhcp_data["hostname_short"] == check_host ||
+          current_dhcp_data["hostname_fq"] == check_host
+
         return true
       end
       false

--- a/test/dns_test.rb
+++ b/test/dns_test.rb
@@ -32,6 +32,7 @@ Yast.import "ProductControl"
 Yast.import "Lan"
 
 describe Yast::DNS do
+  let(:logger) { double(info: true, debug: true) }
   let(:lan_config) do
     Y2Network::Config.new(
       dns: dns_config, hostname: hostname_config, source: :sysconfig,
@@ -68,6 +69,7 @@ describe Yast::DNS do
   subject { Yast::DNS }
 
   before do
+    allow(described_class).to receive(:log).and_return(logger)
     allow(Yast::Lan).to receive(:Read)
     allow(Yast::Lan).to receive(:yast_config).and_return(lan_config)
   end
@@ -184,6 +186,19 @@ describe Yast::DNS do
 
       it "returns false when the ip of local machine is not given" do
         expect(subject.IsHostLocal("1.2.3.4")).to eq(false)
+      end
+    end
+
+    context "for IPv6" do
+      let(:ip6) { "2001:db8:1234:ffff:ffff:ffff:ffff:fff1" }
+
+      it "logs that the implementation is still pending" do
+        expect(logger).to receive(:debug).with(/^TODO/)
+        subject.IsHostLocal(ip6)
+      end
+
+      it "returns false" do
+        expect(subject.IsHostLocal(ip6)).to eq(false)
       end
     end
   end


### PR DESCRIPTION
## Problem

yast2-nisserver uses the `Yast::DNS` module for checking if some host is local or not. Unfortunately it crashes because of a missing `Yast::Lan` import.

- https://trello.com/c/9r2m9E4r/1645-1-littlebugostumbleweed-p2-1163305-yast2-nisserver-crashes-during-reading-of-the-configfiles
- https://bugzilla.suse.com/show_bug.cgi?id=1163305

## Solution

- Added the missing import
- Get rid of the NetworkInterfaces dependencies and adapted the code for using the new network-ng classes for checking if a host is local or not.

## Test

- Adapted `Yast::DNS.IsHostLocal` unit test
