### PR TITLE
Fixed conversion of netmask dot-decimal notation to /prefixlength

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 15 08:38:07 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix prefix length assignation when the alias netmask uses
+  dot notation (bsc#1174766).
+- 4.2.88
+
+-------------------------------------------------------------------
 Thu Dec 10 10:43:48 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix bonding slaves sorting (bsc#1178950)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.87
+Version:        4.2.88
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/additional_addresses.rb
+++ b/src/lib/y2network/widgets/additional_addresses.rb
@@ -244,11 +244,10 @@ module Y2Network
           end
 
           res[:prefixlen] = if prefixlen.empty?
-            IPAddr.new("#{netmask}/#{netmask}")
+            IPAddr.new("#{netmask}/#{netmask}").prefix
           else
             prefixlen
           end
-          res[:prefixlen] = prefixlen
           res[:id] = id
 
           break


### PR DESCRIPTION
## Problem

When an IP alias is edited or added to a connection config and the Netmask uses dot-decimal notation, it is converted to the slash notation without the prefix length.

- https://bugzilla.suse.com/show_bug.cgi?id=1174766

## Solution

Fix the conversion from dot-decimal notation to prefix length.