### PR TITLE
Fix hostname hosts update

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 25 10:02:37 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not crash when trying to replace an /etc/hosts alias using the
+  current static hostname and it is not set (bsc#1179178)
+- 4.3.30
+
+-------------------------------------------------------------------
 Mon Nov 23 08:03:17 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not show a warn message when modifying a bonding configuration

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.29
+Version:        4.3.30
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/modules/Host.rb
+++ b/src/modules/Host.rb
@@ -192,8 +192,8 @@ module Yast
 
     # Update hosts according to the current hostname
     # (only one hostname, assigned to all IP)
-    # @param oldhn [String] current hostname
-    # @param newhn [String] current domain name
+    # @param oldhn [String, nil] hostname to be replaced
+    # @param newhn [String] new hostname value
     # @param ip [String] to assign
     # @return [Boolean] true if success
     def Update(oldhn, newhn, ip)
@@ -203,7 +203,7 @@ module Yast
       log.info("Updating /etc/hosts: #{oldhn} -> #{newhn}: #{ip}")
 
       # Remove old hostname from hosts
-      @hosts.delete_hostname(oldhn) if !oldhn.empty?
+      @hosts.delete_hostname(oldhn) if ![nil, ""].include?(oldhn)
 
       # Add localhost if missing
       @hosts.add_entry("127.0.0.1", "localhost") if @hosts.host("127.0.0.1").empty?
@@ -275,7 +275,7 @@ module Yast
       static_ips = StaticIPs().reject { |sip| @hosts.include_ip?(sip) }
       return if static_ips.empty?
 
-      fqhostname = Hostname.MergeFQ(DNS.hostname, DNS.domain)
+      fqhostname = DNS.hostname
 
       # assign system wide hostname to a static ip without particular hostname
       static_ips.each { |sip| Update(fqhostname, fqhostname, sip) }


### PR DESCRIPTION
## Problem

The current installation crashes when trying to update the /etc/hosts aliases using the static hostname which is not set.

## Solution

Fix the crash checking if the current hostname is nil or empty in order to delete the /etc/hosts alias.