### PR TITLE
Move additional IP address configuration popup dialog to its own class

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 16 10:38:07 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix prefix length assignation when the alias netmask uses
+  dot notation (bsc#1174766).
+- 4.3.35
+
+-------------------------------------------------------------------
 Mon Dec 14 09:36:40 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Write also connections in case that the hostname mapped to a

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.34
+Version:        4.3.35
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/connection_config/ip_config.rb
+++ b/src/lib/y2network/connection_config/ip_config.rb
@@ -34,6 +34,7 @@ module Y2Network
       # @return [IPAddress,nil] Broadcast address
       attr_accessor :broadcast
       # @return [String] ID (needed for sysconfig backend in order to write suffixes in
+      #   ifcfg-* files)
       attr_accessor :id
 
       # Constructor

--- a/src/lib/y2network/dialogs/additional_address.rb
+++ b/src/lib/y2network/dialogs/additional_address.rb
@@ -39,11 +39,9 @@ module Y2Network
       end
 
       def contents
-        focus_label = @settings.label.to_s.empty?
-
         VBox(
-          label_widget(focus_label),
-          ip_address_widget(!focus_label),
+          label_widget,
+          ip_address_widget,
           netmask_widget
         )
       end
@@ -65,16 +63,16 @@ module Y2Network
         [ok_button, cancel_button]
       end
 
-      def label_widget(focus)
-        @label_widget ||= IPAddressLabel.new(@name, @settings)
-        @label_widget.focus if focus
-        @label_widget
+      def focus_label?
+        @settings.label.to_s.empty?
       end
 
-      def ip_address_widget(focus)
-        @ip_address_widget ||= Y2Network::Widgets::IPAddress.new(@settings)
-        @ip_address_widget if focus
-        @ip_address_widget
+      def label_widget
+        @label_widget ||= IPAddressLabel.new(@name, @settings, focus: focus_label?)
+      end
+
+      def ip_address_widget
+        @ip_address_widget ||= Y2Network::Widgets::IPAddress.new(@settings, focus: !focus_label?)
       end
 
       def netmask_widget
@@ -84,15 +82,17 @@ module Y2Network
 
     # Widget to modify the label of an additional IP address configuration
     class IPAddressLabel < CWM::InputField
-      def initialize(name, settings)
+      def initialize(name, settings, focus: false)
         textdomain "network"
 
         @name = name
         @settings = settings
+        @focus = focus
       end
 
       def init
         self.value = @settings.label
+        focus if @focus
         Yast::UI.ChangeWidget(Id(widget_id), :ValidChars, Yast::String.CAlnum)
       end
 

--- a/src/lib/y2network/dialogs/additional_address.rb
+++ b/src/lib/y2network/dialogs/additional_address.rb
@@ -1,0 +1,102 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "cwm/popup"
+require "y2network/widgets/ip_address"
+
+module Y2Network
+  module Dialogs
+    # Popup dialog to add or edit an additional IP address configuration to a
+    # connection config
+    class AdditionalAddress < CWM::Popup
+      # Constructor
+      #
+      # @param name [String]
+      # @param settings [Object]
+      def initialize(name, settings)
+        textdomain "network"
+
+        @name     = name
+        @settings = settings
+      end
+
+      def contents
+        VBox(
+          label_widget,
+          ip_address_widget,
+          netmask_widget
+        )
+      end
+
+      def buttons
+        [ok_button, cancel_button]
+      end
+
+      def label_widget
+        @label_widget ||= IPAddressLabel.new(@name, @settings)
+      end
+
+      def ip_address_widget
+        @ip_address_widget ||= IPAddress.new(@settings)
+      end
+
+      def netmask_widget
+        @netmask_widget ||= Y2Network::Widgets::Netmask.new(@settings)
+      end
+    end
+
+    class IPAddress < Y2Network::Widgets::IPAddress
+      def init
+        super
+        focus unless @settings.label.to_s.empty?
+      end
+    end
+
+    # Widget to modify the label of an additional IP address configuration
+    class IPAddressLabel < CWM::InputField
+      def initialize(name, settings)
+        textdomain "network"
+
+        @name = name
+        @settings = settings
+      end
+
+      def init
+        self.value = @settings.label
+        focus if @settings.label.to_s.empty?
+      end
+
+      def label
+        _("&Address Label")
+      end
+
+      def store
+        @settings.label = value
+      end
+
+      def validate
+        return true unless "#{@name}.#{value}" !~ /^[[:alnum:]._:-]{1,15}\z/
+
+        Yast::Popup.Error(_("Label is too long."))
+        focus
+        false
+      end
+    end
+  end
+end

--- a/src/lib/y2network/dialogs/additional_address.rb
+++ b/src/lib/y2network/dialogs/additional_address.rb
@@ -18,7 +18,9 @@
 # find current contact information at www.suse.com.
 
 require "cwm/popup"
+require "y2network/ip_address"
 require "y2network/widgets/ip_address"
+require "y2network/widgets/netmask"
 
 module Y2Network
   module Dialogs
@@ -56,6 +58,8 @@ module Y2Network
 
         ret
       end
+
+    private
 
       def buttons
         [ok_button, cancel_button]

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -262,27 +262,31 @@ module Y2Network
     end
 
     # gets aliases for interface
-    # @return [Array<Hash>] hash values are `:label` for alias label,
-    #   `:ip` for ip address, `:mask` for netmask and `:prefixlen` for prefix.
-    #   Only one of `:mask` and `:prefixlen` is set.
+    # @return [Array<Hash>] array of the connection additional IP address in
+    #   hash format see #alias_for for the hash values
     def aliases
       return @aliases if @aliases
 
-      aliases = @connection_config.ip_aliases.map do |data|
-        {
-          label:     data.label.to_s,
-          ip:        data.address.address.to_s,
-          prefixlen: data.address.prefix.to_s,
-          id:        data.id.to_s
-          # NOTE: new API does not have netmask at all, we need to adapt UI to clearly mention
-          #       only prefix
-        }
-      end
-      @aliases = aliases
+      @aliases = @connection_config.ip_aliases.map { |d| alias_for(d) }
+    end
+
+    # Convenience method to obtain a new hash from the IP additional address
+    # data
+    #
+    # @param data [IPConfig, nil] Additional IP address configuration
+    # @return [Hash<String>] hash values are `:label` for alias label,
+    #   `:ip_address` for ip address, `:mask` for netmask and `:subnet_prefix` for prefix.
+    def alias_for(data)
+      {
+        label:         data&.label.to_s,
+        ip_address:    data&.address&.address.to_s,
+        subnet_prefix: data&.address&.prefix.to_s,
+        id:            data&.id.to_s
+      }
     end
 
     # sets aliases for interface
-    # @param value [Array<Hash>] see #aliases for hash values
+    # @param value [Array<Hash>] see #alias_for for hash values
     def aliases=(value)
       @aliases = value
     end
@@ -469,8 +473,8 @@ module Y2Network
         .select { |a| a[:id] && a[:id] =~ /\A_\d+\z/ }
         .map { |a| a[:id].sub("_", "").to_i }
       aliases.each_with_object([]) do |map, result|
-        ipaddr = IPAddress.from_string(map[:ip])
-        ipaddr.prefix = map[:prefixlen].delete("/").to_i if map[:prefixlen]
+        ipaddr = IPAddress.from_string(map[:ip_address])
+        ipaddr.prefix = map[:prefixlen].delete("/").to_i if map[:subnet_prefix]
         id = map[:id]
         if id.nil? || id.empty?
           last_id = id = find_free_alias_id(used_ids, last_id) if id.nil? || id.empty?

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -280,7 +280,7 @@ module Y2Network
       {
         label:         data&.label.to_s,
         ip_address:    data&.address&.address.to_s,
-        subnet_prefix: data&.address&.prefix.to_s,
+        subnet_prefix: (data&.address&.prefix) ? "/#{data.address.prefix}" : "",
         id:            data&.id.to_s
       }
     end
@@ -474,7 +474,7 @@ module Y2Network
         .map { |a| a[:id].sub("_", "").to_i }
       aliases.each_with_object([]) do |map, result|
         ipaddr = IPAddress.from_string(map[:ip_address])
-        ipaddr.prefix = map[:prefixlen].delete("/").to_i if map[:subnet_prefix]
+        ipaddr.prefix = map[:subnet_prefix].delete("/").to_i if map[:subnet_prefix]
         id = map[:id]
         if id.nil? || id.empty?
           last_id = id = find_free_alias_id(used_ids, last_id) if id.nil? || id.empty?

--- a/src/lib/y2network/widgets/additional_addresses.rb
+++ b/src/lib/y2network/widgets/additional_addresses.rb
@@ -244,11 +244,10 @@ module Y2Network
           end
 
           res[:prefixlen] = if prefixlen.empty?
-            IPAddr.new("#{netmask}/#{netmask}")
+            IPAddr.new("#{netmask}/#{netmask}").prefix
           else
             prefixlen
           end
-          res[:prefixlen] = prefixlen
           res[:id] = id
 
           break

--- a/src/lib/y2network/widgets/additional_addresses.rb
+++ b/src/lib/y2network/widgets/additional_addresses.rb
@@ -20,6 +20,8 @@
 require "yast"
 require "cwm/custom_widget"
 require "ipaddr"
+require "ostruct"
+require "y2network/dialogs/additional_address"
 
 Yast.import "IP"
 Yast.import "Popup"
@@ -105,8 +107,7 @@ module Y2Network
 
       def refresh_table
         table_items = @settings.aliases.each_with_index.map do |data, i|
-
-          Item(Id(i), data[:label], data[:ip], "/#{data[:prefixlen]}")
+          Item(Id(i), data[:label], data[:ip_address], data[:subnet_prefix])
         end
 
         Yast::UI.ChangeWidget(Id(:address_table), :Items, table_items)
@@ -129,16 +130,16 @@ module Y2Network
         cur = Yast::UI.QueryWidget(Id(:address_table), :CurrentItem).to_i
         case event["ID"]
         when :edit_address
-          item = dialog(@settings.name, @settings.aliases[cur])
-          if item
-            @settings.aliases[cur] = item
+          settings_struct = settings_struct_for(cur)
+          if Dialogs::AdditionalAddress.new(@settings.name, settings_struct).run == :ok
+            @settings.aliases[cur] = settings_struct.to_h
             refresh_table
             Yast::UI.ChangeWidget(Id(:address_table), :CurrentItem, cur)
           end
         when :add_address
-          item = dialog(@settings.name, nil)
-          if item
-            @settings.aliases << item
+          settings_struct = settings_struct_for(nil)
+          if Dialogs::AdditionalAddress.new(@settings.name, settings_struct).run == :ok
+            @settings.aliases << settings_struct.to_h
             refresh_table
             Yast::UI.ChangeWidget(
               Id(:address_table),
@@ -154,123 +155,16 @@ module Y2Network
         nil
       end
 
-      # Open a dialog to edit a name-ipaddr-netmask triple.
-      # TODO: own class for it
-      # @param name  [String]     device name. Used to ensure label is not too long
-      # @param entry [Yast::Term] an existing entry to be edited, or term(:empty)
-      # @return      [Yast::Term] a table item for OK, nil for Cancel
-      def dialog(name, entry)
-        label = entry ? entry[:label] : ""
-        ip = entry ? entry[:ip] : ""
-        id = entry ? entry[:id] : ""
-        mask = entry ? "/#{entry[:prefixlen]}" : ""
+    private
 
-        Yast::UI.OpenDialog(
-          Opt(:decorated),
-          VBox(
-            HSpacing(1),
-            VBox(
-              # TextEntry label
-              TextEntry(Id(:name), _("&Address Label"), label),
-              # TextEntry label
-              TextEntry(
-                Id(:ipaddr),
-                _("&IP Address"),
-                ip
-              ),
-              # TextEntry label
-              TextEntry(Id(:netmask), _("Net&mask"), mask)
-            ),
-            HSpacing(1),
-            HBox(
-              PushButton(Id(:ok), Opt(:default), Yast::Label.OKButton),
-              PushButton(Id(:cancel), Yast::Label.CancelButton)
-            )
-          )
-        )
-
-        Yast::UI.ChangeWidget(
-          Id(:name),
-          :ValidChars,
-          Yast::String.CAlnum
-        )
-        Yast::UI.ChangeWidget(Id(:ipaddr), :ValidChars, Yast::IP.ValidChars)
-
-        if entry
-          Yast::UI.SetFocus(Id(:ipaddr))
-        else
-          Yast::UI.SetFocus(Id(:name))
-        end
-
-        while (ret = Yast::UI.UserInput) == :ok
-
-          res = {}
-          val = Yast::UI.QueryWidget(Id(:name), :Value)
-
-          if "#{name}.#{val}" !~ /^[[:alnum:]._:-]{1,15}\z/
-            # Popup::Error text
-            Yast::Popup.Error(_("Label is too long."))
-            Yast::UI.SetFocus(Id(:name))
-            next
-          end
-
-          res[:label] = val
-
-          ip = Yast::UI.QueryWidget(Id(:ipaddr), :Value)
-          if !Yast::IP.Check(ip)
-            # Popup::Error text
-            Yast::Popup.Error(_("The IP address is invalid."))
-            Yast::UI.SetFocus(Id(:ipaddr))
-            next
-          end
-          res[:ip] = ip
-
-          val = Yast::UI.QueryWidget(Id(:netmask), :Value)
-          if !valid_prefix_or_netmask(ip, val)
-            # Popup::Error text
-            Yast::Popup.Error(_("The subnet mask is invalid."))
-            Yast::UI.SetFocus(Id(:netmask))
-            next
-          end
-
-          netmask = ""
-          prefixlen = ""
-          if val.start_with?("/")
-            prefixlen = val[1..-1]
-          elsif Yast::Netmask.Check6(val)
-            prefixlen = val
-          else
-            netmask = val
-          end
-
-          res[:prefixlen] = if prefixlen.empty?
-            IPAddr.new("#{netmask}/#{netmask}").prefix
-          else
-            prefixlen
-          end
-          res[:id] = id
-
-          break
-        end
-
-        Yast::UI.CloseDialog
-        return nil if ret != :ok
-
-        res
-      end
-
-      def valid_prefix_or_netmask(ip, mask)
-        valid_mask = false
-        mask = mask[1..-1] if mask.start_with?("/")
-
-        if Yast::IP.Check4(ip) && (Yast::Netmask.Check4(mask) || Yast::Netmask.CheckPrefix4(mask))
-          valid_mask = true
-        elsif Yast::IP.Check6(ip) && Yast::Netmask.Check6(mask)
-          valid_mask = true
-        else
-          log.warn "IP address #{ip} and mask #{mask} is not valid"
-        end
-        valid_mask
+      # Convenience method to obtain an object with the additionl IP address
+      # data.
+      #
+      # @param index [Integer, nil] the position of the alias to be edited or
+      #   nil in case a new one is wanted
+      # @return [OpenStruct] additional IP address data
+      def settings_struct_for(index)
+        OpenStruct.new(index ? @settings.aliases[index] : @settings.alias_for(nil))
       end
     end
   end

--- a/src/lib/y2network/widgets/additional_addresses.rb
+++ b/src/lib/y2network/widgets/additional_addresses.rb
@@ -130,16 +130,16 @@ module Y2Network
         cur = Yast::UI.QueryWidget(Id(:address_table), :CurrentItem).to_i
         case event["ID"]
         when :edit_address
-          settings_struct = settings_struct_for(cur)
-          if Dialogs::AdditionalAddress.new(@settings.name, settings_struct).run == :ok
-            @settings.aliases[cur] = settings_struct.to_h
+          ip_settings = settings_for(cur)
+          if Dialogs::AdditionalAddress.new(@settings.name, ip_settings).run == :ok
+            @settings.aliases[cur] = ip_settings.to_h
             refresh_table
             Yast::UI.ChangeWidget(Id(:address_table), :CurrentItem, cur)
           end
         when :add_address
-          settings_struct = settings_struct_for(nil)
-          if Dialogs::AdditionalAddress.new(@settings.name, settings_struct).run == :ok
-            @settings.aliases << settings_struct.to_h
+          ip_settings = settings_for(nil)
+          if Dialogs::AdditionalAddress.new(@settings.name, ip_settings).run == :ok
+            @settings.aliases << ip_settings.to_h
             refresh_table
             Yast::UI.ChangeWidget(
               Id(:address_table),
@@ -163,7 +163,7 @@ module Y2Network
       # @param index [Integer, nil] the position of the alias to be edited or
       #   nil in case a new one is wanted
       # @return [OpenStruct] additional IP address data
-      def settings_struct_for(index)
+      def settings_for(index)
         OpenStruct.new(index ? @settings.aliases[index] : @settings.alias_for(nil))
       end
     end

--- a/src/lib/y2network/widgets/ip_address.rb
+++ b/src/lib/y2network/widgets/ip_address.rb
@@ -25,11 +25,18 @@ Yast.import "Popup"
 
 module Y2Network
   module Widgets
+    # Input field that permits to modify an objet IP address
     class IPAddress < CWM::InputField
-      def initialize(settings)
+      # Constructor
+      #
+      # @param settings [Object] Object with an :ip_address accessor
+      # @param focus [Boolean] whether the widget should get the focus when
+      #   init; by default will not get it
+      def initialize(settings, focus: false)
         textdomain "network"
 
         @settings = settings
+        @focus = focus
       end
 
       def label
@@ -47,6 +54,7 @@ module Y2Network
 
       def init
         self.value = @settings.ip_address
+        focus if @focus
       end
 
       def store

--- a/test/y2network/dialogs/additional_address_test.rb
+++ b/test/y2network/dialogs/additional_address_test.rb
@@ -73,13 +73,32 @@ describe Y2Network::Dialogs::IPAddressLabel do
   end
 
   let(:ip_settings) { OpenStruct.new(builder.aliases[0]) }
+  let(:focus) { false }
 
-  subject { described_class.new(builder.name, ip_settings) }
+  subject { described_class.new(builder.name, ip_settings, focus: focus) }
 
   include_examples "CWM::InputField"
 
   before do
     allow(subject).to receive(:value).and_return(label)
+  end
+
+  describe "#init" do
+    it "sets the input value with the IP settings label" do
+      expect(subject).to receive(:value=).with("bar")
+
+      subject.init
+    end
+
+    context "when it is initialized with the focus option as true" do
+      let(:focus) { true }
+
+      it "gets the focus" do
+        expect(subject).to receive(:focus)
+
+        subject.init
+      end
+    end
   end
 
   describe "#validate" do

--- a/test/y2network/dialogs/additional_address_test.rb
+++ b/test/y2network/dialogs/additional_address_test.rb
@@ -1,0 +1,101 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "cwm/rspec"
+
+require "y2network/dialogs/additional_address"
+
+describe Y2Network::Dialogs::AdditionalAddress do
+  let(:builder) do
+    Y2Network::InterfaceConfigBuilder.for("eth").tap do |eth_builder|
+      eth_builder.name = "eth0"
+    end
+  end
+
+  let(:ip_settings) { OpenStruct.new(builder.alias_for(nil)) }
+
+  subject { described_class.new(builder.name, ip_settings) }
+
+  include_examples "CWM::Dialog"
+
+  describe "#run" do
+    let(:ret_code) { :cancel }
+
+    before do
+      allow(subject).to receive(:cwm_show).and_return(ret_code)
+    end
+
+    context "when the modifications are applied" do
+      let(:ret_code) { :ok }
+
+      context "and the modified IP address settings uses a netmask" do
+        it "converts the netmask to its equivalent prefix length" do
+          ip_settings.subnet_prefix = "255.255.255.0"
+          expect { subject.run }
+            .to change { ip_settings.subnet_prefix }.from("255.255.255.0").to("/24")
+        end
+      end
+    end
+  end
+end
+
+describe Y2Network::Dialogs::IPAddressLabel do
+  let(:label) { "foo" }
+  let(:builder) do
+    Y2Network::InterfaceConfigBuilder.for("eth").tap do |eth_builder|
+      eth_builder.name = "eth0"
+      eth_builder.aliases = [eth_builder.alias_for(ip_alias)]
+    end
+  end
+
+  let(:ip_alias) do
+    Y2Network::ConnectionConfig::IPConfig.new(
+      Y2Network::IPAddress.from_string("192.168.20.200/24"),
+      id: "_0", label: "bar"
+    )
+  end
+
+  let(:ip_settings) { OpenStruct.new(builder.aliases[0]) }
+
+  subject { described_class.new(builder.name, ip_settings) }
+
+  include_examples "CWM::InputField"
+
+  before do
+    allow(subject).to receive(:value).and_return(label)
+  end
+
+  describe "#validate" do
+    context "when the join of the name and the value with ':' is longer than 15" do
+      let(:label) { "tooolonglabel" }
+
+      it "returns false" do
+        expect(subject.validate).to eql(false)
+      end
+    end
+
+    context "when the label is valid" do
+      it "modifies the ip_settings label" do
+        expect { subject.store }
+          .to change { ip_settings.label }.from("bar").to("foo")
+      end
+    end
+  end
+end

--- a/test/y2network/interface_config_builder_test.rb
+++ b/test/y2network/interface_config_builder_test.rb
@@ -146,10 +146,10 @@ describe Y2Network::InterfaceConfigBuilder do
     context "when aliases are defined" do
       before do
         subject.aliases = [
-          { id: "_1", ip: "192.168.122.100", prefixlen: "/24", label: "alias1" },
-          { id: "suffix1", ip: "192.168.123.100", prefixlen: "/24", label: "alias2" },
-          { ip: "10.0.0.2", label: "alias3" },
-          { id: "", ip: "10.0.0.3", label: "alias4" }
+          { id: "_1", ip_address: "192.168.122.100", subnet_prefix: "/24", label: "alias1" },
+          { id: "suffix1", ip_address: "192.168.123.100", subnet_prefix: "/24", label: "alias2" },
+          { ip_address: "10.0.0.2", label: "alias3" },
+          { id: "", ip_address: "10.0.0.3", label: "alias4" }
         ]
       end
 
@@ -247,6 +247,28 @@ describe Y2Network::InterfaceConfigBuilder do
       expect(subject.connection_config).to receive(:hostname=).with("foo").and_call_original
       expect { subject.hostname = "foo" }.to change { subject.hostname }
         .from("").to("foo")
+    end
+  end
+
+  describe "#alias_for" do
+    let(:ip_settings) do
+      Y2Network::ConnectionConfig::IPConfig.new(
+        Y2Network::IPAddress.from_string("192.168.122.100/24"), id: "_1", label: "alias1"
+      )
+    end
+
+    it "obtains a new hash from the given additional IP address config" do
+      expect(subject.alias_for(ip_settings)).to eq(
+        id: "_1", ip_address: "192.168.122.100", subnet_prefix: "/24", label: "alias1"
+      )
+    end
+
+    context "when no IP config is given" do
+      it "generates a new hash with empty values" do
+        expect(subject.alias_for(nil)).to eq(
+          id: "", ip_address: "", subnet_prefix: "", label: ""
+        )
+      end
     end
   end
 end

--- a/test/y2network/widgets/additional_addresses_test.rb
+++ b/test/y2network/widgets/additional_addresses_test.rb
@@ -29,20 +29,22 @@ describe Y2Network::Widgets::AdditionalAddresses do
   include_examples "CWM::CustomWidget"
 
   describe "#handle" do
+    let(:dialog) { Y2Network::Dialogs::AdditionalAddress }
+
     it "opens address dialog for edit address button" do
-      expect(Yast::UI).to receive(:UserInput).and_return(:cancel)
+      expect_any_instance_of(dialog).to receive(:run).and_return(:cancel)
 
       subject.handle("EventReason" => "Activated", "ID" => :edit_address)
     end
 
     it "opens address dialog for add address button" do
-      expect(Yast::UI).to receive(:UserInput).and_return(:cancel)
+      expect_any_instance_of(dialog).to receive(:run).and_return(:cancel)
 
       subject.handle("EventReason" => "Activated", "ID" => :add_address)
     end
 
     it "do validations in address dialog" do
-      expect(Yast::UI).to receive(:UserInput).and_return(:ok)
+      expect_any_instance_of(dialog).to receive(:run).and_return(:ok)
       allow(Yast::UI).to receive(:QueryWidget)
       allow(Yast::UI).to receive(:QueryWidget).with(Id(:name), :Value).and_return("test")
       allow(Yast::UI).to receive(:QueryWidget).with(Id(:ipaddr), :Value).and_return("10.0.0.1")

--- a/test/y2network/widgets/ip_address_test.rb
+++ b/test/y2network/widgets/ip_address_test.rb
@@ -23,7 +23,26 @@ require "y2network/widgets/ip_address"
 require "cwm/rspec"
 
 describe Y2Network::Widgets::IPAddress do
-  subject { described_class.new({}) }
+  let(:ip_settings) { OpenStruct.new(ip_address: "192.168.122.20") }
+  subject { described_class.new(ip_settings) }
 
   include_examples "CWM::InputField"
+
+  describe "#init" do
+    it "sets the input value with the IP settings address" do
+      expect(subject).to receive(:value=).with("192.168.122.20")
+
+      subject.init
+    end
+
+    context "when it is initialized with the focus option as true" do
+      subject { described_class.new(ip_settings, focus: true) }
+
+      it "gets the focus" do
+        expect(subject).to receive(:focus)
+
+        subject.init
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

When an IP alias is edited or added to a connection config and the Netmask uses dot-decimal notation, it is converted to the slash notation without the prefix length.

- https://bugzilla.suse.com/show_bug.cgi?id=1174766

## Solution

The bug was fixed for SLE-15-SP2 / Leap 15.2 in #1132 . So, this PR will merge that one but it also moves the dialog to its own class apart becoming its behavior easier to test.