### PR TITLE
Fixed setting hostname via installer

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar  2 21:01:33 UTC 2020 - Michal Filka <mfilka@suse.com>
+
+- bsc#1164506
+  - fixed setting hostname in installer
+- 4.2.60
+
+-------------------------------------------------------------------
 Mon Mar  2 19:12:32 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not modify interface name when enslaving it (bsc#1165463)

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -3,6 +3,8 @@ Mon Mar  2 21:01:33 UTC 2020 - Michal Filka <mfilka@suse.com>
 
 - bsc#1164506
   - fixed setting hostname in installer
+- bsc#1164587
+  - fixed setting hostname according to AY profile
 - 4.2.60
 
 -------------------------------------------------------------------

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.59
+Version:        4.2.60
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -257,6 +257,18 @@ module Yast
       deep_copy(settings)
     end
 
+    # Stores user's input from hostname field
+    #
+    # @param value [String]
+    # @return [String] stored hostname
+    def store_hostname(value)
+      hostname = Yast::Lan.yast_config.hostname
+      hostname.static = value
+      hostname.installer = value if Stage.initial
+
+      value
+    end
+
     # @param [Hash] settings map of settings to be stored to DNS::
     def StoreSettings(settings)
       settings = deep_copy(settings)
@@ -270,7 +282,8 @@ module Yast
         " ,\n\t"
       )
 
-      DNS.hostname = Ops.get_string(settings, "HOSTNAME", "")
+      store_hostname(settings["HOSTNAME"] || "")
+
       valid_nameservers = NonEmpty(nameservers).each_with_object([]) do |ip_str, all|
         all << IPAddr.new(ip_str) if IP.Check(ip_str)
       end

--- a/src/lib/y2network/autoinst/config_reader.rb
+++ b/src/lib/y2network/autoinst/config_reader.rb
@@ -22,6 +22,7 @@ require "y2network/interface"
 require "y2network/config"
 require "y2network/autoinst/routing_reader"
 require "y2network/autoinst/dns_reader"
+require "y2network/autoinst/hostname_reader"
 require "y2network/autoinst/interfaces_reader"
 require "y2network/autoinst/udev_rules_reader"
 require "y2network/autoinst_profile/networking_section"
@@ -48,10 +49,13 @@ module Y2Network
       # @return [Y2Network::Config] Network configuration
       def config
         config = @original_config.copy
+
         # apply at first udev rules, so interfaces names are correct
         UdevRulesReader.new(section.udev_rules).apply(config) if section.udev_rules
         config.routing = RoutingReader.new(section.routing).config if section.routing
         config.dns = DNSReader.new(section.dns).config if section.dns
+        config.hostname = HostnameReader.new(section.dns).config if section.dns
+
         if section.interfaces
           interfaces = InterfacesReader.new(section.interfaces).config
           interfaces.each do |interface|

--- a/src/lib/y2network/autoinst/hostname_reader.rb
+++ b/src/lib/y2network/autoinst/hostname_reader.rb
@@ -40,7 +40,8 @@ module Y2Network
       def config
         Y2Network::Hostname.new(
           dhcp_hostname: section.dhcp_hostname,
-          hostname:      section.hostname || default_hostname
+          static:        section.hostname || default_hostname,
+          installer:     section.hostname
         )
       end
 

--- a/src/lib/y2network/hostname.rb
+++ b/src/lib/y2network/hostname.rb
@@ -31,7 +31,7 @@ module Y2Network
     # @return [String] dynamically defined hostname (e.g. from DHCP), defaults to static
     attr_accessor :transient
 
-    # @return [String, nil] hostname as read from linuxrc (if set) in installer, nil otherwise
+    # @return [String, nil] hostname as read from linuxrc (if set) or explicitly set in installer, nil otherwise
     attr_accessor :installer
 
     # @return [String,Symbol] Whether to take the hostname from DHCP.

--- a/src/lib/y2network/hostname.rb
+++ b/src/lib/y2network/hostname.rb
@@ -31,7 +31,8 @@ module Y2Network
     # @return [String] dynamically defined hostname (e.g. from DHCP), defaults to static
     attr_accessor :transient
 
-    # @return [String, nil] hostname as read from linuxrc (if set) or explicitly set in installer, nil otherwise
+    # @return [String, nil] hostname as read from linuxrc (if set) or explicitly set
+    #                       in installer, nil otherwise
     attr_accessor :installer
 
     # @return [String,Symbol] Whether to take the hostname from DHCP.

--- a/src/lib/y2network/sysconfig/hostname_writer.rb
+++ b/src/lib/y2network/sysconfig/hostname_writer.rb
@@ -76,7 +76,7 @@ module Y2Network
         hostname = hostname.static
         # 1) when user asked for erasing hostname from /etc/hostname, we keep runtime as it is
         # 2) we will write whatever user wants even FQDN - no changes under the hood
-        Yast::Execute.on_target!("/usr/bin/hostname", hostname) if !hostname.empty?
+        Yast::Execute.locally!("/usr/bin/hostname", hostname) if !hostname.empty?
         Yast::SCR.Write(
           Yast::Path.new(".target.string"),
           HOSTNAME_PATH,

--- a/src/modules/DNS.rb
+++ b/src/modules/DNS.rb
@@ -74,7 +74,6 @@ module Yast
     # for backward compatibility as long as old DNS module is used as an API
     # for new dns and hostname classes
     alias_method :hostname, :static
-    alias_method :hostname=, :static=
 
     def main
       Yast.import "UI"

--- a/test/dns_test.rb
+++ b/test/dns_test.rb
@@ -257,15 +257,4 @@ describe Yast::DNS do
       expect(subject.hostname).to eq "install"
     end
   end
-
-  describe "#hostname=" do
-    let(:hostname_config) do
-      Y2Network::Hostname.new
-    end
-
-    it "sets static hostname" do
-      subject.hostname = "test"
-      expect(subject.hostname).to eq "test"
-    end
-  end
 end

--- a/test/y2network/hostname_writer_test.rb
+++ b/test/y2network/hostname_writer_test.rb
@@ -51,7 +51,7 @@ describe Y2Network::Sysconfig::HostnameWriter do
 
       it "updates system with the new hostname" do
         expect(Yast::Execute)
-          .to receive(:on_target!)
+          .to receive(:locally!)
           .with("/usr/bin/hostname", hostname)
         expect(Yast::SCR)
           .to receive(:Write)


### PR DESCRIPTION
https://trello.com/c/prc25tfh/1662-sles15-sp2-p5-1164506-y2-network-configuring-hostname-during-install-is-not-preserved-regression-from-15-sp1

## Problem ##

When set hostname in the installer it is not preserved.

## Solution ##

Cover also the other way how user can explicitly set the hostname.

It was tested manually.

- [x] common installation without explicit hostname setup
- [x] common installation with explicit hostname setup via linuxrc
- [x] common installation with explicit hostname setup via YaST UI
- [x] AY installation with first stage only
- [x] AY installation with second stage