### PR TITLE
Do not modify interface name when enslaving it (bsc#1165463)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar  2 19:12:32 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not modify interface name when enslaving it (bsc#1165463)
+- 4.2.59
+
+-------------------------------------------------------------------
 Thu Feb 27 20:40:51 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when running the network configuration client if

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.58
+Version:        4.2.59
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/slave_items.rb
+++ b/src/lib/y2network/widgets/slave_items.rb
@@ -52,7 +52,7 @@ module Y2Network
             description = Yast::NetworkInterfaces.GetDevTypeDescription(interface.type.short_name,
               true)
           else
-            description = interface.name
+            description = interface.name.dup
 
             # this conditions origin from bridge configuration
             # if enslaving a configured device then its configuration is rewritten
@@ -64,7 +64,7 @@ module Y2Network
 
           selected = enslaved_ifaces.include?(interface.name)
           if physical_port_id?(interface.name)
-            description << " (Port ID: #{physical_port_id(interface.name)})"
+            description += " (Port ID: #{physical_port_id(interface.name)})"
           end
 
           result << Yast::Term.new(:item,


### PR DESCRIPTION
## Problem

When enslaving an interface with a physical port id it is renamed adding the description as the name.

- https://bugzilla.suse.com/show_bug.cgi?id=1165463

## Solution

Use a dup of the interface name.
