### PR TITLE
Bring back the installation of 'wireless-tools' when scanning wireless networks

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 11 08:24:34 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Try to install the wireless-tools package when the package is
+  not installed and the wifi networks are scanned (bsc#1168479)
+- 4.2.69
+
+-------------------------------------------------------------------
 Wed Jun 10 11:10:29 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Avoid error when accessing to Bond Slaves in s390 (bsc#1172444).

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.68
+Version:        4.2.69
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/wireless_essid.rb
+++ b/src/lib/y2network/widgets/wireless_essid.rb
@@ -123,7 +123,7 @@ module Y2Network
       IWLIST_PKG = "wireless-tools".freeze
 
       def scan_supported?
-        return true if package_installed?
+        return true if install_needed_packages
 
         Yast::Popup.Error(
           _("The package %s was not installed. It is needed in order to " \
@@ -136,7 +136,7 @@ module Y2Network
       # wlan network (bsc#1112952, bsc#1168479)
       #
       # TODO: drop it when supported by wicked directly
-      def package_installed?
+      def install_needed_packages
         Yast::Stage.initial ||
           Yast::Package.Installed(IWLIST_PKG) ||
           Yast::Package.Install(IWLIST_PKG)

--- a/src/lib/y2network/widgets/wireless_essid.rb
+++ b/src/lib/y2network/widgets/wireless_essid.rb
@@ -22,6 +22,8 @@ require "cwm/custom_widget"
 require "yast2/feedback"
 
 Yast.import "String"
+Yast.import "Package"
+Yast.import "Stage"
 
 module Y2Network
   module Widgets
@@ -110,20 +112,46 @@ module Y2Network
       end
 
       def handle
-        networks = essid_list
+        return unless scan_supported?
+
+        @update_widget&.update_essid_list(fetch_essid_list)
+        nil
+      end
+
+    private
+
+      IWLIST_PKG = "wireless-tools".freeze
+
+      def scan_supported?
+        return true if package_installed?
+
+        Yast::Popup.Error(
+          _("The package %s was not installed. It is needed in order to " \
+            "be able to scan the network") % IWLIST_PKG
+        )
+        false
+      end
+
+      # Require wireless-tools installation in order to be able to scan the
+      # wlan network (bsc#1112952, bsc#1168479)
+      #
+      # TODO: drop it when supported by wicked directly
+      def package_installed?
+        Yast::Stage.initial ||
+          Yast::Package.Installed(IWLIST_PKG) ||
+          Yast::Package.Install(IWLIST_PKG)
+      end
+
+      def fetch_essid_list
+        networks = []
 
         Yast2::Feedback.show("Obtaining essid list", headline: "Scanning network") do |_f|
           networks = essid_list
           log.info("Found networks: #{networks}")
         end
 
-        return unless @update_widget
-
-        @update_widget.update_essid_list(networks)
-        nil
+        networks
       end
-
-    private
 
       # TODO: own class and do not call directly in widget.
       def essid_list


### PR DESCRIPTION
## Problem

In order to scan available wireless networks we need the package that provides the `iwlist` command. This dependency was removed in `network-ng` as wicked planned to support the scan directly, but as it is still not the case the user needs to manually install the package in order to perform the wireless networks scan.

- https://bugzilla.suse.com/show_bug.cgi?id=1168479

## Solution

Bring back the installation of the package when missing.

## Tests

- Tested manually
- Unit test added