### PR TITLE
Fix connection hostname read

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 21 07:58:22 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix connection hostname initialization (bsc#1175579)
+- 4.2.78
+
+-------------------------------------------------------------------
 Tue Sep 15 19:51:36 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Infer the vlan_id from the interface file name when the attribute

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.77
+Version:        4.2.78
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/sysconfig/connection_config_readers/base.rb
+++ b/src/lib/y2network/sysconfig/connection_config_readers/base.rb
@@ -129,7 +129,9 @@ module Y2Network
           return nil unless conn.ip
 
           Yast::Host.Read
-          Yast::Host.names(conn.ip.address.address.to_s).first
+          aliases = Yast::Host.names(conn.ip.address.address.to_s).first
+          # Use the fqdn when defined
+          aliases.to_s.split(" ").first
         end
       end
     end

--- a/test/data/scr_read/etc/hosts
+++ b/test/data/scr_read/etc/hosts
@@ -1,2 +1,2 @@
 127.0.0.1     localhost
-192.168.123.1 foo
+192.168.123.1 foo.example.com foo

--- a/test/y2network/sysconfig/connection_config_readers/ethernet_test.rb
+++ b/test/y2network/sysconfig/connection_config_readers/ethernet_test.rb
@@ -71,7 +71,7 @@ describe Y2Network::Sysconfig::ConnectionConfigReaders::Ethernet do
       context "and a hostname is specified" do
         it "sets the hostname" do
           eth = handler.connection_config
-          expect(eth.hostname).to eq("foo")
+          expect(eth.hostname).to eq("foo.example.com")
         end
       end
 


### PR DESCRIPTION
## Problem

YaST initializes the connection hostname with all the aliases instead of just the FQDN when it reads the interface configuration.

- https://bugzilla.suse.com/show_bug.cgi?id=1175579

## Solution

Initialize the hostname using only the first entry.