### PR TITLE
Do not modify bridge STP configuration

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep 24 15:20:15 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixed initialization of the bridge STP configuration
+  (bsc#1176820)
+- 4.2.79
+
+-------------------------------------------------------------------
 Mon Sep 21 07:58:22 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix connection hostname initialization (bsc#1175579)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.78
+Version:        4.2.79
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/sysconfig/connection_config_readers/bridge.rb
+++ b/src/lib/y2network/sysconfig/connection_config_readers/bridge.rb
@@ -28,7 +28,7 @@ module Y2Network
         # @see Y2Network::Sysconfig::ConnectionConfigReaders::Base#update_connection_config
         def update_connection_config(conn)
           conn.ports = file.bridge_ports ? file.bridge_ports.split(" ") : []
-          conn.stp = file.bridge_stp
+          conn.stp = file.bridge_stp == "on"
           conn.forward_delay = file.bridge_forwarddelay
         end
       end

--- a/test/y2network/sysconfig/connection_config_readers/bridge_test.rb
+++ b/test/y2network/sysconfig/connection_config_readers/bridge_test.rb
@@ -40,7 +40,7 @@ describe Y2Network::Sysconfig::ConnectionConfigReaders::Bridge do
       bridge_conn = handler.connection_config
       expect(bridge_conn.interface).to eq("br0")
       expect(bridge_conn.ports).to eq(["eth0", "eth1"])
-      expect(bridge_conn.stp).to eq("on")
+      expect(bridge_conn.stp).to eq(true)
       expect(bridge_conn.forward_delay).to eq(5)
     end
   end


### PR DESCRIPTION
## Problem

When reading a bridge configuration, the **STP** option is wrongly initialized causing a change of it in case of writing.

- https://bugzilla.suse.com/show_bug.cgi?id=1176820

## Solution

Initialize correctly the **STP** attribute