### PR TITLE
Clean SCR cached values before write interface config changes.

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec  9 12:28:21 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Clean the ifcfg file cached data before the connection
+  configuration changes are written (bsc#1178950)
+- 4.2.86
+
+-------------------------------------------------------------------
 Mon Nov 23 08:03:17 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not show a warn message when modifying a bonding configuration

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.85
+Version:        4.2.86
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/sysconfig/connection_config_writer.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writer.rb
@@ -42,6 +42,7 @@ module Y2Network
         handler_class = find_handler_class(conn.type)
         return nil if handler_class.nil?
 
+        remove(old_conn) if old_conn
         file.clean
         handler_class.new(file).write(conn)
         file.save

--- a/src/lib/y2network/sysconfig/connection_config_writer.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writer.rb
@@ -42,8 +42,8 @@ module Y2Network
         handler_class = find_handler_class(conn.type)
         return nil if handler_class.nil?
 
-        remove(old_conn) if old_conn
         file.clean
+        remove(old_conn) if old_conn
         handler_class.new(file).write(conn)
         file.save
       end

--- a/src/lib/y2network/sysconfig/connection_config_writer.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writer.rb
@@ -42,7 +42,6 @@ module Y2Network
         handler_class = find_handler_class(conn.type)
         return nil if handler_class.nil?
 
-        remove(old_conn) if old_conn
         file.clean
         handler_class.new(file).write(conn)
         file.save

--- a/src/lib/y2network/sysconfig/interface_file.rb
+++ b/src/lib/y2network/sysconfig/interface_file.rb
@@ -423,11 +423,10 @@ module Y2Network
           if variable.collection?
             clean_collection(variable.name)
             hash[variable.name] = {}
-            next
+          else
+            write_scalar(variable.name, nil)
+            hash[variable.name] = nil
           end
-
-          hash[variable.name] = nil
-          write_scalar(variable.name, nil)
         end
 
         @defined_variables = nil

--- a/src/lib/y2network/sysconfig/interface_file.rb
+++ b/src/lib/y2network/sysconfig/interface_file.rb
@@ -420,8 +420,16 @@ module Y2Network
       # to do some clean-up before writing the final values.
       def clean
         @values = self.class.variables.values.each_with_object({}) do |variable, hash|
-          hash[variable.name] = variable.collection? ? {} : nil
+          if variable.collection?
+            clean_collection(variable.name)
+            hash[variable.name] = {}
+            next
+          end
+
+          hash[variable.name] = nil
+          write_scalar(variable.name, nil)
         end
+
         @defined_variables = nil
       end
 


### PR DESCRIPTION
## Problem

When the number of bonding slaved interfaces is decreased, the change is not reflected correctly in the updated file.

- https://bugzilla.suse.com/show_bug.cgi?id=1178950#c29

## Solution

Clean the SCR cached data in order to write the ifcfg-file correctly.