### PR TITLE
Do not crash when proposing the bridge configuration for virtualization

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Sep 10 08:16:52 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- When proposing the virtualization network configuration, force a
+  read of the current configuration in case that it is not present
+  (bsc#1176313)
+- 4.2.76
+
+-------------------------------------------------------------------
 Tue Jul 28 08:45:12 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when configuring an IPv6 route through AutoYaST

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.75
+Version:        4.2.76
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -725,6 +725,7 @@ module Yast
     end
 
     def ProposeVirtualized
+      read_config unless yast_config
       Y2Network::VirtualizationConfig.new(yast_config).create
     end
 

--- a/test/lan_test.rb
+++ b/test/lan_test.rb
@@ -321,11 +321,20 @@ describe "LanClass" do
 
   describe "#ProposeVirtualized" do
     let(:yast_config) { instance_double(Y2Network::Config, "YaST") }
+
     before do
-      subject.add_config(:yast, yast_config)
+      Yast::Lan.clear_configs
+      allow_any_instance_of(Y2Network::VirtualizationConfig).to receive(:create)
+    end
+
+    it "reads the network configuration if there is not config present" do
+      expect(Yast::Lan).to receive(:read_config)
+
+      Yast::Lan.ProposeVirtualized
     end
 
     it "creates a new configuration for virtualization" do
+      subject.add_config(:yast, yast_config)
       expect_any_instance_of(Y2Network::VirtualizationConfig).to receive(:create)
 
       Yast::Lan.ProposeVirtualized


### PR DESCRIPTION
## Problem

The virtualization config proposal relies on the current network configuration in order to check the current configured interfaces. The proposal crashes because the network config has not been read by any client.

- https://bugzilla.suse.com/show_bug.cgi?id=1176313

## Solution

Force a read of the configuration in case it was not previously initialized.