### PR TITLE
Write the "\n" after sysctl settings

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 31 14:45:25 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add a line return after the 'disable_ipv6' line in sysctl.conf
+  (bsc#1171416).
+- 4.1.54
+
+-------------------------------------------------------------------
 Tue Sep 24 09:58:00 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - bsc#1136934

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.1.53
+Version:        4.1.54
 Release:        0
 BuildArch:      noarch
 

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -431,6 +431,8 @@ module Yast
         file = Builtins.add(file, row)
       end
       file = Builtins.add(file, sysctl_row) if !found
+      # Make sure a '\n' is added even if it was already missing (bsc#1171416)
+      file << "" unless file.empty? || file.last.empty?
       SCR.Write(
         path(".target.string"),
         filename,


### PR DESCRIPTION
Fixes [bsc#1171416](https://bugzilla.suse.com/show_bug.cgi?id=1171416).

The problem is that, when adding the `disable_ipv6` line, the `\n` is missing. It should be enough with the patch proposed at [comment#3](https://bugzilla.suse.com/show_bug.cgi?id=1171416#c3). However, is the file was already added by YaST, it will not make a difference.

This patch adds the `\n` even in that case.