### PR TITLE
Improve additional addresses prefix length validation

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec 23 09:21:16 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Improve additional addresses validation (bsc#1174766)
+- 4.3.37
+
+-------------------------------------------------------------------
 Mon Dec 21 13:56:55 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - When the static hostname is modified, propose the hostname to be

--- a/src/lib/y2network/dialogs/additional_address.rb
+++ b/src/lib/y2network/dialogs/additional_address.rb
@@ -53,7 +53,7 @@ module Y2Network
           ret = super
           break if ret != :ok
 
-          @settings.subnet_prefix = subnet_prefix_for?(@settings.subnet_prefix)
+          @settings.subnet_prefix = subnet_prefix_for(@settings.subnet_prefix)
 
           begin
             IPAddr.new("#{@settings.ip_address}#{@settings.subnet_prefix}")
@@ -70,7 +70,7 @@ module Y2Network
 
     private
 
-      def subnet_prefix_for?(value)
+      def subnet_prefix_for(value)
         return value if value.start_with?("/")
 
         prefix =

--- a/src/lib/y2network/dialogs/additional_address.rb
+++ b/src/lib/y2network/dialogs/additional_address.rb
@@ -47,17 +47,41 @@ module Y2Network
       end
 
       def run
-        ret = super
-        return ret if ret != :ok || @settings.subnet_prefix.start_with?("/")
+        ret = nil
 
-        netmask = @settings.subnet_prefix
-        prefix = IPAddr.new("#{netmask}/#{netmask}").prefix
-        @settings.subnet_prefix = "/#{prefix}"
+        loop do
+          ret = super
+          break if ret != :ok
+
+          @settings.subnet_prefix = subnet_prefix_for?(@settings.subnet_prefix)
+
+          begin
+            IPAddr.new("#{@settings.ip_address}#{@settings.subnet_prefix}")
+            break
+          rescue IPAddr::InvalidAddressError
+            Yast::Report.Error(
+              format(_("Invalid Address %s%s"), @settings.ip_address, @settings.subnet_prefix)
+            )
+          end
+        end
 
         ret
       end
 
     private
+
+      def subnet_prefix_for?(value)
+        return value if value.start_with?("/")
+
+        prefix =
+          if value.size < 3 || value =~ /^\d{3}$/
+            value.to_i
+          else
+            IPAddr.new("#{value}/#{value}").prefix
+          end
+
+        "/#{prefix}"
+      end
 
       def buttons
         [ok_button, cancel_button]


### PR DESCRIPTION
## Problem

When the additional IP address is modified using a prefix length without the "/", it is treated as a netmask and an exception is raised.

- https://bugzilla.suse.com/show_bug.cgi?id=1174766#c15

## Solution

Better handling of the additional IP address subnet_prefix when it is given as a prefix length.