### PR TITLE
Refresh system config after writing yast_config to the system (bsc#1162987)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Mar 27 14:30:34 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Refresh the current system cached network configuration with the
+  one written avoiding inconsistencies during installation
+  (bsc#1162987)
+- 4.2.64
+
+-------------------------------------------------------------------
 Thu Mar 19 13:52:31 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - AutoYaST: do not crash when defined dns section whitout hostname

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.63
+Version:        4.2.64
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -506,6 +506,8 @@ module Yast
 
       target = :sysconfig if Mode.auto
       yast_config.write(original: system_config, target: target)
+      # Force a refresh of the system_config bsc#1162987
+      add_config(:system, yast_config.copy)
       Progress.set(orig)
       Builtins.sleep(sl)
 


### PR DESCRIPTION
## Problem

Network system configuration is cached by **YaST** the first time it is read, and then it is not refreshed when it is written, thus, some config is not written as it does not see differences between the **yast_config** and the **system_config**.

In this case, before setting the dhcp configuration, the `DHCLIENT_SET_HOSTNAME` is **no**.

YaST enables it when setting the **DHCP** configuration based on the control file default as implemented in https://github.com/yast/yast-network/pull/564

Then, the option is set to **yes** in `yast_config`, it is written to the config file, but it is still cached as **no** in the `system_config`. Which means, that if we set it to **no** in the `GUI` later (`yast_config`), it will not be modified because it is the same in `yast_config` and `system_config`.

- https://trello.com/c/OE476t1s/1728-sles15-sp2-p2-1162987-build-1362-openqa-test-fails-in-hostnameinst-dhclientsethostname-is-not-set-to-no-by-yast-after-user-chang

## Solution

- Replace the cached system network config by the written one after writing.

## Tests

- tested manually