### PR TITLE
Minor fixes in AY import

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Oct 13 12:57:36 UTC 2020 - Michal Filka <mfilka@suse.com>
+
+- bnc#1175360
+  - more robust AY profile parser. Do not crash with internal error
+    on unknown node in interfaces section
+  - support for static configurations without ip address
+- 4.2.83 
+
+-------------------------------------------------------------------
 Wed Oct  7 11:45:04 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Write hostname changes when modified through the 'dns' client

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -5,6 +5,8 @@ Tue Oct 13 12:57:36 UTC 2020 - Michal Filka <mfilka@suse.com>
   - more robust AY profile parser. Do not crash with internal error
     on unknown node in interfaces section
   - support for static configurations without ip address
+- bnc#1175206
+  - support for defined default when missing bootproto in AY
 - 4.2.83 
 
 -------------------------------------------------------------------

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.82
+Version:        4.2.83
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -89,10 +89,13 @@ module Y2Network
         config.interface = config.name # in autoyast name and interface is same
         if config.bootproto == BootProtocol::STATIC
           if !interface_section.ipaddr
-            raise ArgumentError, "Configuration for #{config.name} is invalid #{interface_section.inspect}"
+            msg = "Configuration for #{config.name} is invalid #{interface_section.inspect}"
+            raise ArgumentError, msg
           end
 
-          ipaddr = IPAddress.from_string(interface_section.ipaddr) if !interface_section.ipaddr.empty?
+          if !interface_section.ipaddr.empty?
+            ipaddr = IPAddress.from_string(interface_section.ipaddr)
+          end
           # Assign first netmask, as prefixlen has precedence so it will overwrite it
           ipaddr.netmask = interface_section.netmask if !interface_section.netmask.to_s.empty?
           if !interface_section.prefixlen.to_s.empty?

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -88,8 +88,11 @@ module Y2Network
         config.name = name_from_section(interface_section)
         config.interface = config.name # in autoyast name and interface is same
         if config.bootproto == BootProtocol::STATIC
-          # TODO: report if ipaddr missing for static config
-          ipaddr = IPAddress.from_string(interface_section.ipaddr)
+          if !interface_section.ipaddr
+            raise ArgumentError, "Configuration for #{config.name} is invalid #{interface_section.inspect}"
+          end
+
+          ipaddr = IPAddress.from_string(interface_section.ipaddr) if !interface_section.ipaddr.empty?
           # Assign first netmask, as prefixlen has precedence so it will overwrite it
           ipaddr.netmask = interface_section.netmask if !interface_section.netmask.to_s.empty?
           if !interface_section.prefixlen.to_s.empty?

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -283,7 +283,8 @@ module Y2Network
       # @param config [Y2Network::ConnectionConfig]
       # @return [Boolean]
       def init_from_config(config)
-        @bootproto = config.bootproto.name
+        # nil bootproto is valid use case (missing explicit setup) - wicked defaults to static then
+        @bootproto = config.bootproto&.name
         @name = config.name
         if config.bootproto == BootProtocol::STATIC && config.ip
           # missing ip is valid scenario for wicked - so use empty string here

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -286,8 +286,9 @@ module Y2Network
         @bootproto = config.bootproto.name
         @name = config.name
         if config.bootproto == BootProtocol::STATIC && config.ip
-          @ipaddr = config.ip.address.address.to_s
-          @prefixlen = config.ip.address.prefix.to_s
+          # missing ip is valid scenario for wicked - so use empty string here
+          @ipaddr = config.ip.address&.address.to_s
+          @prefixlen = config.ip.address&.prefix.to_s
           @remote_ipaddr = config.ip.remote_address.address.to_s if config.ip.remote_address
           @broadcast = config.ip.broadcast.address.to_s if config.ip.broadcast
         end

--- a/src/lib/y2network/autoinst_profile/interfaces_section.rb
+++ b/src/lib/y2network/autoinst_profile/interfaces_section.rb
@@ -80,6 +80,7 @@ module Y2Network
       #
       # @param hash [Array] see {.new_from_hashes}. In this case it is array of interfaces
       def init_from_hashes(hash)
+        # we expect list of hashes here, remove everything else
         h = hash.delete_if { |v| !v.is_a?(Hash) }
         @interfaces = interfaces_from_hash(h)
       end

--- a/src/lib/y2network/autoinst_profile/interfaces_section.rb
+++ b/src/lib/y2network/autoinst_profile/interfaces_section.rb
@@ -80,7 +80,8 @@ module Y2Network
       #
       # @param hash [Array] see {.new_from_hashes}. In this case it is array of interfaces
       def init_from_hashes(hash)
-        @interfaces = interfaces_from_hash(hash)
+        h = hash.delete_if { |v| !v.is_a?(Hash) }
+        @interfaces = interfaces_from_hash(h)
       end
 
       # Method used by {.new_from_network} to populate the attributes when cloning routing settings

--- a/src/lib/y2network/boot_protocol.rb
+++ b/src/lib/y2network/boot_protocol.rb
@@ -35,7 +35,7 @@ module Y2Network
       # Returns the boot protocol with a given name
       #
       # @param name [String]
-      # @return [BootProtocol,nil] Boot protocol or nil is not found
+      # @return [BootProtocol,nil] Boot protocol or nil if not found
       def from_name(name)
         all.find { |t| t.name == name }
       end

--- a/src/lib/y2network/clients/auto.rb
+++ b/src/lib/y2network/clients/auto.rb
@@ -77,6 +77,7 @@ module Y2Network
       end
 
       def import(profile)
+        res = true
         modified_profile = Yast::Lan.FromAY(profile)
 
         # see bnc#498993
@@ -87,8 +88,14 @@ module Y2Network
           modified_profile = Yast::NetworkAutoYast.instance.merge_configs(modified_profile)
         end
 
-        Yast::Lan.Import(modified_profile)
-        true
+        begin
+          Yast::Lan.Import(modified_profile)
+        rescue ArgumentError => e
+          log.error("Network section import crashed with: #{e.inspect}")
+          res = Popup.ContinueCancel(_("Network section in the profile is malformed."))
+        end
+
+        res
       end
 
       def packages

--- a/src/lib/y2network/clients/auto.rb
+++ b/src/lib/y2network/clients/auto.rb
@@ -77,7 +77,6 @@ module Y2Network
       end
 
       def import(profile)
-        res = true
         modified_profile = Yast::Lan.FromAY(profile)
 
         # see bnc#498993
@@ -88,14 +87,9 @@ module Y2Network
           modified_profile = Yast::NetworkAutoYast.instance.merge_configs(modified_profile)
         end
 
-        begin
-          Yast::Lan.Import(modified_profile)
-        rescue ArgumentError => e
-          log.error("Network section import crashed with: #{e.inspect}")
-          res = Popup.ContinueCancel(_("Network section in the profile is malformed."))
-        end
+        Yast::Lan.Import(modified_profile)
 
-        res
+        true
       end
 
       def packages

--- a/src/lib/y2network/sysconfig/connection_config_writers/base.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writers/base.rb
@@ -40,7 +40,7 @@ module Y2Network
         #
         # @param conn [Y2Network::ConnectionConfig::Base] Connection to take settings from
         def write(conn)
-          file.bootproto = conn.bootproto.name
+          file.bootproto = conn.bootproto&.name
           file.name = conn.description
           file.lladdr = conn.lladdress
           file.startmode = conn.startmode.to_s


### PR DESCRIPTION
## Problem ##

1) unexpected nodes in in the networking section (e.g. <comment> node) caused an internal error during import
2) missing ip for statically configured interface caused an internal error
3) missing bootproto caused an internal error

https://bugzilla.suse.com/show_bug.cgi?id=1175360
https://bugzilla.suse.com/show_bug.cgi?id=1175206

## Solution ##

ad 1) implemented simple filtering which excludes unknown nodes from further processing
ad 2) implemented support for missing ip (according to wicked man page it is valid usecase)
ad 3) implemented support for missing bootproto (according to wicked man page it is valid usecase)