### PR TITLE
bsc#1172922: do not export <aliases> when not needed

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 15 11:53:03 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not export interfaces <aliases> section when there are no
+  aliases to export (bsc#1172922).
+- 4.2.70
+
+-------------------------------------------------------------------
 Thu Jun 11 08:24:34 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Try to install the wireless-tools package when the package is

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.69
+Version:        4.2.70
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -332,6 +332,13 @@ module Y2Network
         true
       end
 
+      # @see SectionWithAttributes#to_hashes
+      def to_hashes
+        hash = super
+        hash.delete("aliases") if hash["aliases"] && hash["aliases"].empty?
+        hash
+      end
+
       # Helper to get wireless keys as array
       # @return [Array<String>]
       def wireless_keys

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -335,7 +335,7 @@ module Y2Network
       # @see SectionWithAttributes#to_hashes
       def to_hashes
         hash = super
-        hash.delete("aliases") if hash["aliases"] && hash["aliases"].empty?
+        hash.delete("aliases") if hash["aliases"]&.empty?
         hash
       end
 

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -335,7 +335,7 @@ module Y2Network
       # @see SectionWithAttributes#to_hashes
       def to_hashes
         hash = super
-        hash.delete("aliases") if hash["aliases"]&.empty?
+        hash.delete("aliases") if hash.key?("aliases") && hash["aliases"].empty?
         hash
       end
 

--- a/test/y2network/autoinst_profile/interface_section_test.rb
+++ b/test/y2network/autoinst_profile/interface_section_test.rb
@@ -74,6 +74,29 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
     end
   end
 
+  describe "#to_hashes" do
+    subject(:section) do
+      described_class.new_from_hashes(
+        "device"  => "eth0",
+        "aliases" => { "alias0" => { "IPADDR" => "10.100.0.1", "PREFIXLEN" => "24" } }
+      )
+    end
+
+    it "exports the aliases key" do
+      expect(section.to_hashes["aliases"]).to eq(section.aliases)
+    end
+
+    context "when the list of aliases is empty" do
+      subject(:section) do
+        described_class.new_from_hashes("device" => "eth0", "aliases" => {})
+      end
+
+      it "does not export the aliases key" do
+        expect(section.to_hashes).to_not have_key("aliases")
+      end
+    end
+  end
+
   describe "#wireless_keys" do
     it "returns array" do
       section = described_class.new_from_hashes({})


### PR DESCRIPTION
This PR fixes [bsc#1172922](https://bugzilla.suse.com/show_bug.cgi?id=1172922).