### PR TITLE
AutoYaST: Fix route_section IPv6 netmask

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 28 08:45:12 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not crash when configuring an IPv6 route through AutoYaST
+  (bsc#1174353)
+- 4.2.75
+
+-------------------------------------------------------------------
 Thu Jul 16 08:45:00 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Permit to write networking config changes without touching the

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.74
+Version:        4.2.75
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/autoinst_profile/route_section.rb
+++ b/src/lib/y2network/autoinst_profile/route_section.rb
@@ -124,7 +124,7 @@ module Y2Network
       end
 
       IPV4_MASK = "255.255.255.255".freeze
-      IPV6_MASK = "fffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff".freeze
+      IPV6_MASK = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff".freeze
 
       # Returns the netmask
       #

--- a/test/y2network/autoinst_profile/route_section_test.rb
+++ b/test/y2network/autoinst_profile/route_section_test.rb
@@ -30,6 +30,17 @@ describe Y2Network::AutoinstProfile::RouteSection do
         to: to, interface: interface, gateway: gateway, options: options
       )
     end
+
+    let(:route_ipv6) do
+      Y2Network::Route.new(
+        to: to_ipv6, interface: interface_ipv6, gateway: gateway_ipv6
+      )
+    end
+
+    let(:to_ipv6) { IPAddr.new("2001:DB8:100::/32") }
+    let(:interface_ipv6) { double("interface", name: "eth1") }
+    let(:gateway_ipv6) { IPAddr.new("fe80::216:3eff:fe6d:c04") }
+
     let(:to) { IPAddr.new("192.168.122.0/24") }
     let(:interface) { double("interface", name: "eth0") }
     let(:gateway) { IPAddr.new("192.168.122.1") }
@@ -66,6 +77,8 @@ describe Y2Network::AutoinstProfile::RouteSection do
     it "initializes the gateway value" do
       section = described_class.new_from_network(route)
       expect(section.gateway).to eq("192.168.122.1")
+      section_ipv6 = described_class.new_from_network(route_ipv6)
+      expect(section_ipv6.gateway).to eq("fe80::216:3eff:fe6d:c04")
     end
 
     context "when the gateway is missing" do
@@ -80,6 +93,8 @@ describe Y2Network::AutoinstProfile::RouteSection do
     it "initializes the netmask value" do
       section = described_class.new_from_network(route)
       expect(section.netmask).to eq("255.255.255.0")
+      section_ipv6 = described_class.new_from_network(route_ipv6)
+      expect(section_ipv6.netmask).to eq("ffff:ffff::")
     end
 
     context "when it is the default route" do


### PR DESCRIPTION
## Problem

During an autoinstallation, YaST reports an error when an IPv6 route is defined in used in the AutoYaST profile
- https://bugzilla.suse.com/show_bug.cgi?id=1174353

## Solution

Fix the wrong mask declared in the route section