### PR TITLE
Store sysctl

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 10 14:29:36 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Store ip forwarding set during installation to target system
+  (bsc#1159295)
+- 4.2.61
+
+-------------------------------------------------------------------
 Mon Mar  2 21:01:33 UTC 2020 - Michal Filka <mfilka@suse.com>
 
 - bsc#1164506

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.60
+Version:        4.2.61
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -97,7 +97,9 @@ module Yast
         { dir: SYSCONFIG, file: "ifroute-*" },
         { dir: SYSCONFIG, file: "routes" },
         { dir: ETC + "wicked/", file: "common.xml" },
-        { dir: ETC, file: DNSClass::HOSTNAME_FILE }
+        { dir: ETC, file: DNSClass::HOSTNAME_FILE },
+        # Copy sysctl file as network writes there ip forwarding (bsc#1159295)
+        { dir: File.join(ETC, "sysctl.d/"), file: "70-yast.conf" }
       ]
 
       # NetworkManager is usually the default in a live installation. Any
@@ -112,6 +114,7 @@ module Yast
         # can be shell pattern like ifcfg-*
         file_pattern = recipe[:dir] + recipe[:file]
         copy_to = inst_dir + recipe[:dir]
+        log.info("Processing copy recipe #{file_pattern.inspect}")
 
         Dir.glob(file_pattern).each do |file|
           adjust_for_network_disks(file) if file.include?("ifcfg-")

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -79,9 +79,9 @@ module Yast
       )
     end
 
-    ETC = "/etc/".freeze
-    SYSCONFIG = "/etc/sysconfig/network/".freeze
-    NETWORK_MANAGER = "/etc/NetworkManager/".freeze
+    ETC = "/etc".freeze
+    SYSCONFIG = "/etc/sysconfig/network".freeze
+    NETWORK_MANAGER = "/etc/NetworkManager".freeze
 
     def CopyConfiguredNetworkFiles
       return if Mode.autoinst && !NetworkAutoYast.instance.keep_net_config?
@@ -96,24 +96,24 @@ module Yast
         { dir: SYSCONFIG, file: "ifcfg-*" },
         { dir: SYSCONFIG, file: "ifroute-*" },
         { dir: SYSCONFIG, file: "routes" },
-        { dir: ETC + "wicked/", file: "common.xml" },
+        { dir: ::File.join(ETC, "wicked"), file: "common.xml" },
         { dir: ETC, file: DNSClass::HOSTNAME_FILE },
         # Copy sysctl file as network writes there ip forwarding (bsc#1159295)
-        { dir: File.join(ETC, "sysctl.d/"), file: "70-yast.conf" }
+        { dir: ::File.join(ETC, "sysctl.d"), file: "70-yast.conf" }
       ]
 
       # NetworkManager is usually the default in a live installation. Any
       # configuration applied during the installation should be present in the
       # target system.
       if Y2Network::ProposalSettings.instance.network_service == :network_manager
-        copy_recipes << { dir: NETWORK_MANAGER + "/system-connections/", file: "*" }
+        copy_recipes << { dir: ::File.join(NETWORK_MANAGER, "system-connections"), file: "*" }
       end
 
       # just copy files
       copy_recipes.each do |recipe|
         # can be shell pattern like ifcfg-*
-        file_pattern = recipe[:dir] + recipe[:file]
-        copy_to = inst_dir + recipe[:dir]
+        file_pattern = ::File.join(recipe[:dir], recipe[:file])
+        copy_to = ::File.join(inst_dir, recipe[:dir])
         log.info("Processing copy recipe #{file_pattern.inspect}")
 
         Dir.glob(file_pattern).each do |file|
@@ -130,12 +130,12 @@ module Yast
         end
       end
 
-      copy_to = String.Quote(inst_dir + SYSCONFIG)
+      copy_to = String.Quote(::File.join(inst_dir, SYSCONFIG))
 
       # merge files with default installed by sysconfig
       ["dhcp", "config"].each do |file|
-        modified_file = SYSCONFIG + file
-        dest_file = copy_to + file
+        modified_file = ::File.join(SYSCONFIG, file)
+        dest_file = ::File.join(copy_to, file)
         CFA::GenericSysconfig.merge_files(dest_file, modified_file)
       end
       # FIXME: proxy


### PR DESCRIPTION
trello: https://trello.com/c/LQ8ZrNqS/1639-3-sles15-sp2-p2-1159295-build-1054-y2-network-ip-forwarding-is-not-enabled-in-sut-for-remote-installations

Issue: ip forwarding modification done in installation is not on target system

Solution: we need to copy from insts-sys also sysctl config to target system in save_network. In general network do modifications in insts-sys and at the end of installation it store configuration from insts-sys to target system.

Note: change with File.join is done as originally sysctl.d is missing ending slash, so I improve it and when we next time add another dir, it won't need it.