### PR TITLE
Pick the first hostname when there is more than one

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct  5 09:51:14 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not crash when there are more than one parsing hostnames
+  obtained by wicked through DHCP (bsc#1173915)
+- 4.2.81
+
+-------------------------------------------------------------------
 Mon Sep 28 13:44:08 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Write the virtualization network configuration properly during an

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.80
+Version:        4.2.81
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -50,9 +50,7 @@ module Yast
     # @return [String] hostname
     def parse_hostname(iface)
       result = query_wicked(iface, "//hostname")
-
-      raise "Malformed wicked runtime configuration" if result.count > 1
-
+      # If there is more than one just pick the first one
       result.first
     end
 

--- a/src/lib/y2network/widgets/boot_protocol.rb
+++ b/src/lib/y2network/widgets/boot_protocol.rb
@@ -173,12 +173,11 @@ module Y2Network
           none_enabled(false)
           one_ip = Yast::UI.QueryWidget(Id(:bootproto_ipaddr), :Value)
           if one_ip.empty?
-            log.info "Presetting global hostname"
-            Yast::UI.ChangeWidget(
-              Id(:bootproto_hostname),
-              :Value,
-              Yast::Hostname.MergeFQ(Yast::DNS.hostname, Yast::DNS.domain)
-            )
+            current_hostname = Yast::Hostname.MergeFQ(Yast::DNS.hostname, Yast::DNS.domain)
+            unless current_hostname.empty? || current_hostname == "localhost"
+              log.info "Presetting global hostname"
+              Yast::UI.ChangeWidget(Id(:bootproto_hostname), :Value, current_hostname)
+            end
           end
         when :bootproto_dynamic
           static_enabled(false)


### PR DESCRIPTION
## Problem 

There are two separate options for configuring the hostname through **DHCP** in sysconfig, one for **IPv4** and one for **IPv6**. 

Both option are global, that is, you can set also per interface which has precedence over the global one but currently **YaST** only set it for **IPv4**.

We did several changes in order to decide which interface is allowed to modify the hostname but the changes done were only for **IPv4**.

- https://bugzilla.suse.com/show_bug.cgi?id=1173915

## Solution

Do not crash when there are more than one hostname, and just pick the first one.
Also do not propose "localhost" as an alias for an interface configured statically.