### PR TITLE
AY schema: added networking setup_before_proposal element

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 26 08:00:33 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- AutoYaST schema: add the setup_before_proposal element to the
+  schema (bsc#1171922)
+- 4.3.10
+
+-------------------------------------------------------------------
 Wed Jun 24 11:52:46 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not export network when not requested (bsc#1172552)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -9,6 +9,7 @@ networking =
   element networking {
     MAP,
     (
+      element setup_before_proposal { BOOLEAN }? &
       element start_immediately { BOOLEAN }? &
       element keep_install_network { BOOLEAN }? &
       ipv6? &


### PR DESCRIPTION
## Problem

When the AutoYaST profiles contains the `networking -> setup_before_proposal`option, then, the validation complains.

## Solution

Add it to the schema's networking section.