### PR TITLE
Do not remove /etc/hosts entries during AutoYaST

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 30 13:52:44 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not remove automatically aliases from /etc/hosts during an
+  autoinstallation (bsc#1173213)
+- 4.2.72
+
+-------------------------------------------------------------------
 Fri Jun 19 13:04:18 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Parse correctly udev rules keys using underscores (bsc#1167256)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.71
+Version:        4.2.72
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/sysconfig/connection_config_writer.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writer.rb
@@ -21,6 +21,7 @@ require "y2network/sysconfig/interface_file"
 require "y2network/sysconfig/routes_file"
 
 Yast.import "Host"
+Yast.import "Mode"
 
 module Y2Network
   module Sysconfig
@@ -53,7 +54,10 @@ module Y2Network
       def remove(conn)
         ifcfg = Y2Network::Sysconfig::InterfaceFile.find(conn.interface)
         ifcfg&.remove
-        Yast::Host.remove_ip(conn.ip.address.address.to_s) if conn.ip
+        # During an autoinstallation do not remove /etc/hosts entries
+        # associated with the static IP address (bsc#1173213).
+        # The hook or original behavior was introduced because of (bsc#951330)
+        Yast::Host.remove_ip(conn.ip.address.address.to_s) if !Yast::Mode.auto && conn.ip
       end
 
     private

--- a/test/y2network/sysconfig/connection_config_writer_test.rb
+++ b/test/y2network/sysconfig/connection_config_writer_test.rb
@@ -93,8 +93,10 @@ describe Y2Network::Sysconfig::ConnectionConfigWriter do
   end
 
   describe "#remove" do
+    let(:autoinstallation) { false }
     before do
       allow(Y2Network::Sysconfig::InterfaceFile).to receive(:find).and_return(file)
+      allow(Yast::Mode).to receive(:auto).and_return(autoinstallation)
     end
 
     it "removes the configuration file" do
@@ -109,6 +111,15 @@ describe Y2Network::Sysconfig::ConnectionConfigWriter do
 
     context "if no IP address is defined" do
       let(:ip_config) { nil }
+
+      it "does not try to remove the hostname" do
+        expect(Yast::Host).to_not receive(:remove_ip)
+        writer.remove(conn)
+      end
+    end
+
+    context "during an autoinstallation" do
+      let(:autoinstallation) { true }
 
       it "does not try to remove the hostname" do
         expect(Yast::Host).to_not receive(:remove_ip)


### PR DESCRIPTION
## Problem

Since this bug (https://bugzilla.suse.com/show_bug.cgi?id=951330), when a **connection config** (a.k.a interface configuration)  is deleted we also remove any /etc/hosts entry associated to the connection config static IP address.

We maintained that behavior in network-ng and this particular PR introduced the current hook and also provided a description of the solution adopted and the reasons behind it:

https://github.com/yast/yast-network/pull/973

The problem with AutoYaST are the connection configs statically configured during the first stage that are also modified by the profile, them are always removed and added instead of just updated. When the remove of the connection is call, it also removes the /etc/hosts entries associated with their static IP addresses.

That could be OK if the hostname is added later but it is not the case probably because of a wrong initialization (autoyast reader)

https://github.com/yast/yast-network/blob/f36491d044857400215ec14a5e017b9a7152785a/src/lib/y2network/sysconfig/connection_config_writers/base.rb#L54

- https://trello.com/c/DQVxb3cz/1926-sles15-sp2-p5-1173213-gmc-etc-hosts-entries-not-created

## Solution

As a first approach we tried to force the use of the same **connection config ID** by the AutoYaST connection config objects but as the remove is call always that a connection config was present that was not enough and we went for an easier solution.

https://github.com/yast/yast-network/blob/2651eff5ec19ae12151927dccfafb63e7c566d9c/src/lib/y2network/connection_configs_collection.rb#L82

So finally it was decided to not remove automatically any /etc/hosts entry during an autoinstallation as in case of present it should be already defined by the profile or by a user script.

A proper fix will need a rethink of the current behavior, discussions and also some testing.