### PR TITLE
Added a method to only write the yast Y2Network::Config

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,8 +1,15 @@
 -------------------------------------------------------------------
+Thu Jul 16 08:45:00 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Permit to write networking config changes without touching the
+  service and other components like the firewall (bsc#1173298)
+- 4.2.74
+
+-------------------------------------------------------------------
 Tue Jul 14 14:07:39 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Permit dot characters in the hostname allowing to specify it as
-  a FQDN (1173298)
+  a FQDN (bsc#1173298)
 - 4.2.73
 
 -------------------------------------------------------------------

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.73
+Version:        4.2.74
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -818,14 +818,14 @@ module Yast
 
     # Reads system configuration
     #
-    # It clears already read configuration.
+    # It resets already read configuration.
     def read_config
       system_config = Y2Network::Config.from(:sysconfig)
       Yast::Lan.add_config(:system, system_config)
       Yast::Lan.add_config(:yast, system_config.copy)
     end
 
-    # Writes current yast config and replace the system config with it
+    # Writes current yast config and replaces the system config with it
     def write_config
       target = :sysconfig if Mode.auto
       yast_config.write(original: system_config, target: target)

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -493,10 +493,8 @@ module Yast
       ProgressNextStage(_("Writing routing configuration..."))
       orig = Progress.set(false)
 
-      target = :sysconfig if Mode.auto
-      yast_config.write(original: system_config, target: target)
-      # Force a refresh of the system_config bsc#1162987
-      add_config(:system, yast_config.copy)
+      write_config
+
       Progress.set(orig)
       Builtins.sleep(sl)
 
@@ -818,6 +816,23 @@ module Yast
       find_config(:yast)
     end
 
+    # Reads system configuration
+    #
+    # It clears already read configuration.
+    def read_config
+      system_config = Y2Network::Config.from(:sysconfig)
+      Yast::Lan.add_config(:system, system_config)
+      Yast::Lan.add_config(:yast, system_config.copy)
+    end
+
+    # Writes current yast config and replace the system config with it
+    def write_config
+      target = :sysconfig if Mode.auto
+      yast_config.write(original: system_config, target: target)
+      # Force a refresh of the system_config bsc#1162987
+      add_config(:system, yast_config.copy)
+    end
+
     publish variable: :ipv6, type: "boolean"
     publish variable: :AbortFunction, type: "block <boolean>"
     publish variable: :bond_autoconf_slaves, type: "list <string>"
@@ -887,15 +902,6 @@ module Yast
 
         reload_config(connection_names)
       end
-    end
-
-    # Reads system configuration
-    #
-    # It clears already read configuration.
-    def read_config
-      system_config = Y2Network::Config.from(:sysconfig)
-      Yast::Lan.add_config(:system, system_config)
-      Yast::Lan.add_config(:yast, system_config.copy)
     end
 
     def firewalld

--- a/test/lan_test.rb
+++ b/test/lan_test.rb
@@ -443,4 +443,53 @@ describe "LanClass" do
         .from(nil).to(system_config)
     end
   end
+
+  describe "#read_config" do
+    let(:system_config_copy) { double.as_null_object }
+
+    before do
+      subject.main
+      allow(Y2Network::Config).to receive(:from).and_return(system_config)
+      allow(system_config).to receive(:copy).and_return(system_config_copy)
+      allow(Yast::Lan).to receive(:add_config)
+    end
+
+    it "reads the Y2Network::Config from sysconfig" do
+      expect(Y2Network::Config).to receive(:from).and_return(system_config)
+      subject.read_config
+    end
+
+    it "adds the read config as the Yast::Lan.system_config" do
+      expect(Yast::Lan).to receive(:add_config).with(:system, system_config)
+      subject.read_config
+    end
+
+    it "copies the system config as the Yast::Lan.yast_config" do
+      expect(Yast::Lan).to receive(:add_config).with(:yast, system_config_copy)
+      subject.read_config
+    end
+  end
+
+  describe "#write_config" do
+    let(:yast_config_copy) { double.as_null_object }
+
+    before do
+      subject.main
+      allow(Y2Network::Config).to receive(:from).and_return(system_config)
+      subject.read_config
+      allow(Yast::Lan.yast_config).to receive(:write)
+      allow(Yast::Lan.yast_config).to receive(:copy).and_return(yast_config_copy)
+    end
+
+    it "writes the current yast_config passing the system config as the original" do
+      expect(Yast::Lan.yast_config).to receive(:write).with(original: system_config, target: nil)
+      subject.write_config
+    end
+
+    it "replaces the system config by a copy of the written one" do
+      expect { subject.write_config }
+        .to change { Yast::Lan.system_config }
+        .from(system_config).to(yast_config_copy)
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Firstboot used to call DNS.Write in order to apply hostname changes but it does not write hostname anymore.

- https://bugzilla.suse.com/show_bug.cgi?id=1173298
- Needed by https://github.com/yast/yast-firstboot/pull/100

## Solution

Added a method to write only **Yast::Lan.yast_config** changes and update the current system_config without touching other components.

## Test

- Added unit test and tested manually