### PR TITLE
Avoid Bond Slaves error in s390 (forward-port to master)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 10 11:10:29 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Avoid error when accessing to Bond Slaves in s390 (bsc#1172444).
+- 4.3.4
+
+-------------------------------------------------------------------
 Mon Jun  8 08:15:26 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - AutoYaST: Udev rules are written or copied to the target system

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only
@@ -73,7 +73,7 @@ BuildArch:      noarch
 
 %build
 
-%description 
+%description
 This package contains the YaST2 component for network configuration.
 
 %prep

--- a/src/include/network/lan/s390.rb
+++ b/src/include/network/lan/s390.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -24,14 +24,15 @@ module Yast
 
     def initialize_network_lan_s390(_include_target)
       Yast.import "FileUtils"
+      Yast.import "Arch"
     end
 
     # Checks if driver was successfully loaded for particular device.
     def s390_DriverLoaded(devname)
-      return false if !Arch.s390
+      return false if !Yast::Arch.s390
       return false if devname.empty?
 
-      FileUtils.IsDirectory("#{SYS_DIR}/#{devname}") == true
+      Yast::FileUtils.IsDirectory("#{SYS_DIR}/#{devname}") == true
     end
 
     # Reads particular qeth attribute and returns its value as a string.
@@ -41,14 +42,14 @@ module Yast
     def s390_ReadQethAttribute(devname, attrib)
       return nil if !s390_DriverLoaded(devname)
 
-      result = Convert.to_string(
-        SCR.Read(
-          path(".target.string"),
-          Builtins.sformat("%1/%2/device/%3", SYS_DIR, devname, attrib)
+      result = Yast::Convert.to_string(
+        Yast::SCR.Read(
+          Yast.path(".target.string"),
+          Yast::Builtins.sformat("%1/%2/device/%3", SYS_DIR, devname, attrib)
         )
       )
 
-      Builtins.regexpsub(result, "(.*)\n", "\\1")
+      Yast::Builtins.regexpsub(result, "(.*)\n", "\\1")
     end
 
     # Reads attributes for particular qeth based network device.
@@ -72,27 +73,27 @@ module Yast
       result = {}
 
       qeth_layer2 = (s390_ReadQethAttribute(devname, "layer2") == "1") ? "yes" : "no"
-      result = Builtins.add(result, "QETH_LAYER2", qeth_layer2)
+      result = Yast::Builtins.add(result, "QETH_LAYER2", qeth_layer2)
 
       qeth_portno = s390_ReadQethAttribute(devname, "portno")
-      result = Builtins.add(result, "QETH_PORTNUMBER", qeth_portno)
+      result = Yast::Builtins.add(result, "QETH_PORTNUMBER", qeth_portno)
 
       # FIXME: another code handles chanids merged in one string separated by spaces.
       read_chan = s390_ReadQethAttribute(devname, "cdev0")
       write_chan = s390_ReadQethAttribute(devname, "cdev1")
       ctrl_chan = s390_ReadQethAttribute(devname, "cdev2")
-      qeth_chanids = Builtins.mergestring(
+      qeth_chanids = Yast::Builtins.mergestring(
         [read_chan, write_chan, ctrl_chan],
         " "
       )
-      result = Builtins.add(result, "QETH_CHANIDS", qeth_chanids)
+      result = Yast::Builtins.add(result, "QETH_CHANIDS", qeth_chanids)
 
       # TODO: ipa_takover. study a bit. It cannot be read from /sys. Not visible using lsqeth,
       # qethconf configures it.
 
-      Builtins.y2debug("s390_ReadQethConfig: %1", result)
+      Yast::Builtins.y2debug("s390_ReadQethConfig: %1", result)
 
-      deep_copy(result)
+      Yast.deep_copy(result)
     end
   end
 end

--- a/test/y2network/interface_config_builders/bonding_test.rb
+++ b/test/y2network/interface_config_builders/bonding_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -47,8 +47,104 @@ describe Y2Network::InterfaceConfigBuilders::Bonding do
   end
 
   describe "#bondable_interfaces" do
-    it "returns array" do
+    before do
+      allow(config).to receive(:interfaces).and_return(interfaces_collection)
+
+      allow(config).to receive(:connections).and_return(connection_configs_collection)
+
+      allow(connection_config).to receive(:name).and_return(connection_name)
+
+      allow(connection_config).to receive(:find_master).and_return(connection_master)
+
+      allow(Yast::Arch).to receive(:s390).and_return(s390)
+    end
+
+    let(:interfaces_collection) do
+      Y2Network::InterfacesCollection.new([interface1, interface2])
+    end
+
+    let(:connection_configs_collection) do
+      Y2Network::ConnectionConfigsCollection.new([connection_config])
+    end
+
+    let(:interface1) { Y2Network::Interface.new("iface1") }
+
+    let(:interface2) { Y2Network::Interface.new("iface2") }
+
+    let(:connection_config) { Y2Network::ConnectionConfig::Bonding.new }
+
+    let(:connection_name) { "" }
+
+    let(:connection_master) { nil }
+
+    let(:s390) { false }
+
+    shared_examples "interface filters" do
+      context "when an interface does not have a connection config yet" do
+        let(:connection_name) { "iface2" } # only iface2 has a config
+
+        it "includes the interface without a connection config" do
+          expect(subject.bondable_interfaces).to include(interface1)
+        end
+      end
+
+      context "when an interface has a connection config" do
+        let(:connection_name) { "iface1" }
+
+        context "and there already is a master connection" do
+          let(:connection_master) do
+            instance_double(Y2Network::ConnectionConfig::Bonding, name: "bond1")
+          end
+
+          it "does not include the interface" do
+            expect(subject.bondable_interfaces).to_not include(interface1)
+          end
+        end
+
+        context "and there is no master connection yet" do
+          let(:connection_master) { nil }
+
+          it "includes the interface" do
+            expect(subject.bondable_interfaces).to include(interface1)
+          end
+        end
+      end
+    end
+
+    it "returns an array" do
       expect(subject.bondable_interfaces).to be_a(::Array)
+    end
+
+    context "when the architecture is s390" do
+      let(:s390) { true }
+
+      before do
+        allow(Yast::FileUtils).to receive(:IsDirectory).and_return(true)
+      end
+
+      context "and the interface has no L2 support" do
+        before do
+          allow(Yast::SCR).to receive(:Read).with(anything, /.*iface1.*\/layer2/).and_return("0\n")
+        end
+
+        it "does not include the interface" do
+          expect(subject.bondable_interfaces).to_not include(interface1)
+        end
+      end
+
+      context "and the interface has L2 support" do
+        before do
+          allow(Yast::SCR).to receive(:Read).with(anything, /.*iface1.*\/layer2/).and_return("1\n")
+        end
+
+        include_examples "interface filters"
+      end
+    end
+
+    context "when the architecture is not s390" do
+      let(:s390) { false }
+
+      include_examples "interface filters"
     end
   end
 end


### PR DESCRIPTION
See https://github.com/yast/yast-network/pull/1072 and https://github.com/yast/yast-network/pull/1074.