### PR TITLE
 Use element path

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 26 12:35:44 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Unify profile element paths (bsc#1175680).
+- 4.3.17
+
+-------------------------------------------------------------------
 Tue Aug 11 12:13:34 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(host,networking,remote)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -33,8 +33,9 @@ BuildRequires:  yast2-devtools >= 3.1.15
 #for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  yast2-storage-ng
-# NetworkService.use
-BuildRequires:  yast2 >= 4.3.9
+# AutoYaST ElementPath class
+BuildRequires:  yast2 >= 4.3.20
+
 BuildRequires:  yast2-packager >= 4.0.18
 # Product control need xml agent
 BuildRequires:  yast2-xml
@@ -48,8 +49,8 @@ PreReq:         /bin/rm
 Requires:       sysconfig >= 0.80.0
 Requires:       yast2-proxy
 Requires:       yast2-storage-ng
-# NetworkService.use
-Requires:       yast2 >= 4.3.9
+# AutoYaST ElementPath class
+Requires:       yast2 >= 4.3.20
 # Packages::vnc_packages
 Requires:       yast2-packager >= 4.0.18
 Requires:       rubygem(%rb_default_ruby_abi:cfa) >= 0.6.4

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.16
+Version:        4.3.17
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/autoinst_profile/dns_section.rb
+++ b/src/lib/y2network/autoinst_profile/dns_section.rb
@@ -71,11 +71,12 @@ module Y2Network
       #
       # @param dns [Y2Network::DNS] DNS settings
       # @param hostname [Y2Network::Hostname] Hostname settings
+      # @param parent [SectionWithAttributes,nil] Parent section
       # @return [DNSSection]
       # NOTE: we need both DNS and Hostname settings because of historical reasons
       # when both used to be handled in one class / module
-      def self.new_from_network(dns, hostname)
-        result = new
+      def self.new_from_network(dns, hostname, parent = nil)
+        result = new(parent)
         initialized = result.init_from_network(dns, hostname)
         initialized ? result : nil
       end

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -365,6 +365,23 @@ module Y2Network
         slaves
       end
 
+      # Returns the collection name
+      #
+      # @return [String] "interfaces"
+      def collection_name
+        "interfaces"
+      end
+
+      # Returns the section path
+      #
+      # @return [Installation::AutoinstProfile::ElementPath,nil] Section path or
+      #   nil if the parent is not set
+      def section_path
+        return nil unless parent
+
+        parent.section_path.join(index)
+      end
+
     private
 
       def init_from_wireless(config)

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -249,9 +249,10 @@ module Y2Network
       # Clones a network interface into an AutoYaST interface section
       #
       # @param connection_config [Y2Network::ConnectionConfig] Network connection config
+      # @param parent [SectionWithAttributes,nil] Parent section
       # @return [InterfacesSection]
-      def self.new_from_network(connection_config)
-        result = new
+      def self.new_from_network(connection_config, parent = nil)
+        result = new(parent)
         result.init_from_config(connection_config)
         result
       end

--- a/src/lib/y2network/autoinst_profile/interfaces_section.rb
+++ b/src/lib/y2network/autoinst_profile/interfaces_section.rb
@@ -63,9 +63,10 @@ module Y2Network
       #
       # @param config [Y2Network::Config] whole config as it need both interfaces and
       #   connection configs
+      # @param parent [SectionWithAttributes,nil] Parent section
       # @return [InterfacesSection]
-      def self.new_from_network(config)
-        result = new
+      def self.new_from_network(config, parent = nil)
+        result = new(parent)
         initialized = result.init_from_network(config)
         initialized ? result : nil
       end
@@ -100,7 +101,7 @@ module Y2Network
       def interfaces_from_hash(hash)
         hash.map do |h|
           h = h["device"] if h["device"].is_a? ::Hash # hash can be enclosed in different hash
-          res = InterfaceSection.new_from_hashes(h)
+          res = InterfaceSection.new_from_hashes(h, self)
           log.info "interfaces section #{res.inspect} load from hash #{h.inspect}"
           res
         end
@@ -108,7 +109,7 @@ module Y2Network
 
       def interfaces_section(connection_configs)
         connection_configs.map do |c|
-          Y2Network::AutoinstProfile::InterfaceSection.new_from_network(c)
+          Y2Network::AutoinstProfile::InterfaceSection.new_from_network(c, self)
         end
       end
     end

--- a/src/lib/y2network/autoinst_profile/networking_section.rb
+++ b/src/lib/y2network/autoinst_profile/networking_section.rb
@@ -17,6 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "installation/autoinst_profile/section_with_attributes"
 require "y2network/autoinst_profile/dns_section"
 require "y2network/autoinst_profile/interfaces_section"
 require "y2network/autoinst_profile/routing_section"
@@ -34,7 +35,7 @@ module Y2Network
     #  </networking>
     #
     # @see RoutingSection
-    class NetworkingSection
+    class NetworkingSection < Installation::AutoinstProfile::SectionWithAttributes
       # @return [Boolean]
       attr_accessor :setup_before_proposal
       # @return [Boolean]
@@ -69,14 +70,16 @@ module Y2Network
         result.start_immediately = hash.fetch("start_immediately", false)
         result.keep_install_network = hash.fetch("keep_install_network", true)
         result.strict_ip_check_timeout = hash.fetch("strict_ip_check_timeout", -1)
-        result.routing = RoutingSection.new_from_hashes(hash["routing"]) if hash["routing"]
-        result.dns = DNSSection.new_from_hashes(hash["dns"]) if hash["dns"]
+        result.routing = RoutingSection.new_from_hashes(hash["routing"], result) if hash["routing"]
+        result.dns = DNSSection.new_from_hashes(hash["dns"], result) if hash["dns"]
         if hash["interfaces"]
-          result.interfaces = InterfacesSection.new_from_hashes(hash["interfaces"])
+          result.interfaces = InterfacesSection.new_from_hashes(hash["interfaces"], result)
         end
-        result.udev_rules = UdevRulesSection.new_from_hashes(hash["net-udev"]) if hash["net-udev"]
+        if hash["net-udev"]
+          result.udev_rules = UdevRulesSection.new_from_hashes(hash["net-udev"], result)
+        end
         if hash["s390-devices"]
-          result.s390_devices = S390DevicesSection.new_from_hashes(hash["s390-devices"])
+          result.s390_devices = S390DevicesSection.new_from_hashes(hash["s390-devices"], result)
         end
         result
       end
@@ -94,7 +97,7 @@ module Y2Network
 
         result.routing = RoutingSection.new_from_network(config.routing) if config.routing
         result.dns = DNSSection.new_from_network(config.dns, config.hostname) if build_dns
-        result.interfaces = InterfacesSection.new_from_network(config.connections)
+        result.interfaces = InterfacesSection.new_from_network(config.connections, result)
         result.udev_rules = UdevRulesSection.new_from_network(config.interfaces)
         result.s390_devices = S390DevicesSection.new_from_network(config.connections)
         result

--- a/src/lib/y2network/autoinst_profile/route_section.rb
+++ b/src/lib/y2network/autoinst_profile/route_section.rb
@@ -62,10 +62,11 @@ module Y2Network
 
       # Clones a network route into an AutoYaST route section
       #
+      # @param parent [SectionWithAttributes,nil] Parent section
       # @param route [Y2Network::Route] Network route
       # @return [RouteSection]
-      def self.new_from_network(route)
-        result = new
+      def self.new_from_network(route, parent = nil)
+        result = new(parent)
         result.init_from_route(route)
         result
       end

--- a/src/lib/y2network/autoinst_profile/route_section.rb
+++ b/src/lib/y2network/autoinst_profile/route_section.rb
@@ -98,6 +98,13 @@ module Y2Network
         true
       end
 
+      # Returns the collection name
+      #
+      # @return [String] "routes"
+      def collection_name
+        "routes"
+      end
+
     private
 
       def destination_from_hash(hash)

--- a/src/lib/y2network/autoinst_profile/routing_section.rb
+++ b/src/lib/y2network/autoinst_profile/routing_section.rb
@@ -62,9 +62,10 @@ module Y2Network
       # Clones network routing settings into an AutoYaST routing section
       #
       # @param routing [Y2Network::Routing] Routing settings
+      # @param parent [SectionWithAttributes,nil] Parent section
       # @return [RoutingSection]
-      def self.new_from_network(routing)
-        result = new
+      def self.new_from_network(routing, parent = nil)
+        result = new(parent)
         initialized = result.init_from_network(routing)
         initialized ? result : nil
       end
@@ -104,11 +105,11 @@ module Y2Network
       # @param hash [Hash] Routing section hash
       def routes_from_hash(hash)
         hashes = hash["routes"] || []
-        hashes.map { |h| RouteSection.new_from_hashes(h) }
+        hashes.map { |h| RouteSection.new_from_hashes(h, self) }
       end
 
       def routes_section(routes)
-        routes.map { |r| Y2Network::AutoinstProfile::RouteSection.new_from_network(r) }
+        routes.map { |r| Y2Network::AutoinstProfile::RouteSection.new_from_network(r, self) }
       end
     end
   end

--- a/src/lib/y2network/autoinst_profile/s390_device_section.rb
+++ b/src/lib/y2network/autoinst_profile/s390_device_section.rb
@@ -101,6 +101,23 @@ module Y2Network
         self.chanids = normalized_chanids(hash["chanids"]) if hash["chanids"]
       end
 
+      # Returns the collection name
+      #
+      # @return [String] "interfaces"
+      def collection_name
+        "devices"
+      end
+
+      # Returns the section path
+      #
+      # @return [Installation::AutoinstProfile::ElementPath,nil] Section path or
+      #   nil if the parent is not set
+      def section_path
+        return nil unless parent
+
+        parent.section_path.join(index)
+      end
+
     private
 
       # Normalizes the list of channel IDs

--- a/src/lib/y2network/autoinst_profile/s390_device_section.rb
+++ b/src/lib/y2network/autoinst_profile/s390_device_section.rb
@@ -64,21 +64,11 @@ module Y2Network
       # Clones a network s390 connection config into an AutoYaST s390 device section
       #
       # @param connection_config [Y2Network::ConnectionConfig] Network connection config
+      # @param parent [SectionWithAttributes,nil] Parent section
       # @return [S390DeviceSection]
-      def self.new_from_network(connection_config)
-        result = new
+      def self.new_from_network(connection_config, parent = nil)
+        result = new(parent)
         result.init_from_config(connection_config)
-        result
-      end
-
-      # Creates an instance based on the profile representation used by the AutoYaST modules
-      # (array of hashes objects).
-      #
-      # @param hash [Hash] Networking section from an AutoYaST profile
-      # @return [S390DeviceSection]
-      def self.new_from_hashes(hash)
-        result = new
-        result.init_from_hashes(hash)
         result
       end
 

--- a/src/lib/y2network/autoinst_profile/s390_devices_section.rb
+++ b/src/lib/y2network/autoinst_profile/s390_devices_section.rb
@@ -82,6 +82,13 @@ module Y2Network
         true
       end
 
+      # Returns the collection name
+      #
+      # @return [String] "s390-devices"
+      def section_name
+        "s390-devices"
+      end
+
     private
 
       # Returns an array of s390 devices sections
@@ -90,7 +97,7 @@ module Y2Network
       def devices_from_hash(hash)
         hash.map do |h|
           h = h["device"] if h["device"].is_a? ::Hash # hash can be enclosed in different hash
-          res = S390DeviceSection.new_from_hashes(h)
+          res = S390DeviceSection.new_from_hashes(h, self)
           log.info "devices section #{res.inspect} load from hash #{h.inspect}"
           res
         end
@@ -99,7 +106,7 @@ module Y2Network
       def s390_devices_section(connection_configs)
         connection_configs
           .select { |c| supported_device?(c) }
-          .map { |c| Y2Network::AutoinstProfile::S390DeviceSection.new_from_network(c) }
+          .map { |c| Y2Network::AutoinstProfile::S390DeviceSection.new_from_network(c, self) }
       end
 
       def supported_device?(connection)

--- a/src/lib/y2network/autoinst_profile/s390_devices_section.rb
+++ b/src/lib/y2network/autoinst_profile/s390_devices_section.rb
@@ -52,9 +52,10 @@ module Y2Network
       #
       # @param config [Y2Network::Config] whole config as it need both s390-devices
       #   and connection configs
+      # @param parent [SectionWithAttributes,nil] Parent section
       # @return [S390DevicesSection]
-      def self.new_from_network(config)
-        result = new
+      def self.new_from_network(config, parent = nil)
+        result = new(parent)
         initialized = result.init_from_network(config)
         initialized ? result : nil
       end

--- a/src/lib/y2network/autoinst_profile/udev_rule_section.rb
+++ b/src/lib/y2network/autoinst_profile/udev_rule_section.rb
@@ -103,6 +103,23 @@ module Y2Network
       def mechanism
         RULE_MAPPING.each_pair { |k, v| return k if v == rule }
       end
+
+      # Returns the collection name
+      #
+      # @return [String] "interfaces"
+      def collection_name
+        "udev_rules"
+      end
+
+      # Returns the section path
+      #
+      # @return [Installation::AutoinstProfile::ElementPath,nil] Section path or
+      #   nil if the parent is not set
+      def section_path
+        return nil unless parent
+
+        parent.section_path.join(index)
+      end
     end
   end
 end

--- a/src/lib/y2network/autoinst_profile/udev_rule_section.rb
+++ b/src/lib/y2network/autoinst_profile/udev_rule_section.rb
@@ -57,13 +57,14 @@ module Y2Network
       # Clones a network interface into an AutoYaST udev rule section
       #
       # @param interface [Y2Network::Interface]
+      # @param parent [SectionWithAttributes,nil] Parent section
       # @return [InterfacesSection, nil] Udev rule section or nil if udev naming is not implemented
       #   for interface
-      def self.new_from_network(interface)
+      def self.new_from_network(interface, parent = nil)
         return if interface.renaming_mechanism == :none
         return unless interface.hardware
 
-        new.tap { |r| r.init_from_config(interface) }
+        new(parent).tap { |r| r.init_from_config(interface) }
       end
 
       def initialize(*_args)

--- a/src/lib/y2network/autoinst_profile/udev_rules_section.rb
+++ b/src/lib/y2network/autoinst_profile/udev_rules_section.rb
@@ -51,9 +51,10 @@ module Y2Network
       # Clones network interfaces settings into an AutoYaST interfaces section
       #
       # @param interfaces [Y2Network::InterfacesCollection] interfaces to detect udev rules
+      # @param parent [SectionWithAttributes,nil] Parent section
       # @return [UdevRulesSection]
-      def self.new_from_network(interfaces)
-        new.tap { |r| r.init_from_network(interfaces) }
+      def self.new_from_network(interfaces, parent = nil)
+        new(parent).tap { |r| r.init_from_network(interfaces) }
       end
 
       # Constructor
@@ -84,7 +85,7 @@ module Y2Network
       # @param hash [Hash] net-udev section hash
       def udev_rules_from_hash(hash)
         hash.map do |h|
-          res = UdevRuleSection.new_from_hashes(h)
+          res = UdevRuleSection.new_from_hashes(h, self)
           log.info "udev rules section #{res.inspect} load from hash #{h.inspect}"
           res
         end
@@ -93,7 +94,7 @@ module Y2Network
       # @param interfaces [Y2Network::InterfacesCollection] interfaces to detect udev rules
       def udev_rules_section(interfaces)
         result = interfaces
-          .map { |i| Y2Network::AutoinstProfile::UdevRuleSection.new_from_network(i) }
+          .map { |i| Y2Network::AutoinstProfile::UdevRuleSection.new_from_network(i, self) }
           .compact
 
         log.info "udev rules for interfaces: #{interfaces.inspect} => #{result.inspect}"

--- a/src/lib/y2network/autoinst_profile/udev_rules_section.rb
+++ b/src/lib/y2network/autoinst_profile/udev_rules_section.rb
@@ -78,6 +78,13 @@ module Y2Network
         @udev_rules = udev_rules_section(interfaces)
       end
 
+      # Returns the section name
+      #
+      # @return [String] "udev-rules"
+      def section_name
+        "net-udev"
+      end
+
     private
 
       # Returns an array of udev rules sections

--- a/test/y2network/autoinst_profile/dns_section_test.rb
+++ b/test/y2network/autoinst_profile/dns_section_test.rb
@@ -44,6 +44,7 @@ describe Y2Network::AutoinstProfile::DNSSection do
 
     let(:nameservers) { [IPAddr.new("1.1.1.1")] }
     let(:searchlist) { ["example.net"] }
+    let(:parent) { double("Installation::AutoinstProfile::SectionWithAttributes") }
 
     it "sets the hostname attribute" do
       section = described_class.new_from_network(dns, hostname)
@@ -68,6 +69,11 @@ describe Y2Network::AutoinstProfile::DNSSection do
     it "sets the searchlist attribute" do
       section = described_class.new_from_network(dns, hostname)
       expect(section.searchlist).to eq(["example.net"])
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_network(dns, hostname, parent)
+      expect(section.parent).to eq(parent)
     end
   end
 

--- a/test/y2network/autoinst_profile/interface_section_test.rb
+++ b/test/y2network/autoinst_profile/interface_section_test.rb
@@ -47,6 +47,8 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
       end
     end
 
+    let(:parent) { double("parent section") }
+
     it "initializes values properly" do
       section = described_class.new_from_network(config)
       expect(section.bootproto).to eq("static")
@@ -56,6 +58,11 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
         "alias0" => { "IPADDR" => "10.100.0.1", "PREFIXLEN" => "24", "LABEL" => "test" },
         "alias1" => { "IPADDR" => "10.100.0.2", "PREFIXLEN" => "24", "LABEL" => "test1" }
       )
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_network(config, parent)
+      expect(section.parent).to eq(parent)
     end
   end
 
@@ -68,9 +75,16 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
       }
     end
 
+    let(:parent) { double("parent section") }
+
     it "loads properly boot protocol" do
       section = described_class.new_from_hashes(hash)
       expect(section.bootproto).to eq "dhcp4"
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_hashes(hash, parent)
+      expect(section.parent).to eq(parent)
     end
   end
 

--- a/test/y2network/autoinst_profile/interface_section_test.rb
+++ b/test/y2network/autoinst_profile/interface_section_test.rb
@@ -19,6 +19,7 @@
 
 require_relative "../../test_helper"
 require "y2network/autoinst_profile/interface_section"
+require "y2network/autoinst_profile/networking_section"
 require "y2network/connection_config/ip_config"
 
 describe Y2Network::AutoinstProfile::InterfaceSection do
@@ -142,6 +143,20 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
 
       section = described_class.new_from_hashes(hash)
       expect(section.bonding_slaves).to eq ["eth0", "eth1"]
+    end
+  end
+
+  describe "#section_path" do
+    let(:networking) do
+      Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(
+        "interfaces" => [{ "device" => "eth0" }]
+      )
+    end
+
+    subject(:section) { networking.interfaces.interfaces.first }
+
+    it "returns the section path" do
+      expect(section.section_path.to_s).to eq("networking,interfaces,0")
     end
   end
 end

--- a/test/y2network/autoinst_profile/networking_section_test.rb
+++ b/test/y2network/autoinst_profile/networking_section_test.rb
@@ -67,9 +67,9 @@ describe Y2Network::AutoinstProfile::NetworkingSection do
 
     before do
       allow(Y2Network::AutoinstProfile::RoutingSection).to receive(:new_from_hashes)
-        .with(routing).and_return(routing_section)
+        .with(routing, described_class).and_return(routing_section)
       allow(Y2Network::AutoinstProfile::DNSSection).to receive(:new_from_hashes)
-        .with(dns).and_return(dns_section)
+        .with(dns, described_class).and_return(dns_section)
     end
 
     it "initializes the routing section" do

--- a/test/y2network/autoinst_profile/route_section_test.rb
+++ b/test/y2network/autoinst_profile/route_section_test.rb
@@ -46,6 +46,8 @@ describe Y2Network::AutoinstProfile::RouteSection do
     let(:gateway) { IPAddr.new("192.168.122.1") }
     let(:options) { "some-option" }
 
+    let(:parent) { double("Installation::AutoinstProfile::SectionWithAttributes") }
+
     it "initializes the destination value" do
       section = described_class.new_from_network(route)
       expect(section.destination).to eq("192.168.122.0")
@@ -118,6 +120,11 @@ describe Y2Network::AutoinstProfile::RouteSection do
         section = described_class.new_from_network(route)
         expect(section.extrapara).to eq("")
       end
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_network(route, parent)
+      expect(section.parent).to eq(parent)
     end
   end
 

--- a/test/y2network/autoinst_profile/route_section_test.rb
+++ b/test/y2network/autoinst_profile/route_section_test.rb
@@ -19,6 +19,7 @@
 
 require_relative "../../test_helper"
 require "y2network/autoinst_profile/route_section"
+require "y2network/autoinst_profile/networking_section"
 require "y2network/route"
 
 describe Y2Network::AutoinstProfile::RouteSection do
@@ -177,6 +178,20 @@ describe Y2Network::AutoinstProfile::RouteSection do
         section = described_class.new_from_hashes(default_gateway)
         expect(section.destination).to eq(:default)
       end
+    end
+  end
+
+  describe "#section_path" do
+    let(:networking) do
+      Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(
+        "routing" => { "routes" => [{ "device" => "eth0" }] }
+      )
+    end
+
+    subject(:section) { networking.routing.routes.first }
+
+    it "returns the section path" do
+      expect(section.section_path.to_s).to eq("networking,routing,routes,0")
     end
   end
 end

--- a/test/y2network/autoinst_profile/routing_section_test.rb
+++ b/test/y2network/autoinst_profile/routing_section_test.rb
@@ -30,6 +30,7 @@ describe Y2Network::AutoinstProfile::RoutingSection do
     end
     let(:route1) { double("Y2Network::Route") }
     let(:route_section) { double("Y2Network::AutoinstProfile::RouteSection") }
+    let(:parent) { double("parent section") }
 
     before do
       allow(Y2Network::AutoinstProfile::RouteSection).to receive(:new_from_network).with(route1)
@@ -49,6 +50,11 @@ describe Y2Network::AutoinstProfile::RoutingSection do
     it "sets the routing section" do
       section = described_class.new_from_network(routing)
       expect(section.routes).to eq([route_section])
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_network(routing, parent)
+      expect(section.parent).to eq(parent)
     end
   end
 

--- a/test/y2network/autoinst_profile/s390_device_section_test.rb
+++ b/test/y2network/autoinst_profile/s390_device_section_test.rb
@@ -42,11 +42,18 @@ describe Y2Network::AutoinstProfile::S390DeviceSection do
       end
     end
 
+    let(:parent) { double("Installation::AutoinstProfile::SectionWithAttributes") }
+
     it "initializes values properly" do
       section = described_class.new_from_network(config)
       expect(section.layer2).to eq(true)
       expect(section.chanids).to eq("0.0.0700:0.0.0701:0.0.0702")
       expect(section.type).to eq("qeth")
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_network(config, parent)
+      expect(section.parent).to eq(parent)
     end
   end
 

--- a/test/y2network/autoinst_profile/s390_device_section_test.rb
+++ b/test/y2network/autoinst_profile/s390_device_section_test.rb
@@ -88,4 +88,18 @@ describe Y2Network::AutoinstProfile::S390DeviceSection do
       end
     end
   end
+
+  describe "#section_path" do
+    let(:networking) do
+      Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(
+        "s390-devices" => [{ "type" => "qeth" }]
+      )
+    end
+
+    subject(:section) { networking.s390_devices.devices.first }
+
+    it "returns the section path" do
+      expect(section.section_path.to_s).to eq("networking,s390-devices,0")
+    end
+  end
 end

--- a/test/y2network/autoinst_profile/s390_devices_section_test.rb
+++ b/test/y2network/autoinst_profile/s390_devices_section_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -18,25 +18,31 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
-require "y2network/autoinst_profile/udev_rule_section"
+require "y2network/autoinst_profile/s390_device_section"
 require "y2network/connection_config/ip_config"
 
-describe Y2Network::AutoinstProfile::UdevRuleSection do
+describe Y2Network::AutoinstProfile::S390DevicesSection do
   subject(:section) { described_class.new }
 
   describe ".new_from_network" do
-    let(:hardware) do
-      double(Y2Network::Hwinfo, mac: "mac1", busid: "bus1")
-    end
-    let(:interface) do
-      double(Y2Network::Interface, renaming_mechanism: :mac, hardware: hardware, name: "eth0")
+    let(:config) do
+      Y2Network::ConnectionConfig::Qeth.new.tap do |c|
+        c.bootproto = Y2Network::BootProtocol::STATIC
+        c.interface = "eth0"
+      end
     end
 
-    it "initializes values properly" do
-      section = described_class.new_from_network(interface)
-      expect(section.name).to eq "eth0"
-      expect(section.value).to eq "mac1"
-      expect(section.rule).to eq "ATTR{address}"
+    let(:parent) { double("Installation::AutoinstProfile::SectionWithAttributes") }
+
+    it "initializes s390 devices values properly" do
+      section = described_class.new_from_network([config])
+      expect(section.devices)
+        .to contain_exactly(a_kind_of(Y2Network::AutoinstProfile::S390DeviceSection))
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_network([config], parent)
+      expect(section.parent).to eq(parent)
     end
   end
 end

--- a/test/y2network/autoinst_profile/udev_rule_section_test.rb
+++ b/test/y2network/autoinst_profile/udev_rule_section_test.rb
@@ -1,0 +1,49 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/autoinst_profile/udev_rule_section"
+require "y2network/connection_config/ip_config"
+
+describe Y2Network::AutoinstProfile::UdevRuleSection do
+  subject(:section) { described_class.new }
+
+  describe ".new_from_network" do
+    let(:hardware) do
+      double(Y2Network::Hwinfo, mac: "mac1", busid: "bus1")
+    end
+    let(:interface) do
+      double(Y2Network::Interface, renaming_mechanism: :mac, hardware: hardware, name: "eth0")
+    end
+
+    let(:parent) { double("Installation::AutoinstProfile::SectionWithAttributes") }
+
+    it "initializes values properly" do
+      section = described_class.new_from_network(interface)
+      expect(section.name).to eq "eth0"
+      expect(section.value).to eq "mac1"
+      expect(section.rule).to eq "ATTR{address}"
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_network(interface, parent)
+      expect(section.parent).to eq(parent)
+    end
+  end
+end

--- a/test/y2network/autoinst_profile/udev_rule_section_test.rb
+++ b/test/y2network/autoinst_profile/udev_rule_section_test.rb
@@ -19,7 +19,7 @@
 
 require_relative "../../test_helper"
 require "y2network/autoinst_profile/udev_rule_section"
-require "y2network/connection_config/ip_config"
+require "y2network/autoinst_profile/networking_section"
 
 describe Y2Network::AutoinstProfile::UdevRuleSection do
   subject(:section) { described_class.new }
@@ -44,6 +44,20 @@ describe Y2Network::AutoinstProfile::UdevRuleSection do
     it "sets the parent section" do
       section = described_class.new_from_network(interface, parent)
       expect(section.parent).to eq(parent)
+    end
+  end
+
+  describe "#section_path" do
+    let(:networking) do
+      Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(
+        "net-udev" => [{ "name" => "eth0" }]
+      )
+    end
+
+    subject(:section) { networking.udev_rules.udev_rules.first }
+
+    it "returns the section path" do
+      expect(section.section_path.to_s).to eq("networking,net-udev,0")
     end
   end
 end

--- a/test/y2network/autoinst_profile/udev_rules_section_test.rb
+++ b/test/y2network/autoinst_profile/udev_rules_section_test.rb
@@ -1,0 +1,47 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/autoinst_profile/udev_rules_section"
+
+describe Y2Network::AutoinstProfile::UdevRulesSection do
+  subject(:section) { described_class.new }
+
+  describe ".new_from_network" do
+    let(:hardware) do
+      double(Y2Network::Hwinfo, mac: "mac1", busid: "bus1")
+    end
+    let(:interface) do
+      double(Y2Network::Interface, renaming_mechanism: :mac, hardware: hardware, name: "eth0")
+    end
+
+    let(:parent) { double("Installation::AutoinstProfile::SectionWithAttributes") }
+
+    it "initializes the list of udev rules" do
+      section = described_class.new_from_network([interface])
+      expect(section.udev_rules)
+        .to contain_exactly(a_kind_of(Y2Network::AutoinstProfile::UdevRuleSection))
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_network([interface], parent)
+      expect(section.parent).to eq(parent)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The new error reporting mechanism and the <ask-list> features use different syntax to point to a specific element in a profile (`networking,interfaces,1` vs `interfaces [1]`).

## Solution

Use the same syntax that the ask-list. This PR relies on https://github.com/yast/yast-yast2/pull/1090. Additionally, now the parent section is properly set.
