### PR TITLE
S390 devices activation and better chanids handling

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -3,6 +3,8 @@ Thu Apr  2 11:33:49 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: Do not try to activate network devices that are already
   active in S390 systems (bsc#1163149). Related to jsc#SLE-7396.
+- AutoYaST: Allow to use spaces or colons to separate channel IDs
+  in the "chanids" element.
 - 4.2.65
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr  2 11:33:49 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: Do not try to activate network devices that are already
+  active in S390 systems (bsc#1163149). Related to jsc#SLE-7396.
+- 4.2.65
+
+-------------------------------------------------------------------
 Fri Mar 27 14:30:34 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Refresh the current system cached network configuration with the

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.64
+Version:        4.2.65
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -125,15 +125,20 @@ module Yast
       devices_section = Y2Network::AutoinstProfile::S390DevicesSection
         .new_from_hashes(profile_devices)
       connections = Y2Network::Autoinst::S390DevicesReader.new(devices_section).config
-      connections.each do |conn|
 
+      connections.each do |conn|
         builder = Y2Network::InterfaceConfigBuilder.for(conn.type, config: conn)
         activator = Y2Network::S390DeviceActivator.for(builder)
+        if !activator.configured_interface.empty?
+          log.info "Interface #{activator.configured_interface} is already active. " \
+            "Skipping the activation."
+          next
+        end
+
         log.info "Created interface #{activator.configured_interface}" if activator.configure
       rescue RuntimeError => e
         log.error("An error ocurred when trying to activate the s390 device: #{conn.inspect}")
-        log.error("Error: #{e.sinpect}")
-
+        log.error("Error: #{e.inspect}")
       end
 
       true

--- a/src/lib/y2network/autoinst/s390_devices_reader.rb
+++ b/src/lib/y2network/autoinst/s390_devices_reader.rb
@@ -86,6 +86,7 @@ module Y2Network
 
       # Returns the list of channel IDs from a string
       #
+      # @param ids [String] String representing the channel IDs
       # @return [Array<String>]
       def chanids_from(ids)
         ids.to_s.split(CHANIDS_SEPARATOR)

--- a/src/lib/y2network/autoinst/s390_devices_reader.rb
+++ b/src/lib/y2network/autoinst/s390_devices_reader.rb
@@ -66,18 +66,29 @@ module Y2Network
       end
 
       def load_qeth(config, device_section)
-        chanids = device_section.chanids
-        config.read_channel, config.write_channel, config.data_channel = chanids.split(" ")
+        config.read_channel, config.write_channel, config.data_channel =
+          chanids_from(device_section.chanids)
         config.layer2 = device_section.layer2
       end
 
       def load_ctc(config, device_section)
-        config.read_channel, config.write_channel = device_section.chanids.split(" ")
+        config.read_channel, config.write_channel = chanids_from(device_section.chanids)
         config.protocol = device_section.protocol
       end
 
       def load_lcs(config, device_section)
-        config.read_channel, config.write_channel = device_section.chanids.split(" ")
+        config.read_channel, config.write_channel = chanids_from(device_section.chanids)
+      end
+
+      # Separator used for the list of channel IDs
+      CHANIDS_SEPARATOR = ":".freeze
+      private_constant :CHANIDS_SEPARATOR
+
+      # Returns the list of channel IDs from a string
+      #
+      # @return [Array<String>]
+      def chanids_from(ids)
+        ids.to_s.split(CHANIDS_SEPARATOR)
       end
     end
   end

--- a/src/lib/y2network/autoinst_profile/s390_device_section.rb
+++ b/src/lib/y2network/autoinst_profile/s390_device_section.rb
@@ -44,7 +44,7 @@ module Y2Network
       define_attr_accessors
 
       # @!attribute chanids
-      #   @return [String] channel device id separated by spaces
+      #   @return [String] channel device id separated by spaces or colons
 
       # @!attribute layer2
       #   @return [Boolean] Whether layer2 is enabler or not
@@ -71,6 +71,17 @@ module Y2Network
         result
       end
 
+      # Creates an instance based on the profile representation used by the AutoYaST modules
+      # (array of hashes objects).
+      #
+      # @param hash [Hash] Networking section from an AutoYaST profile
+      # @return [S390DeviceSection]
+      def self.new_from_hashes(hash)
+        result = new
+        result.init_from_hashes(hash)
+        result
+      end
+
       # Method used by {.new_from_network} to populate the attributes when cloning a network s390
       # device
       #
@@ -90,6 +101,25 @@ module Y2Network
         end
 
         true
+      end
+
+      # Method used by {.new_from_hashes} to populate the attributes when importing a profile
+      #
+      # @param hash [Hash] see {.new_from_hashes}
+      def init_from_hashes(hash)
+        super
+        self.chanids = normalized_chanids(hash["chanids"]) if hash["chanids"]
+      end
+
+    private
+
+      # Normalizes the list of channel IDs
+      #
+      # It replaces spaces with colons.
+      #
+      # @return [String]
+      def normalized_chanids(ids)
+        ids.gsub(/\ +/, ":")
       end
     end
   end

--- a/src/lib/y2network/autoinst_profile/s390_device_section.rb
+++ b/src/lib/y2network/autoinst_profile/s390_device_section.rb
@@ -117,6 +117,7 @@ module Y2Network
       #
       # It replaces spaces with colons.
       #
+      # @param ids [String] String representing the channel IDs
       # @return [String]
       def normalized_chanids(ids)
         ids.gsub(/\ +/, ":")

--- a/src/lib/y2network/hwinfo.rb
+++ b/src/lib/y2network/hwinfo.rb
@@ -37,7 +37,7 @@ module Y2Network
       read_hardware
       @netcards = ReadHardware("netcard").map do |attrs|
         name = attrs["dev_name"]
-        extra_attrs = name ? extra_attrs_for(name) : {}
+        extra_attrs = name.to_s.empty? ? {} : extra_attrs_for(name)
         Hwinfo.new(attrs.merge(extra_attrs))
       end
     end

--- a/test/y2network/autoinst/s390_devices_reader_test.rb
+++ b/test/y2network/autoinst/s390_devices_reader_test.rb
@@ -51,8 +51,19 @@ describe Y2Network::Autoinst::S390DevicesReader do
 
   describe "#config" do
     it "builds a new Y2Network::ConnectionConfigsCollection" do
-      expect(subject.config).to be_a Y2Network::ConnectionConfigsCollection
-      expect(subject.config.size).to eq(2)
+      expect(subject.config).to contain_exactly(
+        an_object_having_attributes(
+          read_channel:  "0.0.0700",
+          write_channel: "0.0.0701",
+          data_channel:  "0.0.0702"
+        ),
+        an_object_having_attributes(
+          read_channel:  "0.0.0800",
+          write_channel: "0.0.0801",
+          data_channel:  "0.0.0802",
+          layer2:        true
+        )
+      )
     end
   end
 end

--- a/test/y2network/autoinst_profile/s390_device_section_test.rb
+++ b/test/y2network/autoinst_profile/s390_device_section_test.rb
@@ -62,7 +62,23 @@ describe Y2Network::AutoinstProfile::S390DeviceSection do
     it "loads properly boot protocol" do
       section = described_class.new_from_hashes(hash)
       expect(section.type).to eq "ctc"
+      expect(section.chanids).to eq("0.0.0800:0.0.0801")
       expect(section.protocol).to eq "1"
+    end
+
+    context "using the old syntax for chanids" do
+      let(:hash) do
+        {
+          "type"     => "ctc",
+          "chanids"  => "0.0.0800 0.0.0801",
+          "protocol" => "1"
+        }
+      end
+
+      it "loads properly boot protocol" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.chanids).to eq("0.0.0800:0.0.0801")
+      end
     end
   end
 end

--- a/test/y2network/autoinst_profile/s390_device_section_test.rb
+++ b/test/y2network/autoinst_profile/s390_device_section_test.rb
@@ -59,7 +59,7 @@ describe Y2Network::AutoinstProfile::S390DeviceSection do
       }
     end
 
-    it "loads properly boot protocol" do
+    it "loads properly type, chanids and boot protocol" do
       section = described_class.new_from_hashes(hash)
       expect(section.type).to eq "ctc"
       expect(section.chanids).to eq("0.0.0800:0.0.0801")
@@ -75,7 +75,7 @@ describe Y2Network::AutoinstProfile::S390DeviceSection do
         }
       end
 
-      it "loads properly boot protocol" do
+      it "loads properly the chanids" do
         section = described_class.new_from_hashes(hash)
         expect(section.chanids).to eq("0.0.0800:0.0.0801")
       end


### PR DESCRIPTION
This PR fixes two issues:

* Activation of devices that were already active in S390 systems. It is the network counterpart of https://github.com/yast/yast-s390/pull/81.
* Allow importing `chanids` using the spaces or colons as separators. It is preferred to use colons, to be consistent with the `lszdev` tool, but we need to be backward compatible.

A fix for the documentation will follow.