### PR TITLE
Avoid Bond Slaves error in s390

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 10 11:10:29 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Avoid error when accessing to Bond Slaves in s390 (bsc#1172444).
+- 4.2.68
+
+-------------------------------------------------------------------
 Mon Jun  8 08:15:26 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - AutoYaST: Udev rules are written or copied to the target system

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.67
+Version:        4.2.68
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/lan/s390.rb
+++ b/src/include/network/lan/s390.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -24,6 +24,7 @@ module Yast
 
     def initialize_network_lan_s390(_include_target)
       Yast.import "FileUtils"
+      Yast.import "Arch"
     end
 
     # Checks if driver was successfully loaded for particular device.
@@ -43,7 +44,7 @@ module Yast
 
       result = Convert.to_string(
         SCR.Read(
-          path(".target.string"),
+          Yast.path(".target.string"),
           Builtins.sformat("%1/%2/device/%3", SYS_DIR, devname, attrib)
         )
       )
@@ -92,7 +93,7 @@ module Yast
 
       Builtins.y2debug("s390_ReadQethConfig: %1", result)
 
-      deep_copy(result)
+      Yast.deep_copy(result)
     end
   end
 end

--- a/src/include/network/lan/s390.rb
+++ b/src/include/network/lan/s390.rb
@@ -29,10 +29,10 @@ module Yast
 
     # Checks if driver was successfully loaded for particular device.
     def s390_DriverLoaded(devname)
-      return false if !Arch.s390
+      return false if !Yast::Arch.s390
       return false if devname.empty?
 
-      FileUtils.IsDirectory("#{SYS_DIR}/#{devname}") == true
+      Yast::FileUtils.IsDirectory("#{SYS_DIR}/#{devname}") == true
     end
 
     # Reads particular qeth attribute and returns its value as a string.
@@ -42,14 +42,14 @@ module Yast
     def s390_ReadQethAttribute(devname, attrib)
       return nil if !s390_DriverLoaded(devname)
 
-      result = Convert.to_string(
-        SCR.Read(
+      result = Yast::Convert.to_string(
+        Yast::SCR.Read(
           Yast.path(".target.string"),
-          Builtins.sformat("%1/%2/device/%3", SYS_DIR, devname, attrib)
+          Yast::Builtins.sformat("%1/%2/device/%3", SYS_DIR, devname, attrib)
         )
       )
 
-      Builtins.regexpsub(result, "(.*)\n", "\\1")
+      Yast::Builtins.regexpsub(result, "(.*)\n", "\\1")
     end
 
     # Reads attributes for particular qeth based network device.
@@ -73,25 +73,25 @@ module Yast
       result = {}
 
       qeth_layer2 = (s390_ReadQethAttribute(devname, "layer2") == "1") ? "yes" : "no"
-      result = Builtins.add(result, "QETH_LAYER2", qeth_layer2)
+      result = Yast::Builtins.add(result, "QETH_LAYER2", qeth_layer2)
 
       qeth_portno = s390_ReadQethAttribute(devname, "portno")
-      result = Builtins.add(result, "QETH_PORTNUMBER", qeth_portno)
+      result = Yast::Builtins.add(result, "QETH_PORTNUMBER", qeth_portno)
 
       # FIXME: another code handles chanids merged in one string separated by spaces.
       read_chan = s390_ReadQethAttribute(devname, "cdev0")
       write_chan = s390_ReadQethAttribute(devname, "cdev1")
       ctrl_chan = s390_ReadQethAttribute(devname, "cdev2")
-      qeth_chanids = Builtins.mergestring(
+      qeth_chanids = Yast::Builtins.mergestring(
         [read_chan, write_chan, ctrl_chan],
         " "
       )
-      result = Builtins.add(result, "QETH_CHANIDS", qeth_chanids)
+      result = Yast::Builtins.add(result, "QETH_CHANIDS", qeth_chanids)
 
       # TODO: ipa_takover. study a bit. It cannot be read from /sys. Not visible using lsqeth,
       # qethconf configures it.
 
-      Builtins.y2debug("s390_ReadQethConfig: %1", result)
+      Yast::Builtins.y2debug("s390_ReadQethConfig: %1", result)
 
       Yast.deep_copy(result)
     end


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1172444

In s390, when we are configuring a network card and we go to the Bond Slaves tab, an exception is raised because method `#path` is not defined.

## Solution

Prefix methods with `Yast` namespace.

## Testing

* Added unit tests.
