### PR TITLE
Permit to use dots when modifying the hostname in YaST

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 14 14:07:39 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Permit dot characters in the hostname allowing to specify it as
+  a FQDN (1173298)
+- 4.2.73
+
+-------------------------------------------------------------------
 Tue Jun 30 13:52:44 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not remove automatically aliases from /etc/hosts during an

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.72
+Version:        4.2.73
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -65,7 +65,7 @@ module Yast
           "label"             => _("Static H&ostname"),
           "opt"               => [],
           "help"              => Ops.get_string(@help, "hostname_global", ""),
-          "valid_chars"       => Hostname.ValidChars,
+          "valid_chars"       => Yast::Hostname.ValidCharsDomain,
           "validate_type"     => :function_no_popup,
           "validate_function" => fun_ref(
             method(:ValidateHostname),

--- a/src/modules/Host.rb
+++ b/src/modules/Host.rb
@@ -260,7 +260,7 @@ module Yast
     #
     # It is expected to be used during installation only. If user configures static
     # ips during installation and do not assign them particular hostname, then such
-    # ips are configuret to resolve to the system wide hostname (see Hostname module,
+    # ips are configured to resolve to the system wide hostname (see Hostname module,
     # /etc/HOSTNAME)
     #
     # Originally implemented as a fix for bnc#664929, later extended for bnc#1039532


### PR DESCRIPTION
## Problem

The **hostname** input field prevent the user to use a **FQDN** not allowing the use of dot characters but only when modifying it. Although it is recommended to not use a **FQDN** as the static hostname there is not a restriction in the kernel or hostnamectl to use it and thus, there should not be a restriction in **YaST** in case that the user has a use case in which it is needed.

- https://bugzilla.suse.com/show_bug.cgi?id=1173298

## Solution

Permit to use dots when modifying the hostname

