### PR TITLE
Update connections mapped hostname when modified through the DNS client

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Dec 14 09:36:40 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Write also connections in case that the hostname mapped to a
+  connection primary IP address is changed through the DNS
+  standalone client (bsc#1174431)
+- 4.3.34
+
+-------------------------------------------------------------------
 Mon Dec 14 08:27:46 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Allow to modify the hostname mapped to a connection primary IP

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.33
+Version:        4.3.34
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -307,7 +307,7 @@ module Yast
       return false if hostname == current_hostname
       return false if current_hostname.empty?
 
-      conn = config.connections.find { |c| c.hostnames.include?(current_hostname) }
+      conn = config.connections.find { |c| c.hostnames&.include?(current_hostname) }
 
       update_hostname = conn && Popup.YesNo(
         wrap_text(

--- a/src/lib/y2network/clients/dns.rb
+++ b/src/lib/y2network/clients/dns.rb
@@ -276,7 +276,7 @@ module Y2Network
       end
 
       def write_config
-        Yast::Lan.write_config(only: [:dns, :hostname])
+        Yast::Lan.write_config(only: [:dns, :hostname, :connections])
       end
     end
   end

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -91,6 +91,7 @@ module Y2Network
         @description = ""
         @ethtool_options = ""
         @firewall_zone = ""
+        @hostnames = []
       end
 
       # Compares ConnectionConfigs

--- a/src/lib/y2network/sysconfig/connection_config_readers/base.rb
+++ b/src/lib/y2network/sysconfig/connection_config_readers/base.rb
@@ -124,9 +124,9 @@ module Y2Network
 
         # Returns the hostnames for the given connection
         #
-        # @return [Array<String>, nil]
+        # @return [Array<String>]
         def hostnames(conn)
-          return nil unless conn.ip
+          return [] unless conn.ip
 
           Yast::Host.Read
           aliases = Yast::Host.names(conn.ip.address.address.to_s).first

--- a/test/y2network/clients/dns_test.rb
+++ b/test/y2network/clients/dns_test.rb
@@ -83,7 +83,7 @@ describe Y2Network::Clients::DNS do
 
         it "writes the changes" do
           allow(subject).to receive(:write_config).and_call_original
-          expect(Yast::Lan).to receive(:write_config).with(only: [:dns, :hostname])
+          expect(Yast::Lan).to receive(:write_config).with(only: [:dns, :hostname, :connections])
           subject.main
         end
 


### PR DESCRIPTION
## Problem

When the hostname is modified through the DNS standalone client, it warns the user about the mapped hostname but does write the changes as it only change the dns and hostname settings

- https://trello.com/c/G1OvvwjV/2104-3-sle15-sp2-1174431-yast-network-yast-does-not-update-ip-aliases-when-the-hostname-is-modified

## Solution

Write connection changes too when the connection hostname is modified.