### PR TITLE
Fix wireless essid combobox

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 25 22:23:00 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixed update of the scanned wireless networks list (bsc#1178832)
+- 4.3.31
+
+-------------------------------------------------------------------
 Wed Nov 25 10:02:37 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when trying to replace an /etc/hosts alias using the

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.30
+Version:        4.3.31
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/wireless_essid.rb
+++ b/src/lib/y2network/widgets/wireless_essid.rb
@@ -62,6 +62,11 @@ module Y2Network
       def initialize(settings)
         @settings = settings
         textdomain "network"
+        @items = []
+      end
+
+      def items
+        @items
       end
 
       def label
@@ -76,6 +81,12 @@ module Y2Network
       # allow to use not found name e.g. when scan failed or when network is hidden
       def opt
         [:editable]
+      end
+
+      def change_items(new_items)
+        @items = new_items
+
+        super
       end
 
       # updates essid list with given array and ensure that previously selected value is preserved

--- a/test/y2network/widgets/wireless_essid_test.rb
+++ b/test/y2network/widgets/wireless_essid_test.rb
@@ -81,4 +81,28 @@ describe Y2Network::Widgets::WirelessScan do
       end
     end
   end
+
+  describe "#update_essid_list" do
+    let(:selected) { "YaST" }
+
+    before do
+      allow(essid).to receive(:update_essid_list).and_call_original
+      allow(essid).to receive(:value).and_return(selected)
+    end
+
+    it "populates the ComboBox with the scanned networks list" do
+      essid.update_essid_list(available_networks)
+
+      expect(essid.items).to eql(available_networks.map { |i| [i, i] })
+    end
+
+    context "when the selected value is not part of the scanned networks" do
+      let(:selected) { "hidden_essid" }
+
+      it "also appens the selected value to the ComboBox list" do
+        essid.update_essid_list(available_networks)
+        expect(essid.items).to include(["hidden_essid", "hidden_essid"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Since yast/yast-yast2#1044, when the selected essid is not part of the scanned network list, the list is not populated correctly and it becomes empty.

Original we fixed it with yast/yast-yast2#1113 but unfortunately introduced a new bug (see https://github.com/yast/yast-yast2/pull/1116)

## Solution

Revert the changes in the ComboBox, not introducing the current_items method and fix the update of the widget items just in this repository. Now we store the items list in a variable which is updated with the scanned network list.

