### PR TITLE
save inst-sys memory by ending the agent process after use (bsc#1172139)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 19 08:52:54 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Save inst-sys memory by ending ag_udev_persistent after use
+  (bsc#1172139).
+- 4.3.7
+
+-------------------------------------------------------------------
 Mon Jun 15 11:53:03 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not export interfaces <aliases> section when there are no

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.6
+Version:        4.3.7
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/udev_rule.rb
+++ b/src/lib/y2network/udev_rule.rb
@@ -160,6 +160,7 @@ module Y2Network
         Yast::SCR.Write(Yast::Path.new(".udev_persistent.rules"), udev_rules.map(&:to_s))
         # Writes changes to the rules file
         Yast::SCR.Write(Yast::Path.new(".udev_persistent.nil"), [])
+        Yast::SCR.UnmountAgent(Yast::Path.new(".udev_persistent"))
       end
 
       # Writes drivers specific udev rules to the filesystem
@@ -177,6 +178,7 @@ module Y2Network
         Yast::SCR.Write(Yast::Path.new(".udev_persistent.drivers"), rules_hash)
         # Writes changes to the rules file
         Yast::SCR.Write(Yast::Path.new(".udev_persistent.nil"), [])
+        Yast::SCR.UnmountAgent(Yast::Path.new(".udev_persistent"))
       end
 
       # Clears rules cache map
@@ -191,6 +193,7 @@ module Y2Network
         return @all[group] if @all[group]
 
         rules_map = Yast::SCR.Read(Yast::Path.new(".udev_persistent.#{group}")) || {}
+        Yast::SCR.UnmountAgent(Yast::Path.new(".udev_persistent"))
         @all[group] = rules_map.values.map do |parts|
           udev_parts = parts.map { |p| UdevRulePart.from_string(p) }.compact
           new(udev_parts)


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1172139

[memsample](https://github.com/yast/yast-installation/pull/864) has revealed that `ag_udev_persistent` not only makes NIC names persistent, it also persists as a useless process until the end of the installation, taking up 31MiB (!) of RSS. Fortunately the agent needs no internal state between its 2 calls at install time, so we can simply⁺ terminate it via UnmountAgent after each use. The cost is the slowdown of starting up the process again.

⁺ (In practice it works like slicing up a zombie in half: now you have TWO deadly zombies. Fixed in https://github.com/yast/yast-core/pull/147)

The effect of this PR can be observed in the memsample graphs below, where the green y2start+children line jumps down to hug the y2starts line:

<table>
<tr><td>before</td><td>after</td></tr>
<tr>
<td>

![memsample-dash](https://user-images.githubusercontent.com/102056/85140980-5ca51900-b246-11ea-9d8a-c42a5eed260e.png)

</td><td>

![memsample-noudev-core](https://user-images.githubusercontent.com/102056/85140999-63339080-b246-11ea-82be-4bc91f3b87ea.png)

</td></tr>
</table>