### PR TITLE
Fixed false error in the y2log (bsc#1176653)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 21 13:15:39 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed false error in the y2log (bsc#1176653)
+- 4.3.22
+
+-------------------------------------------------------------------
 Mon Sep 21 07:58:22 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix connection hostname initialization (bsc#1175579)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.21
+Version:        4.3.22
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/servers_non_y2/ag_udev_persistent
+++ b/src/servers_non_y2/ag_udev_persistent
@@ -188,6 +188,14 @@ sub Write {
 sub Dir {
 }
 
+sub OtherCommand ()
+{
+    my $class = shift;
+    my $command = shift;
+    y2warning ("OtherCommand ($command) not implemented in this agent");
+    return undef;
+}
+
 package main;
 
 ag_udev_persistent->Run ();


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1176653, there is an error logged in the `y2log` even in a successful installation
- Override the default `OtherCommand` implementation from the `YaST::SCRAgent` (see https://github.com/yast/yast-core/blob/master/agents-perl/lib/YaST/SCRAgent.pm#L83-L89)
- Just to not log an error into the `y2log`
- 4.3.22

### Testing

Run `echo 'OtherCommand("SetRoot")' | ./ag_udev_persistent ; tail -n 1 ~/.y2log` to check that the agent works and logs the message as a warning.