### PR TITLE
Reduce export

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 19 18:24:34 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not export any settings when NetworkManager is the network
+  backend (bsc#1172822).
+- 4.3.8
+
+-------------------------------------------------------------------
 Fri Jun 19 08:52:54 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Save inst-sys memory by ending ag_udev_persistent after use

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -33,8 +33,8 @@ BuildRequires:  yast2-devtools >= 3.1.15
 #for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  yast2-storage-ng
-# AutoYaST issue handling
-BuildRequires:  yast2 >= 4.3.3
+# NetworkService.use
+BuildRequires:  yast2 >= 4.3.9
 BuildRequires:  yast2-packager >= 4.0.18
 # Product control need xml agent
 BuildRequires:  yast2-xml
@@ -48,8 +48,8 @@ PreReq:         /bin/rm
 Requires:       sysconfig >= 0.80.0
 Requires:       yast2-proxy
 Requires:       yast2-storage-ng
-# AutoYaST issue handling
-Requires:       yast2 >= 4.3.2
+# NetworkService.use
+Requires:       yast2 >= 4.3.9
 # Packages::vnc_packages
 Requires:       yast2-packager >= 4.0.18
 Requires:       rubygem(%rb_default_ruby_abi:cfa) >= 0.6.4

--- a/src/include/network/routines.rb
+++ b/src/include/network/routines.rb
@@ -41,8 +41,6 @@ module Yast
       Yast.import "Popup"
       Yast.import "Progress"
       Yast.import "String"
-      Yast.import "NetworkService"
-      Yast.import "NetworkInterfaces"
       Yast.import "Arch"
       Yast.import "Confirm"
       Yast.import "Map"
@@ -678,8 +676,9 @@ module Yast
     end
 
     def unconfigureable_service?
-      return true if Mode.normal && NetworkService.is_network_manager
-      return true if NetworkService.is_disabled
+      Yast.import "Lan"
+      return true if Mode.normal && Lan.yast_config&.backend?(:network_manager)
+      return true unless Lan.yast_config&.backend
 
       false
     end

--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -36,10 +36,8 @@ module Yast
       Yast.import "Hostname"
       Yast.import "IP"
       Yast.import "Label"
-      Yast.import "LanItems"
       Yast.import "Popup"
       Yast.import "Map"
-      Yast.import "NetworkService"
 
       Yast.include include_target, "network/routines.rb"
       Yast.include include_target, "network/widgets.rb"
@@ -386,7 +384,7 @@ module Yast
 
     # Init handler for DHCP_HOSTNAME
     def InitDhcpHostname(_key)
-      UI.ChangeWidget(Id("DHCP_HOSTNAME"), :Enabled, dhcp? && NetworkService.is_wicked)
+      UI.ChangeWidget(Id("DHCP_HOSTNAME"), :Enabled, dhcp? && config&.backend?(:wicked))
       dhcp_hostname = DNS.dhcp_hostname
 
       items = [

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -89,7 +89,7 @@ module Yast
 
     def config
       # TODO: get it from some config holder
-      Yast::Lan.yast_config
+      @config ||= Yast::Lan.yast_config
     end
 
     def routing_table_widget

--- a/src/include/network/services/routing.rb
+++ b/src/include/network/services/routing.rb
@@ -89,7 +89,7 @@ module Yast
 
     def config
       # TODO: get it from some config holder
-      @config ||= Yast::Lan.yast_config
+      Yast::Lan.yast_config
     end
 
     def routing_table_widget

--- a/src/include/network/widgets.rb
+++ b/src/include/network/widgets.rb
@@ -59,9 +59,7 @@ module Yast
     def ManagedInit(_key)
       items = []
 
-      Y2Network::Backend.all.each do |backend|
-        next unless backend.available?
-
+      Y2Network::Backend.available.each do |backend|
         items << Item(
           Id(backend.name),
           # the user can control the network with the NetworkManager program

--- a/src/lib/network/clients/inst_lan.rb
+++ b/src/lib/network/clients/inst_lan.rb
@@ -100,7 +100,7 @@ module Yast
     end
 
     # It returns whether the network has been configured or not. It returns
-    # true in case NetworkManager is in use, otherwise returns whehter there is
+    # true in case NetworkManager is in use, otherwise returns whether there is
     # some connection configured
     #
     # @see connections_configured?

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -82,7 +82,7 @@ module Yast
 
       if use_network_manager && Lan.yast_config.backend.available?
         log.info("- using NetworkManager")
-        NetworkService.use_networ_kmanager
+        NetworkService.use_network_manager
       else
         log.info("- using wicked")
         log.warn("- NetworkManager requested but not available") if use_network_manager

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -78,9 +78,7 @@ module Yast
 
       log.info("Setting network service according to AY profile")
 
-      use_network_manager = ay_networking_section["managed"]
-      use_network_manager = Lan.UseNetworkManager if use_network_manager.nil?
-
+      use_network_manager = Lan.yast_config&.backend?(:network_manager)
       nm_available = NetworkService.is_backend_available(:network_manager) if use_network_manager
 
       if use_network_manager && nm_available

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -82,13 +82,14 @@ module Yast
 
       if use_network_manager && Lan.yast_config.backend.available?
         log.info("- using NetworkManager")
+        NetworkService.use_networ_kmanager
       else
         log.info("- using wicked")
         log.warn("- NetworkManager requested but not available") if use_network_manager
         Lan.yast_config&.backend = :wicked
+        NetworkService.use_wicked
       end
 
-      Lan.yast_config&.backend&.use!
       NetworkService.EnableDisableNow
     end
 

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -79,9 +79,8 @@ module Yast
       log.info("Setting network service according to AY profile")
 
       use_network_manager = Lan.yast_config&.backend?(:network_manager)
-      nm_available = NetworkService.is_backend_available(:network_manager) if use_network_manager
 
-      if use_network_manager && nm_available
+      if use_network_manager && Lan.yast_config.backend.available?
         log.info("- using NetworkManager")
 
         NetworkService.use_network_manager

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -82,15 +82,13 @@ module Yast
 
       if use_network_manager && Lan.yast_config.backend.available?
         log.info("- using NetworkManager")
-
-        NetworkService.use_network_manager
       else
         log.info("- using wicked")
         log.warn("- NetworkManager requested but not available") if use_network_manager
-
-        NetworkService.use_wicked
+        Lan.yast_config&.backend = :wicked
       end
 
+      Lan.yast_config&.backend&.use!
       NetworkService.EnableDisableNow
     end
 

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -82,14 +82,13 @@ module Yast
 
       if use_network_manager && Lan.yast_config.backend.available?
         log.info("- using NetworkManager")
-        NetworkService.use_network_manager
       else
         log.info("- using wicked")
         log.warn("- NetworkManager requested but not available") if use_network_manager
         Lan.yast_config&.backend = :wicked
-        NetworkService.use_wicked
       end
 
+      NetworkService.use(Lan.yast_config&.backend&.id)
       NetworkService.EnableDisableNow
     end
 

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -64,6 +64,7 @@ module Yast
     # @param query [String] xpath query. See man wicked for info what is supported there.
     # @return [String] result of the query
     def query_wicked(iface, query)
+      Yast.import "NetworkService"
       raise ArgumentError, "A network device has to be specified" if iface.nil? || iface.empty?
       raise "Parsing not supported for network service in use" if !NetworkService.is_wicked
 

--- a/src/lib/y2network/autoinst_profile/dns_section.rb
+++ b/src/lib/y2network/autoinst_profile/dns_section.rb
@@ -103,7 +103,7 @@ module Y2Network
       #
       # @return [Boolean] Result true on success or false otherwise
       def init_from_network(dns, hostname)
-        @dhcp_hostname = hostname.dhcp_hostname
+        @dhcp_hostname = hostname.dhcp_hostname == :any
         @hostname = hostname.hostname
         @nameservers = dns.nameservers.map(&:to_s)
         @resolv_conf_policy = dns.resolv_conf_policy

--- a/src/lib/y2network/backend.rb
+++ b/src/lib/y2network/backend.rb
@@ -1,0 +1,89 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+module Y2Network
+  # This class is the base class for the different network backends and also
+  # responsible of listing the supported ones.
+  class Backend
+    include Yast::I18n
+
+    # @return [Symbol] backend id
+    attr_reader :id
+
+    # Constructor
+    #
+    # @param id [Symbol]
+    def initialize(id)
+      textdomain "network"
+      Yast.import "NetworkService"
+
+      @id = id
+    end
+
+    # Return the backend short name
+    #
+    # @return [String]
+    def name
+      id.to_s
+    end
+
+    def ==(other)
+      return false unless other
+
+      id == other.id
+    end
+
+    alias_method :eql?, :==
+
+    # Return the translated backend label
+    #
+    # @return [String]
+    def label
+      raise NotImplementedError
+    end
+
+    alias_method :to_s, :name
+
+    # Return all the supported backends
+    #
+    # @return [Array<Backend>]
+    def self.all
+      require "y2network/backends"
+      Backends.constants.map { |c| Backends.const_get(c).new }
+    end
+
+    def self.by_id(id)
+      all.find { |b| b.id == id }
+    end
+
+    # Return whether the backend is available or not
+    #
+    # @return [Boolean]
+    def available?
+      Yast::NetworkService.is_backend_available(id)
+    end
+
+    # Sets the backend to be used as the current network service
+    def use!
+      Yast::NetworkService.public_send("use_#{id}")
+    end
+  end
+end

--- a/src/lib/y2network/backend.rb
+++ b/src/lib/y2network/backend.rb
@@ -91,10 +91,5 @@ module Y2Network
     def available?
       Yast::NetworkService.is_backend_available(id)
     end
-
-    # Sets the backend to be used as the current network service
-    def use!
-      Yast::NetworkService.public_send("use_#{id}")
-    end
   end
 end

--- a/src/lib/y2network/backend.rb
+++ b/src/lib/y2network/backend.rb
@@ -67,9 +67,20 @@ module Y2Network
     # @return [Array<Backend>]
     def self.all
       require "y2network/backends"
-      Backends.constants.map { |c| Backends.const_get(c).new }
+      @all ||= Backends.constants.map { |c| Backends.const_get(c).new }
     end
 
+    # Return all the supported and installed backends
+    #
+    # @return [Array<Backend>]
+    def self.available
+      all.select(&:available?)
+    end
+
+    # Return the backend with the given id when supported
+    #
+    # @param id [Symbol] the backend id to be find
+    # @return [Backend, nil]
     def self.by_id(id)
       all.find { |b| b.id == id }
     end

--- a/src/lib/y2network/backends.rb
+++ b/src/lib/y2network/backends.rb
@@ -1,0 +1,3 @@
+require "y2network/backends/network_manager"
+require "y2network/backends/wicked"
+require "y2network/backends/netconfig"

--- a/src/lib/y2network/backends/netconfig.rb
+++ b/src/lib/y2network/backends/netconfig.rb
@@ -5,6 +5,7 @@ module Y2Network
     # This class represents the Netconfig backend
     class Netconfig < Backend
       def initialize
+        textdomain "network"
         super(:netconfig)
       end
 

--- a/src/lib/y2network/backends/netconfig.rb
+++ b/src/lib/y2network/backends/netconfig.rb
@@ -1,3 +1,22 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require "y2network/backend"
 
 module Y2Network

--- a/src/lib/y2network/backends/netconfig.rb
+++ b/src/lib/y2network/backends/netconfig.rb
@@ -1,0 +1,16 @@
+require "y2network/backend"
+
+module Y2Network
+  module Backends
+    # This class represents the Netconfig backend
+    class Netconfig < Backend
+      def initialize
+        super(:netconfig)
+      end
+
+      def label
+        _("Traditional ifup")
+      end
+    end
+  end
+end

--- a/src/lib/y2network/backends/network_manager.rb
+++ b/src/lib/y2network/backends/network_manager.rb
@@ -5,6 +5,7 @@ module Y2Network
     # This class represents the NetworkManager backend
     class NetworkManager < Backend
       def initialize
+        textdomain "network"
         super(:network_manager)
       end
 

--- a/src/lib/y2network/backends/network_manager.rb
+++ b/src/lib/y2network/backends/network_manager.rb
@@ -1,3 +1,22 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require "y2network/backend"
 
 module Y2Network

--- a/src/lib/y2network/backends/network_manager.rb
+++ b/src/lib/y2network/backends/network_manager.rb
@@ -1,0 +1,16 @@
+require "y2network/backend"
+
+module Y2Network
+  module Backends
+    # This class represents the NetworkManager backend
+    class NetworkManager < Backend
+      def initialize
+        super(:network_manager)
+      end
+
+      def label
+        _("Network Manager")
+      end
+    end
+  end
+end

--- a/src/lib/y2network/backends/wicked.rb
+++ b/src/lib/y2network/backends/wicked.rb
@@ -5,6 +5,7 @@ module Y2Network
     # This class represents the wicked backend
     class Wicked < Backend
       def initialize
+        textdomain "network"
         super(:wicked)
       end
 

--- a/src/lib/y2network/backends/wicked.rb
+++ b/src/lib/y2network/backends/wicked.rb
@@ -1,3 +1,22 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require "y2network/backend"
 
 module Y2Network

--- a/src/lib/y2network/backends/wicked.rb
+++ b/src/lib/y2network/backends/wicked.rb
@@ -1,0 +1,16 @@
+require "y2network/backend"
+
+module Y2Network
+  module Backends
+    # This class represents the wicked backend
+    class Wicked < Backend
+      def initialize
+        super(:wicked)
+      end
+
+      def label
+        _("Wicked Service")
+      end
+    end
+  end
+end

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -22,7 +22,6 @@ require "cwm/table"
 require "y2network/presenters/interface_summary"
 require "y2network/presenters/s390_group_device_summary"
 
-Yast.import "NetworkService"
 Yast.import "Lan"
 Yast.import "Popup"
 Yast.import "UI"
@@ -65,7 +64,7 @@ module Y2Network
 
       # Workaround for usage in old CWM which also cache content of cwm items
       def init
-        if Yast::NetworkService.is_network_manager
+        if config.backend?(:network_manager)
           Yast::Popup.Warning(
             _(
               "Network is currently handled by NetworkManager\n" \

--- a/src/lib/y2network/widgets/ip4_forwarding.rb
+++ b/src/lib/y2network/widgets/ip4_forwarding.rb
@@ -18,7 +18,6 @@
 # find current contact information at www.suse.com.
 
 require "cwm/common_widgets"
-Yast.import "NetworkService"
 
 module Y2Network
   module Widgets
@@ -31,7 +30,7 @@ module Y2Network
 
       def init
         self.value = @config.routing.forward_ipv4
-        disable if Yast::NetworkService.network_manager?
+        disable if @config.backend?(:network_manager)
       end
 
       def store

--- a/src/lib/y2network/widgets/ip6_forwarding.rb
+++ b/src/lib/y2network/widgets/ip6_forwarding.rb
@@ -18,7 +18,6 @@
 # find current contact information at www.suse.com.
 
 require "cwm/common_widgets"
-Yast.import "NetworkService"
 
 module Y2Network
   module Widgets
@@ -31,7 +30,7 @@ module Y2Network
 
       def init
         self.value = @config.routing.forward_ipv6
-        disable if Yast::NetworkService.network_manager?
+        disable if @config.backend?(:network_manager)
       end
 
       def store

--- a/src/lib/y2network/widgets/routing_buttons.rb
+++ b/src/lib/y2network/widgets/routing_buttons.rb
@@ -43,7 +43,7 @@ module Y2Network
       end
 
       def init
-        disable if Yast::NetworkService.network_manager?
+        disable if @config.backend?(:network_manager)
       end
     end
 
@@ -69,7 +69,7 @@ module Y2Network
       end
 
       def init
-        disable if Yast::NetworkService.network_manager?
+        disable if @config.backend?(:network_manager)
       end
     end
 
@@ -92,7 +92,7 @@ module Y2Network
       end
 
       def init
-        disable if Yast::NetworkService.network_manager?
+        disable if @table&.config&.backend?(:network_manager)
       end
     end
   end

--- a/src/lib/y2network/widgets/routing_table.rb
+++ b/src/lib/y2network/widgets/routing_table.rb
@@ -23,7 +23,7 @@ require "cwm/table"
 require "y2network/interface"
 
 Yast.import "Label"
-Yast.import "NetworkService"
+Yast.import "Lan"
 
 module Y2Network
   module Widgets
@@ -60,7 +60,7 @@ module Y2Network
       # TODO: just workaround to make it work with old hash based CWM
       def init
         redraw_table
-        disable if Yast::NetworkService.network_manager?
+        disable if config.backend?(:network_manager)
       end
 
       def selected_route
@@ -91,6 +91,10 @@ module Y2Network
 
       def redraw_table
         change_items(items)
+      end
+
+      def config
+        Yast::Lan.yast_config
       end
     end
   end

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -482,7 +482,7 @@ module Yast
         # Progress step 9
         ProgressNextStage(_("Activating network services..."))
 
-        activate_network_service
+        select_network_service ? activate_network_service : NetworkService.disable
 
         Builtins.sleep(sl)
       end
@@ -842,6 +842,10 @@ module Yast
       system_config.backend = NetworkService.cached_name
       Yast::Lan.add_config(:system, system_config)
       Yast::Lan.add_config(:yast, system_config.copy)
+    end
+
+    def select_network_service
+      NetworkService.use(yast_config&.backend&.id)
     end
 
     def firewalld

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -699,6 +699,7 @@ module Yast
     #
     # @return [Array<String>] list of ntp servers obtained byg DHCP
     def dhcp_ntp_servers
+      # Used before the config has been read
       return [] if !NetworkService.isNetworkRunning || Yast::NetworkService.is_network_manager
 
       ReadWithCacheNoGUI()

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -666,6 +666,8 @@ module Yast
     # we export a 2-level map of typed "devices"
     # @return dumped settings
     def Export
+      return { "managed" => true } if NetworkService.is_network_manager
+
       profile = Y2Network::AutoinstProfile::NetworkingSection.new_from_network(yast_config)
       ay = {
         "dns"                  => profile.dns&.to_hashes || {},

--- a/test/lan_test.rb
+++ b/test/lan_test.rb
@@ -443,4 +443,34 @@ describe "LanClass" do
         .from(nil).to(system_config)
     end
   end
+
+  describe "#Export" do
+    let(:nm) { false }
+    let(:yast_config) do
+      Y2Network::Config.new(source: :autoinst).tap do |config|
+        config.hostname.static = "yasties"
+      end
+    end
+
+    before do
+      allow(Yast::NetworkService).to receive(:is_network_manager).and_return(nm)
+      Yast::Lan.add_config(:yast, yast_config)
+    end
+
+    it "exports the current network settings" do
+      exported_profile = Yast::Lan.Export
+      expect(exported_profile["dns"]).to eql("hostname" => "yasties")
+      expect(exported_profile["interfaces"]).to be_empty
+      expect(exported_profile["net-udev"]).to be_empty
+      expect(exported_profile["s390-devices"]).to be_empty
+    end
+
+    context "when NetworkManager is the network service" do
+      let(:nm) { true }
+
+      it "exports onlye the manage attribute" do
+        expect(subject.Export).to eql("managed" => true)
+      end
+    end
+  end
 end

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -151,7 +151,7 @@ describe "NetworkAutoYast" do
       it "enables NetworkManager" do
         expect(Yast::NetworkService).to receive(:is_backend_available)
           .with(:network_manager).and_return(true)
-        expect(Yast::NetworkService).to receive(:use_network_manager).and_return nil
+        expect(Yast::NetworkService).to receive(:use).with(:network_manager)
         expect(Yast::NetworkService).to receive(:EnableDisableNow).and_return nil
 
         network_autoyast.set_network_service
@@ -165,7 +165,7 @@ describe "NetworkAutoYast" do
 
       it "enables wicked" do
         expect(Yast::PackageSystem).to receive(:Installed).and_return(installed)
-        expect(Yast::NetworkService).to receive(:use_wicked).and_return nil
+        expect(Yast::NetworkService).to receive(:use).with(:wicked)
         expect(Yast::NetworkService).to receive(:EnableDisableNow).and_return nil
 
         network_autoyast.set_network_service

--- a/test/y2network/autoinst_profile/dns_section_test.rb
+++ b/test/y2network/autoinst_profile/dns_section_test.rb
@@ -38,7 +38,7 @@ describe Y2Network::AutoinstProfile::DNSSection do
       instance_double(
         Y2Network::Hostname,
         hostname:      "linux",
-        dhcp_hostname: true
+        dhcp_hostname: :any
       )
     end
 

--- a/test/y2network/backend_test.rb
+++ b/test/y2network/backend_test.rb
@@ -22,11 +22,25 @@ require "y2network/backend"
 
 describe Y2Network::Backend do
   let(:supported_backends) { [:netconfig, :network_manager, :wicked] }
+  let(:installed_backends) { [:netconfig, :wicked] }
   let(:network_manager) { described_class.by_id(:network_manager) }
 
   describe "#all" do
-    it "returns all the available backends" do
+    it "returns all the supported backends" do
       expect(described_class.all.map(&:id).sort).to eql(supported_backends)
+    end
+  end
+
+  describe "#available" do
+    before do
+      described_class.all.each do |backend|
+        allow(backend).to receive(:available?).and_return(true)
+      end
+    end
+
+    it "returns all the supported and installed backends" do
+      expect(network_manager).to receive(:available?).and_return(false)
+      expect(described_class.available.map(&:id).sort).to eql(installed_backends)
     end
   end
 

--- a/test/y2network/backend_test.rb
+++ b/test/y2network/backend_test.rb
@@ -1,0 +1,59 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2network/backend"
+
+describe Y2Network::Backend do
+  let(:supported_backends) { [:netconfig, :network_manager, :wicked] }
+  let(:network_manager) { described_class.by_id(:network_manager) }
+
+  describe "#all" do
+    it "returns all the available backends" do
+      expect(described_class.all.map(&:id).sort).to eql(supported_backends)
+    end
+  end
+
+  describe "#by_id" do
+    it "returns the backend with the given id when present" do
+      expect(described_class.by_id(:wicked).class).to eql(Y2Network::Backends::Wicked)
+      expect(described_class.by_id(:wicked).id).to eql(:wicked)
+    end
+
+    it "returns nil when the backend is not supported" do
+      expect(described_class.by_id(:networkd)).to be_nil
+    end
+  end
+
+  describe ".label" do
+    it "raises an exception when not implemented" do
+      expect { described_class.new(:networkd).label }.to raise_error(NotImplementedError)
+    end
+
+    it "returns the translated backend label when implemented" do
+      expect(network_manager.label).to eq("Network Manager")
+    end
+  end
+
+  describe ".id" do
+    it "returns the backend id" do
+      expect(network_manager.id).to eql(:network_manager)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When the selected network service is NetworkManager, many of the settings are irrelevant when exporting the configuration.

- https://trello.com/c/1RXM7d8u/1851-8-reduce-profile-i-do-not-export-not-relevant-information#comment-5ee1e470b3a5b661db5b2bcd

## Solution

- Do not export any settings by now when NetworkManager is the selected network service.
- Keep the selection of the **network backend** in the `config` object decoupling it from the **NetworkService** module in order to permit having different backends in different configurations (related to https://trello.com/c/87QL0IuF/3606-sles15-sp2-p3-1151841-network-proposal-is-not-a-proposal-it-just-configures-the-network-on-the-fly)