### PR TITLE
Fix write autoinstall config

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 28 13:44:08 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Write the virtualization network configuration properly during an
+  autoinstallation (bsc#1177025)
+- 4.2.80
+
+-------------------------------------------------------------------
 Thu Sep 24 15:20:15 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixed initialization of the bridge STP configuration

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.79
+Version:        4.2.80
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -109,7 +109,7 @@ module Yast
       # wait for rebooting into just installed target
       return if Lan.yast_config == Lan.system_config
 
-      Lan.yast_config.write
+      Lan.write_config
     end
 
     # Propose DNS and Hostname setup

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -203,7 +203,7 @@ describe Yast::NetworkAutoconfiguration do
       allow(Y2Network::Config).to receive(:find).with(:yast).and_return(yast_config)
       allow(Y2Network::Config).to receive(:find).with(:system).and_return(system_config)
       allow(instance).to receive(:virtual_proposal_required?).and_return(proposal)
-      allow(yast_config).to receive(:write)
+      allow(Yast::Lan).to receive(:write_config)
       allow_any_instance_of(Y2Network::VirtualizationConfig)
         .to receive(:connected_and_bridgeable?).and_return(true)
       allow(Yast::PackageSystem).to receive(:Installed).and_return(true)
@@ -231,7 +231,7 @@ describe Yast::NetworkAutoconfiguration do
       end
 
       it "writes the configuration of the interfaces" do
-        expect(Yast::Lan.yast_config).to receive(:write)
+        expect(Yast::Lan).to receive(:write_config)
         instance.configure_virtuals
       end
 
@@ -241,7 +241,7 @@ describe Yast::NetworkAutoconfiguration do
         end
 
         it "writes the routing config" do
-          expect(yast_config).to receive(:write)
+          expect(Yast::Lan).to receive(:write_config)
           instance.configure_virtuals
         end
       end


### PR DESCRIPTION
## Problem

During an auto-installation, if the network configuration declared in the profile is written, the source becomes `:autoinstall`. The virtualization network proposal tries to write the config later using that writer which is wrong.

- https://bugzilla.suse.com/show_bug.cgi?id=1177025

## Solution

Fix the write of the virtualization network configuration using `Lan.write_config` which takes care of using the correct writer and replace the system config properly