### PR TITLE
Do not show a warn popup when all the slaves are already configured

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Nov 23 08:03:17 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not show a warn message when modifying a bonding configuration
+  and all the slaves are already configured with BOOTPROTO='none'
+  (bsc#1178950)
+- 4.2.85
+
+-------------------------------------------------------------------
 Fri Nov 20 07:23:27 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixed detection of connection configuration changes (bsc#1178950)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.84
+Version:        4.2.85
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/interface_config_builders/bonding.rb
+++ b/src/lib/y2network/interface_config_builders/bonding.rb
@@ -50,10 +50,13 @@ module Y2Network
         connection_config.options
       end
 
-      # Checks if any of given device is already configured and need adaptation for bridge
+      # Returns whether any configuration of the given devices needs to be
+      # adapted in order to be added as a bonding slave
+
       # @param devices [Array<String>] devices to check
-      # @return [Boolean] true if there is device that needs adaptation
-      def already_configured?(devices)
+      # return [Boolean] true if there is a device config that needs
+      #   to be adaptated; false otherwise
+      def config_need_to_be_adapted?(devices)
         devices.any? do |device|
           next false unless yast_config.configured_interface?(device)
 

--- a/src/lib/y2network/interface_config_builders/bonding.rb
+++ b/src/lib/y2network/interface_config_builders/bonding.rb
@@ -56,7 +56,7 @@ module Y2Network
       # @param devices [Array<String>] devices to check
       # return [Boolean] true if there is a device config that needs
       #   to be adaptated; false otherwise
-      def config_need_to_be_adapted?(devices)
+      def require_adaptation?(devices)
         devices.any? do |device|
           next false unless yast_config.configured_interface?(device)
 

--- a/src/lib/y2network/interface_config_builders/bonding.rb
+++ b/src/lib/y2network/interface_config_builders/bonding.rb
@@ -57,7 +57,7 @@ module Y2Network
         devices.any? do |device|
           next false unless yast_config.configured_interface?(device)
 
-          yast_config.connections.by_name(device).startmode.name != "none"
+          yast_config.connections.by_name(device).bootproto.name != "none"
         end
       end
 
@@ -66,7 +66,7 @@ module Y2Network
         slaves.each do |slave|
           interface = yast_config.interfaces.by_name(slave)
           connection = yast_config.connections.by_name(slave)
-          next if connection && connection.startmode.name == "none"
+          next if connection && connection.bootproto.name == "none"
 
           builder = InterfaceConfigBuilder.for(interface.type, config: connection)
           builder.name = interface.name

--- a/src/lib/y2network/interface_config_builders/bridge.rb
+++ b/src/lib/y2network/interface_config_builders/bridge.rb
@@ -32,10 +32,13 @@ module Y2Network
         super(type: InterfaceType::BRIDGE, config: config)
       end
 
-      # Checks if any of given device is already configured and need adaptation for bridge
+      # Returns whether any configuration of the given devices needs to be
+      # adapted in order to be added as a bridge port
+      #
       # @param devices [Array<String>] devices to check
-      # @return [Boolean] true if there is device that needs adaptation
-      def already_configured?(devices)
+      # @return [Boolean] true if there is a device config that needs
+      #   to be adaptated; false otherwise
+      def config_need_to_be_adapted?(devices)
         devices.any? do |device|
           next false unless yast_config.configured_interface?(device)
 

--- a/src/lib/y2network/interface_config_builders/bridge.rb
+++ b/src/lib/y2network/interface_config_builders/bridge.rb
@@ -38,7 +38,7 @@ module Y2Network
       # @param devices [Array<String>] devices to check
       # @return [Boolean] true if there is a device config that needs
       #   to be adaptated; false otherwise
-      def config_need_to_be_adapted?(devices)
+      def require_adaptation?(devices)
         devices.any? do |device|
           next false unless yast_config.configured_interface?(device)
 

--- a/src/lib/y2network/widgets/bond_slave.rb
+++ b/src/lib/y2network/widgets/bond_slave.rb
@@ -130,7 +130,7 @@ module Y2Network
           return false unless continue_with_duplicates?(physical_ports)
         end
 
-        if @settings.already_configured?(selected_items || [])
+        if @settings.config_need_to_be_adapted?(selected_items || [])
           return Yast::Popup.ContinueCancel(
             _(
               "At least one selected device is already configured.\n" \

--- a/src/lib/y2network/widgets/bond_slave.rb
+++ b/src/lib/y2network/widgets/bond_slave.rb
@@ -130,7 +130,7 @@ module Y2Network
           return false unless continue_with_duplicates?(physical_ports)
         end
 
-        if @settings.config_need_to_be_adapted?(selected_items || [])
+        if @settings.require_adaptation?(selected_items || [])
           return Yast::Popup.ContinueCancel(
             _(
               "At least one selected device is already configured.\n" \

--- a/src/lib/y2network/widgets/bridge_ports.rb
+++ b/src/lib/y2network/widgets/bridge_ports.rb
@@ -69,7 +69,7 @@ module Y2Network
       #
       # @return true if valid or user decision if not
       def validate
-        if @settings.config_need_to_be_adapted?(value || [])
+        if @settings.require_adaptation?(value || [])
           Yast::Popup.ContinueCancel(
             _(
               "At least one selected device is already configured.\n" \

--- a/src/lib/y2network/widgets/bridge_ports.rb
+++ b/src/lib/y2network/widgets/bridge_ports.rb
@@ -69,7 +69,7 @@ module Y2Network
       #
       # @return true if valid or user decision if not
       def validate
-        if @settings.already_configured?(value || [])
+        if @settings.config_need_to_be_adapted?(value || [])
           Yast::Popup.ContinueCancel(
             _(
               "At least one selected device is already configured.\n" \

--- a/test/y2network/interface_config_builders/bonding_test.rb
+++ b/test/y2network/interface_config_builders/bonding_test.rb
@@ -140,21 +140,21 @@ describe Y2Network::InterfaceConfigBuilders::Bonding do
     end
   end
 
-  describe "config_need_to_be_adapted?" do
+  describe "require_adaptation?" do
     before do
       connection_config.slaves = ["iface1", "iface2"]
     end
 
     context "when there is no slave configured" do
       it "returns false" do
-        expect(subject.config_need_to_be_adapted?(connection_config.slaves)).to eql(false)
+        expect(subject.require_adaptation?(connection_config.slaves)).to eql(false)
       end
     end
 
     context "when all the slaves are properly configure do" do
       it "return false" do
         subject.save
-        expect(subject.config_need_to_be_adapted?(connection_config.slaves)).to eql(false)
+        expect(subject.require_adaptation?(connection_config.slaves)).to eql(false)
       end
     end
     context "when at least one configured slave need to be adapted" do
@@ -162,7 +162,7 @@ describe Y2Network::InterfaceConfigBuilders::Bonding do
         subject.save
         iface1_conn = connection_configs_collection.by_name("iface1")
         iface1_conn.bootproto = Y2Network::BootProtocol::DHCP
-        expect(subject.config_need_to_be_adapted?(connection_config.slaves)).to eql(true)
+        expect(subject.require_adaptation?(connection_config.slaves)).to eql(true)
       end
     end
 

--- a/test/y2network/interface_config_builders/bridge_test.rb
+++ b/test/y2network/interface_config_builders/bridge_test.rb
@@ -53,9 +53,9 @@ describe Y2Network::InterfaceConfigBuilders::Bridge do
     end
   end
 
-  describe "#already_configured?" do
+  describe "#require_adaptation?" do
     it "returns boolean" do
-      expect(subject.already_configured?([])).to eq false
+      expect(subject.require_adaptation?([])).to eq false
     end
   end
 end

--- a/test/y2network/widgets/bridge_ports_test.rb
+++ b/test/y2network/widgets/bridge_ports_test.rb
@@ -28,7 +28,7 @@ describe Y2Network::Widgets::BridgePorts do
   subject { described_class.new(builder) }
 
   before do
-    allow(builder).to receive(:already_configured?).and_return(false)
+    allow(builder).to receive(:require_adaptation?).and_return(false)
   end
 
   include_examples "CWM::MultiSelectionBox"
@@ -43,7 +43,7 @@ describe Y2Network::Widgets::BridgePorts do
 
     context "when some of the enslaved interfaces are configured" do
       it "warns the user and request confirmation to continue" do
-        allow(builder).to receive(:already_configured?).and_return(true)
+        allow(builder).to receive(:require_adaptation?).and_return(true)
 
         expect(Yast::Popup).to receive(:ContinueCancel).and_return(true)
 


### PR DESCRIPTION
## Problem

Each time that a bond is modified it prompts an annoying message warning the user about slaves configuration changes, even when the bond slaves are configured properly

- https://trello.com/c/wmoYqtac/2184-l3-1178950-changing-bond-details-through-yast-does-not-change-files-on-disk

## Solution

Check whether the bond slaves are configured with (BOOTPROTO='none') instead of (STARTMODE='none')

## Test

- Added a unit test covering the issue.
- Tested manually