### PR TITLE
Do not propose a hostname during AY

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 19 13:52:31 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixed AutoYaST installation crash when defined dns section
+  whitout hostname (bsc#1166953)
+- 4.2.63
+
+-------------------------------------------------------------------
 Wed Mar 18 09:42:36 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do a reload of configured interfaces when writing the

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,8 +1,10 @@
 -------------------------------------------------------------------
 Thu Mar 19 13:52:31 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
-- Fixed AutoYaST installation crash when defined dns section
-  whitout hostname (bsc#1166953)
+- AutoYaST: do not crash when defined dns section whitout hostname
+  (bsc#1166953)
+- AutoYaST: handle the dhcp_hostname option in the dns section
+  correctly
 - 4.2.63
 
 -------------------------------------------------------------------

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.62
+Version:        4.2.63
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/autoinst/hostname_reader.rb
+++ b/src/lib/y2network/autoinst/hostname_reader.rb
@@ -39,7 +39,7 @@ module Y2Network
       # @return [Hostname] the imported {Hostname} config
       def config
         Y2Network::Hostname.new(
-          dhcp_hostname: section.dhcp_hostname,
+          dhcp_hostname: section.dhcp_hostname ? :any : :none,
           static:        static_hostname,
           installer:     section.hostname
         )

--- a/src/lib/y2network/autoinst/hostname_reader.rb
+++ b/src/lib/y2network/autoinst/hostname_reader.rb
@@ -39,7 +39,7 @@ module Y2Network
       # @return [Hostname] the imported {Hostname} config
       def config
         Y2Network::Hostname.new(
-          dhcp_hostname: section.dhcp_hostname ? :any : :none,
+          dhcp_hostname: dhcp_hostname_for(section.dhcp_hostname),
           static:        static_hostname,
           installer:     section.hostname
         )
@@ -52,6 +52,20 @@ module Y2Network
       # @return [String]
       def static_hostname
         Y2Network::Sysconfig::HostnameReader.new.static_hostname
+      end
+
+      # Returns the value for the dhcp_hostname option selected in the profile.
+      # If the option is not present then it is read from the system
+      #
+      # @return [String]
+      def dhcp_hostname_for(section_value)
+        # The autoyast network configuration is usually merge with current
+        # config, but we do not want to override current config if the value is
+        # not present and the merge is missing for whatever reason, for example
+        # in case AutoYaST is called in config mode
+        return Y2Network::Sysconfig::HostnameReader.new.dhcp_hostname if section_value.nil?
+
+        section_value ? :any : :none
       end
     end
   end

--- a/src/lib/y2network/autoinst/hostname_reader.rb
+++ b/src/lib/y2network/autoinst/hostname_reader.rb
@@ -40,7 +40,7 @@ module Y2Network
       def config
         Y2Network::Hostname.new(
           dhcp_hostname: dhcp_hostname_for(section.dhcp_hostname),
-          static:        static_hostname,
+          static:        section.hostname || static_hostname,
           installer:     section.hostname
         )
       end

--- a/src/lib/y2network/autoinst/hostname_reader.rb
+++ b/src/lib/y2network/autoinst/hostname_reader.rb
@@ -40,18 +40,18 @@ module Y2Network
       def config
         Y2Network::Hostname.new(
           dhcp_hostname: section.dhcp_hostname,
-          static:        section.hostname || default_hostname,
+          static:        static_hostname,
           installer:     section.hostname
         )
       end
 
     private
 
-      # Returns a default hostname proposal for installer
+      # Returns the current static_hostname
       #
       # @return [String]
-      def default_hostname
-        Y2Network::Sysconfig::HostnameReader.new.hostname
+      def static_hostname
+        Y2Network::Sysconfig::HostnameReader.new.static_hostname
       end
     end
   end

--- a/src/lib/y2network/sysconfig/hostname_reader.rb
+++ b/src/lib/y2network/sysconfig/hostname_reader.rb
@@ -106,12 +106,19 @@ module Y2Network
         nil
       end
 
-      # Reads the system (local) hostname
+      # Reads the transient hostname or system (local) hostname
       #
       # @return [String, nil] Hostname
       def hostname_from_system
         Yast::Execute.on_target!("/usr/bin/hostname", stdout: :capture).strip
       rescue Cheetah::ExecutionFailed
+        static_hostname
+      end
+
+      # Reads the static hostname from /etc/hostname
+      #
+      # @return [String, nil]
+      def static_hostname
         name = Yast::SCR.Read(Yast::Path.new(".target.string"), "/etc/hostname").to_s.strip
         name.empty? ? nil : name
       end

--- a/src/lib/y2network/sysconfig/hostname_writer.rb
+++ b/src/lib/y2network/sysconfig/hostname_writer.rb
@@ -73,7 +73,7 @@ module Y2Network
       #
       # @param hostname [Y2Network::Hostname] Hostname configuration
       def update_hostname(hostname)
-        hostname = hostname.static
+        hostname = hostname.static.to_s
         # 1) when user asked for erasing hostname from /etc/hostname, we keep runtime as it is
         # 2) we will write whatever user wants even FQDN - no changes under the hood
         Yast::Execute.locally!("/usr/bin/hostname", hostname) if !hostname.empty?

--- a/test/y2network/autoinst/config_reader_test.rb
+++ b/test/y2network/autoinst/config_reader_test.rb
@@ -58,7 +58,8 @@ describe Y2Network::Autoinst::ConfigReader do
         "ipv4_forward" => true,
         "ipv6_forward" => false,
         "routes"       => routes
-      }
+      },
+      "dns"        => dns
     }
   end
 
@@ -67,6 +68,8 @@ describe Y2Network::Autoinst::ConfigReader do
       expect(subject.config).to be_a Y2Network::Config
       expect(subject.config.routing).to be_a Y2Network::Routing
       expect(subject.config.dns).to be_a Y2Network::DNS
+      expect(subject.config.hostname.dhcp_hostname).to eq(:any)
+      expect(subject.config.hostname.installer).to eq("host")
     end
   end
 end

--- a/test/y2network/autoinst/hostname_reader_test.rb
+++ b/test/y2network/autoinst/hostname_reader_test.rb
@@ -54,7 +54,15 @@ describe Y2Network::Autoinst::HostnameReader do
       expect(config).to be_a Y2Network::Hostname
       expect(config.installer).to eq("host")
       expect(config.dhcp_hostname).to eq(:none)
-      expect(config.static).to eq(current_static_hostname)
+      expect(config.static).to eq("host")
+    end
+
+    context "when no hostname option is defined" do
+      let(:profile) { { "dns" => { "dhcp_hostname" => true } } }
+
+      it "reads the current hostname configuration from the system" do
+        expect(subject.config.hostname).to eq(current_static_hostname)
+      end
     end
 
     context "when no dhcp_hostname option is defined" do

--- a/test/y2network/autoinst/hostname_reader_test.rb
+++ b/test/y2network/autoinst/hostname_reader_test.rb
@@ -30,10 +30,13 @@ describe Y2Network::Autoinst::HostnameReader do
   end
 
   let(:current_static_hostname) { "test" }
+  let(:current_dhcp_hostname) { :any }
 
   before do
     allow_any_instance_of(Y2Network::Sysconfig::HostnameReader)
       .to receive(:static_hostname).and_return(current_static_hostname)
+    allow_any_instance_of(Y2Network::Sysconfig::HostnameReader)
+      .to receive(:dhcp_hostname).and_return(current_dhcp_hostname)
   end
 
   let(:profile) do
@@ -52,6 +55,14 @@ describe Y2Network::Autoinst::HostnameReader do
       expect(config.installer).to eq("host")
       expect(config.dhcp_hostname).to eq(:none)
       expect(config.static).to eq(current_static_hostname)
+    end
+
+    context "when no dhcp_hostname option is defined" do
+      let(:profile) { { "dns" => { "hostname" => "another_host" } } }
+
+      it "reads the current dhcp_hostname configuration from the system" do
+        expect(subject.config.dhcp_hostname).to eq(current_dhcp_hostname)
+      end
     end
   end
 end

--- a/test/y2network/autoinst/hostname_reader_test.rb
+++ b/test/y2network/autoinst/hostname_reader_test.rb
@@ -40,7 +40,7 @@ describe Y2Network::Autoinst::HostnameReader do
     {
       "dns" => {
         "hostname" => "host",
-        "dhcp_hostname" => true, "write_hostname" => true
+        "dhcp_hostname" => false, "write_hostname" => true
       }
     }
   end
@@ -50,7 +50,7 @@ describe Y2Network::Autoinst::HostnameReader do
       config = subject.config
       expect(config).to be_a Y2Network::Hostname
       expect(config.installer).to eq("host")
-      expect(config.dhcp_hostname).to eq(true)
+      expect(config.dhcp_hostname).to eq(:none)
       expect(config.static).to eq(current_static_hostname)
     end
   end

--- a/test/y2network/autoinst/hostname_reader_test.rb
+++ b/test/y2network/autoinst/hostname_reader_test.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/autoinst/hostname_reader"
+
+describe Y2Network::Autoinst::HostnameReader do
+  let(:subject) { described_class.new(dns_section) }
+
+  let(:dns_section) do
+    Y2Network::AutoinstProfile::DNSSection.new_from_hashes(profile["dns"])
+  end
+
+  let(:current_static_hostname) { "test" }
+
+  before do
+    allow_any_instance_of(Y2Network::Sysconfig::HostnameReader)
+      .to receive(:static_hostname).and_return(current_static_hostname)
+  end
+
+  let(:profile) do
+    {
+      "dns" => {
+        "hostname" => "host",
+        "dhcp_hostname" => true, "write_hostname" => true
+      }
+    }
+  end
+
+  describe "#config" do
+    it "builds a new Y2Network::Hostname config from the profile dns section" do
+      config = subject.config
+      expect(config).to be_a Y2Network::Hostname
+      expect(config.installer).to eq("host")
+      expect(config.dhcp_hostname).to eq(true)
+      expect(config.static).to eq(current_static_hostname)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

AutoYaST crashes when installing a system with dns_section but without a defined hostname

![HostnameError](https://user-images.githubusercontent.com/7056681/77097803-3f736b00-6a09-11ea-91fe-84bf1243b987.png)

- https://trello.com/c/ZjcRfwqR/1720-important-sle15-sp2-p1-1166953-autoyast-complaining-ie-about-defaulthostname
- https://bugzilla.suse.com/show_bug.cgi?id=1166953

## Solution

- Do not set the static hostname, as it should be read from the system. The value from the profile is set as the installer which should modify the current static.
- Set correctly whether dhcp_hostname should be enable or not
