### PR TITLE
Reload configured interfaces when wriing the config and installing through ssh / vnc

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 18 09:42:36 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do a reload of configured interfaces when writing the
+  configuration during a ssh or vnc installation (bsc#1166287)
+- 4.2.62
+
+-------------------------------------------------------------------
 Tue Mar 10 14:29:36 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Store ip forwarding set during installation to target system

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.61
+Version:        4.2.62
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -877,14 +877,14 @@ module Yast
         NetworkService.ReloadOrRestart if Stage.normal || !Linuxrc.usessh
 
       when :remote_installer
-        connections = yast_config&.connections&.map(&:name) || []
+        connection_names = yast_config&.connections&.map(&:name) || []
 
         # last instance handling "special" cases like ssh installation
         # FIXME: most probably not everything will be set properly
         log.info("Running in ssh/vnc installer -> just setting links up")
-        log.info("Configured interfaces: #{connections}")
+        log.info("Configured connections: #{connection_names}")
 
-        reload_config(connections)
+        reload_config(connection_names)
       end
     end
 

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -44,6 +44,7 @@ require "shellwords"
 module Yast
   class LanClass < Module
     include ::UI::TextHelpers
+    include Wicked
 
     def main
       Yast.import "UI"
@@ -876,14 +877,14 @@ module Yast
         NetworkService.ReloadOrRestart if Stage.normal || !Linuxrc.usessh
 
       when :remote_installer
-        ifaces = LanItems.getNetworkInterfaces
+        connections = yast_config&.connections&.map(&:name) || []
 
         # last instance handling "special" cases like ssh installation
         # FIXME: most probably not everything will be set properly
         log.info("Running in ssh/vnc installer -> just setting links up")
-        log.info("Available interfaces: #{ifaces}")
+        log.info("Configured interfaces: #{connections}")
 
-        LanItems.reload_config(ifaces)
+        reload_config(connections)
       end
     end
 


### PR DESCRIPTION
## Problem

If the network is configured during installation over ssh or vnc, the interfaces are not reloaded and thus, the changes are not reflected in the inst-sys.

- https://trello.com/c/yjXeyDJA/1711-3-sle15-sp2-p2-1166287-additional-network-devices-and-depending-vlans-are-not-set-online-during-installation
- https://bugzilla.suse.com/show_bug.cgi?id=1166287

## Solution

The reload config still used the Lanitems config which is not modified by YaST anymore. Thus, we have modified the code obtaining the list of configured connections names from `Yast::Lan.yast_config`

## Screenshots

![ConfigureVLAN](https://user-images.githubusercontent.com/7056681/76947962-4d889500-68fe-11ea-9915-8f62edc066cd.png)
![ConfiguredVLANCheck](https://user-images.githubusercontent.com/7056681/76947951-482b4a80-68fe-11ea-83e4-fca56a25c593.png)

