### PR TITLE
bsc#1174643: do not crash AutoYaST when <host> is present

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 29 10:47:01 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: do not crash when the <host> section is present
+  (bsc#1174643).
+- 4.3.15
+
+-------------------------------------------------------------------
 Tue Jul 28 08:45:12 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when configuring an IPv6 route through AutoYaST

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.14
+Version:        4.3.15
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -140,23 +140,8 @@ module Yast
     # is also written
     #
     # @param [Boolean] write forces instant writing of the configuration
-    # @return [Boolean] true when configuration was present and loaded from the profile
-    def configure_hosts(write: false)
-      log.info("NetworkAutoYast: Hosts configuration")
-
-      if ay_host_section.empty?
-        Host.Write(gui: false)
-
-        return true
-      end
-
-      hosts_config = (ay_host_section["hosts"] || {}).map do |host|
-        # we need to guarantee order of the items here
-        [host["host_address"] || "", host["names"] || []]
-      end
-      hosts_config = hosts_config.to_h.delete_if { |k, v| k.empty? || v.empty? }
-
-      configure_submodule(Host, "hosts" => hosts_config, write: write)
+    def configure_hosts
+      Host.Write(gui: false)
     end
 
     # Checks if the profile asks for keeping installation network configuration
@@ -171,10 +156,6 @@ module Yast
     # setter for networking section. Should be done during import.
     # @return [Hash] networking section hash
     attr_writer :ay_networking_section
-
-    # setter for host section. Should be done during import.
-    # @return [Hash] host section hash
-    attr_writer :ay_host_section
 
   private
 
@@ -221,50 +202,6 @@ module Yast
     # Returns networking section of current AY profile
     def ay_networking_section
       @ay_networking_section || {}
-    end
-
-    # Returns host section of the current AY profile
-    #
-    # Note that autoyast transforms the host's subsection
-    # into:
-    # {
-    #   hosts => [
-    #     # first <host_entry>
-    #     {
-    #       "host_address" => <ip>,
-    #       "names" => [list, of, names]
-    #     }
-    #     # second <host_entry>
-    #     ...
-    #   ]
-    # }
-    #
-    # return <Hash> with hosts configuration
-    def ay_host_section
-      @ay_host_section || {}
-    end
-
-    # Configures given yast submodule according AY configuration
-    #
-    # It takes data from AY profile transformed into a format expected by the YaST
-    # sub module's Import method.
-    #
-    # It imports the profile, configures the module and writes the configuration.
-    # Writing the configuration is optional when second stage is available and mandatory
-    # when running autoyast installation with first stage only.
-    def configure_submodule(yast_module, ay_config, write: false)
-      return false if !ay_config
-
-      yast_module.Import(ay_config)
-
-      # Results of imported values semantic check.
-      # Return true in order to not call the NetworkAutoconfiguration.configure_hosts
-      return true unless AutoInstall.valid_imported_values
-
-      log.info("Write configuration instantly: #{write}")
-      yast_module.Write(gui: false) if write
-
-      true
     end
   end
 end

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -138,8 +138,6 @@ module Yast
     #
     # If the installer is running in 1st stage mode only, then the configuration
     # is also written
-    #
-    # @param [Boolean] write forces instant writing of the configuration
     def configure_hosts
       Host.Write(gui: false)
     end

--- a/src/modules/Host.rb
+++ b/src/modules/Host.rb
@@ -160,8 +160,6 @@ module Yast
         set_names(ip, names)
       end
 
-      NetworkAutoYast.instance.ay_host_section = settings
-
       true
     end
 


### PR DESCRIPTION
In #1086, the `NetworkAutoyast` started to [store the /etc/hosts settings](https://github.com/yast/yast-network/blob/master/src/modules/Host.rb#L163), instead of accessing the current profile. However, the settings were [already mangled at that point](https://github.com/yast/yast-network/blob/master/src/clients/host_auto.rb#L86), which caused AutoYaST to crash. See [bsc#1174643](https://bugzilla.opensuse.org/show_bug.cgi?id=1174643).

While I was analyzing the bug, I found out that most of the import/write logic seems to be duplicated (and wrong). So after a short discussion with @teclator, I decided to remove that duplication. Now, the import only happens in one place.