### PR TITLE
Fix udev string parse (bsc#1167256)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 19 13:04:18 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Parse correctly udev rules keys using underscores (bsc#1167256)
+- 4.2.71
+
+-------------------------------------------------------------------
 Mon Jun 15 11:53:03 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not export interfaces <aliases> section when there are no

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.70
+Version:        4.2.71
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/udev_rule_part.rb
+++ b/src/lib/y2network/udev_rule_part.rb
@@ -27,7 +27,7 @@ module Y2Network
   class UdevRulePart
     include Yast::Logger
     # Regular expression to match a udev rule part
-    PART_REGEXP = Regexp.new("\\A(?<key>[A-Za-z\{\}]+)(?<operator>[^\"]+)\"(?<value>.+)\"\\Z")
+    PART_REGEXP = Regexp.new("\\A(?<key>[A-Za-z\{\}_]+)(?<operator>[^\"]+)\"(?<value>.+)\"\\Z")
 
     class << self
       # Returns a rule part from a string

--- a/test/y2network/udev_rule_part_test.rb
+++ b/test/y2network/udev_rule_part_test.rb
@@ -33,6 +33,11 @@ describe Y2Network::UdevRulePart do
       expect(part.key).to eq("ACTION")
       expect(part.operator).to eq("==")
       expect(part.value).to eq("add")
+
+      part = described_class.from_string("ATTR{dev_id}==\"0x0\"")
+      expect(part.key).to eq("ATTR{dev_id}")
+      expect(part.operator).to eq("==")
+      expect(part.value).to eq("0x0")
     end
 
     it "returns nil in case of an invalid udev rule" do


### PR DESCRIPTION
## Problem

When the udev rules are read, keys containing underscores like `ATTR{dev_port}` and `ATTR{dev_id}` are not parsed / initialized correctly.

https://bugzilla.suse.com/show_bug.cgi?id=1167256

## Solution

Add the underscore to the REGEXP as a key permitted character.