### PR TITLE
Permit to disable the virt bridge config proposal

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb 10 10:30:53 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Allow to disable the proposal of the bridge network configuration
+  for virtualization in the installation summary or by the new
+  'virt_bridge_proposal' AutoYaST option (bsc#1178603)
+- 4.3.46
+
+-------------------------------------------------------------------
 Tue Feb  9 08:18:26 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix for not present interfaces when deciding whether

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.45
+Version:        4.3.46
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -12,6 +12,7 @@ networking =
       element setup_before_proposal { BOOLEAN }? &
       element start_immediately { BOOLEAN }? &
       element keep_install_network { BOOLEAN }? &
+      element virt_bridge_proposal { BOOLEAN }? &
       ipv6? &
       managed? &
       strict_IP_check_timeout? &

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -290,7 +290,7 @@ module Yast
       # that a bridge configuration is present in the profile it should be
       # skipped or even only done in case of missing `networking -> interfaces`
       # section
-      NetworkAutoconfiguration.instance.configure_virtuals
+      NetworkAutoconfiguration.instance.configure_virtuals if propose_virt_config?
 
       if !Mode.autoinst
         NetworkAutoconfiguration.instance.configure_dns
@@ -315,6 +315,12 @@ module Yast
         Yast::Lan.yast_config.backend = :network_manager
         Yast::Lan.write_config
       end
+    end
+
+    # Convenience method to check whether a bridge network configuration for
+    # virtualization should be proposed or not
+    def propose_virt_config?
+      Y2Network::ProposalSettings.instance.propose_bridge?
     end
 
     # It does an automatic configuration of installed system

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -320,7 +320,7 @@ module Yast
     # Convenience method to check whether a bridge network configuration for
     # virtualization should be proposed or not
     def propose_virt_config?
-      Y2Network::ProposalSettings.instance.propose_bridge?
+      Y2Network::ProposalSettings.instance.virt_bridge_proposal
     end
 
     # It does an automatic configuration of installed system

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -97,6 +97,21 @@ module Yast
       Lan.read_config
     end
 
+    # Decides if a proposal for virtualization host machine is required.
+    #
+    # @return [Boolean] whether the bridge network configuration for
+    #   virtualization should be proposed or not
+    def virtual_proposal_required?
+      # S390 has special requirements. See bnc#817943
+      return false if Arch.s390
+
+      return true if PackageSystem.Installed("xen") && !Arch.is_xenU
+      return true if PackageSystem.Installed("kvm")
+      return true if PackageSystem.Installed("qemu")
+
+      false
+    end
+
     # Propose configuration for virtual devices
     #
     # It checks if any of supported virtual machines were installed. If found,
@@ -217,18 +232,6 @@ module Yast
     # @param [String] value "yes" or "no", as in sysconfig
     def set_default_route_flag(devname, value)
       # TODO: not implemented
-    end
-
-    # Decides if a proposal for virtualization host machine is required.
-    def virtual_proposal_required?
-      # S390 has special requirements. See bnc#817943
-      return false if Arch.s390
-
-      return true if PackageSystem.Installed("xen") && !Arch.is_xenU
-      return true if PackageSystem.Installed("kvm")
-      return true if PackageSystem.Installed("qemu")
-
-      false
     end
 
     def config

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -105,7 +105,7 @@ module Yast
       # S390 has special requirements. See bnc#817943
       return false if Arch.s390
 
-      return true if PackageSystem.Installed("xen") && !Arch.is_xenU
+      return true if PackageSystem.Installed("xen") && Arch.is_xen0
       return true if PackageSystem.Installed("kvm")
       return true if PackageSystem.Installed("qemu")
 

--- a/src/lib/y2network/autoinst/config.rb
+++ b/src/lib/y2network/autoinst/config.rb
@@ -33,6 +33,9 @@ module Y2Network
       attr_accessor :keep_install_network
       # @return [Integer]
       attr_accessor :ip_check_timeout
+      # @return [Boolean] controls whether a bridge configuration for
+      #   virtualization network should be proposed or not
+      attr_accessor :virt_bridge_proposal
 
       # Constructor
       #
@@ -41,11 +44,13 @@ module Y2Network
       # @option opts [Boolean] :start_immediately
       # @option opts [Boolean] :keep_install_network
       # @option opts [Integer] :ip_check_timetout
+      # @option opts [Boolean] :virt_bridge_proposal
       def initialize(opts = {})
         @before_proposal = opts.fetch(:before_proposal, false)
         @start_immediately = opts.fetch(:start_immediately, false)
         @keep_install_network = opts.fetch(:keep_install_network, true)
         @ip_check_timeout = opts.fetch(:ip_check_timeout, -1)
+        @virt_bridge_proposal = opts.fetch(:virt_bridge_proposal, true)
       end
 
       # Return whether the network should be copied at the end

--- a/src/lib/y2network/autoinst_profile/networking_section.rb
+++ b/src/lib/y2network/autoinst_profile/networking_section.rb
@@ -42,6 +42,8 @@ module Y2Network
       attr_accessor :start_immediately
       # @return [Boolean]
       attr_accessor :keep_install_network
+      # @return [Boolean]
+      attr_accessor :virt_bridge_proposal
       # @return [Integer]
       attr_accessor :strict_ip_check_timeout
 
@@ -69,6 +71,7 @@ module Y2Network
         result.setup_before_proposal = hash.fetch("setup_before_proposal", false)
         result.start_immediately = hash.fetch("start_immediately", false)
         result.keep_install_network = hash.fetch("keep_install_network", true)
+        result.virt_bridge_proposal = hash.fetch("virt_bridge_proposal", true)
         result.strict_ip_check_timeout = hash.fetch("strict_ip_check_timeout", -1)
         result.routing = RoutingSection.new_from_hashes(hash["routing"], result) if hash["routing"]
         result.dns = DNSSection.new_from_hashes(hash["dns"], result) if hash["dns"]

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -20,6 +20,7 @@
 
 require "yast"
 require "y2packager/package"
+require "network/network_autoconfiguration"
 
 module Y2Network
   # Class that stores the proposal settings for network during installation.
@@ -29,6 +30,7 @@ module Y2Network
 
     # @return [Boolean] network service to be used after the installation
     attr_accessor :selected_backend
+    attr_accessor :virt_bridge_proposal
 
     # Constructor
     def initialize
@@ -38,6 +40,7 @@ module Y2Network
       Yast.import "PackagesProposal"
 
       @selected_backend = nil
+      @virt_bridge_proposal = true
     end
 
     def current_backend
@@ -48,6 +51,14 @@ module Y2Network
       default = use_network_manager? ? :network_manager : :wicked
       log.info "The default backend is: #{default}"
       default
+    end
+
+    def propose_bridge?
+      virtual_proposal_required? && virt_bridge_proposal
+    end
+
+    def propose_bridge!(option)
+      @virt_bridge_proposal = option
     end
 
     # Adds the NetworkManager package to the Yast::PackagesProposal and sets
@@ -92,6 +103,11 @@ module Y2Network
       end
       log.info("The NetworkManager package status: #{p.status}")
       true
+    end
+
+    # Decides if a proposal for virtualization host machine is required.
+    def virtual_proposal_required?
+      Yast::NetworkAutoconfiguration.instance.virtual_proposal_required?
     end
 
     # Propose the network service to be use at the end of the installation

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -112,7 +112,7 @@ module Y2Network
     def virtual_proposal_required?
       return false if Yast::Arch.s390
 
-      return true if package_selected?("xen") && !Yast::Arch.is_xenU
+      return true if package_selected?("xen") && Yast::Arch.is_xen0
       return true if package_selected?("kvm")
       return true if package_selected?("qemu")
 
@@ -149,10 +149,14 @@ module Y2Network
 
   private
 
+    # Convenience method to check whether the bridge configuration proposal for
+    # configuration was disabled in the AutoYaST profile.
     def autoinst_disabled_proposal?
       Yast::Lan.autoinst.virt_bridge_proposal == false
     end
 
+    # Convenience method to check whether a specific package is selected to be
+    # installed
     def package_selected?(name)
       Y2Packager::Resolvable.any?(kind: :package, name: name, status: :selected)
     end

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -824,7 +824,8 @@ module Yast
 
       !section.start_immediately.nil? ||
         !section.keep_install_network.nil? ||
-        !section.setup_before_proposal.nil?
+        !section.setup_before_proposal.nil? ||
+        !section.virt_bridge_proposal.nil?
     end
 
     def activate_network_service

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -814,7 +814,8 @@ module Yast
         before_proposal:      section.setup_before_proposal,
         start_immediately:    section.start_immediately,
         keep_install_network: section.keep_install_network,
-        ip_check_timeout:     section.strict_ip_check_timeout
+        ip_check_timeout:     section.strict_ip_check_timeout,
+        virt_bridge_proposal: section.virt_bridge_proposal
       )
     end
 

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -191,14 +191,14 @@ describe Yast::NetworkAutoconfiguration do
 
       context "and we are in a guest machine" do
         it "returns false" do
-          allow(Yast::Arch).to receive(:is_xen0).and_return(true)
+          allow(Yast::Arch).to receive(:is_xen0).and_return(false)
           expect(instance.virtual_proposal_required?).to eql(false)
         end
       end
 
       context "and we are in the host machine" do
         it "returns true" do
-          allow(Yast::Arch).to receive(:is_xen0).and_return(false)
+          allow(Yast::Arch).to receive(:is_xen0).and_return(true)
           expect(instance.virtual_proposal_required?).to eql(true)
         end
       end

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -191,14 +191,14 @@ describe Yast::NetworkAutoconfiguration do
 
       context "and we are in a guest machine" do
         it "returns false" do
-          allow(Yast::Arch).to receive(:is_xenU).and_return(true)
+          allow(Yast::Arch).to receive(:is_xen0).and_return(true)
           expect(instance.virtual_proposal_required?).to eql(false)
         end
       end
 
       context "and we are in the host machine" do
         it "returns true" do
-          allow(Yast::Arch).to receive(:is_xenU).and_return(false)
+          allow(Yast::Arch).to receive(:is_xen0).and_return(false)
           expect(instance.virtual_proposal_required?).to eql(true)
         end
       end

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -68,6 +68,7 @@ end
 describe Yast::NetworkAutoconfiguration do
   let(:yast_config) { Y2Network::Config.new(source: :wicked) }
   let(:system_config) { yast_config.copy }
+  let(:instance) { Yast::NetworkAutoconfiguration.instance }
 
   before do
     Y2Network::Config.add(:yast, yast_config)
@@ -77,7 +78,6 @@ describe Yast::NetworkAutoconfiguration do
   end
 
   describe "it sets DHCLIENT_SET_DEFAULT_ROUTE properly" do
-    let(:instance) { Yast::NetworkAutoconfiguration.instance }
     let(:network_interfaces) { double("NetworkInterfaces") }
 
     before(:each) do
@@ -143,8 +143,6 @@ describe Yast::NetworkAutoconfiguration do
   describe "#any_iface_active?" do
     IFACE = "eth0".freeze
 
-    let(:instance) { Yast::NetworkAutoconfiguration.instance }
-
     it "returns true if any of available interfaces has configuration and is up" do
       allow(Yast::Lan).to receive(:yast_config)
         .and_return(
@@ -159,6 +157,68 @@ describe Yast::NetworkAutoconfiguration do
         .and_return(0)
 
       expect(instance.any_iface_active?).to be true
+    end
+  end
+
+  describe "#virtual_proposal_required?" do
+    let(:is_s390) { false }
+    let(:installed) { [] }
+
+    before do
+      allow(Yast::Arch).to receive(:s390).and_return(is_s390)
+      allow(Yast::PackageSystem).to receive(:Installed).and_return(false)
+      installed.map do |package|
+        allow(Yast::PackageSystem).to receive(:Installed).with(package).and_return(true)
+      end
+    end
+
+    context "in s390 arch" do
+      let(:is_s390) { true }
+
+      it "returns false" do
+        expect(instance.virtual_proposal_required?).to eql(false)
+      end
+    end
+
+    context "when KVM, Xen or QEMU packages are not installed" do
+      it "returns false" do
+        expect(instance.virtual_proposal_required?).to eql(false)
+      end
+    end
+
+    context "when XEN is installed" do
+      let(:installed) { ["xen"] }
+
+      context "and we are in a guest machine" do
+        it "returns false" do
+          allow(Yast::Arch).to receive(:is_xenU).and_return(true)
+          expect(instance.virtual_proposal_required?).to eql(false)
+        end
+      end
+
+      context "and we are in the host machine" do
+        it "returns true" do
+          allow(Yast::Arch).to receive(:is_xenU).and_return(false)
+          expect(instance.virtual_proposal_required?).to eql(true)
+        end
+      end
+
+      context "when KVM is installed" do
+        let(:installed) { ["kvm"] }
+
+        it "returns true" do
+          expect(instance.virtual_proposal_required?).to eql(true)
+        end
+      end
+
+      context "when QEMU is installed" do
+        let(:installed) { ["qemu"] }
+
+        it "returns true" do
+          expect(instance.virtual_proposal_required?).to eql(true)
+        end
+      end
+
     end
   end
 
@@ -177,7 +237,6 @@ describe Yast::NetworkAutoconfiguration do
     let(:yast_config) do
       Y2Network::Config.new(interfaces: interfaces, routing: routing, source: :testing)
     end
-    let(:instance) { Yast::NetworkAutoconfiguration.instance }
     let(:proposal) { false }
     let(:eth0_profile) do
       {

--- a/test/network_proposal_test.rb
+++ b/test/network_proposal_test.rb
@@ -50,10 +50,12 @@ describe Yast::NetworkProposal do
     let(:current_backend) { :wicked }
     let(:nm_available) { true }
     let(:proposal) { subject.make_proposal({}) }
+    let(:virt_installed) { false }
 
     before do
       settings.selected_backend = current_backend
       allow(settings).to receive(:network_manager_available?).and_return(nm_available)
+      allow(settings).to receive(:virtual_proposal_required?).and_return(virt_installed)
     end
 
     it "returns a hash describing the proposal" do
@@ -83,6 +85,14 @@ describe Yast::NetworkProposal do
 
       it "does not include a link for switch to wicked" do
         expect(proposal["preformatted_proposal"]).to_not match(/.*href.*wicked.*/)
+      end
+
+      context "and Xen, KVM or QEMU will be installed" do
+        let(:virt_installed) { true }
+
+        it "includes a link to enable or disable the virt bridge network config proposal" do
+          expect(proposal["preformatted_proposal"]).to match(/.*href.*bridge.*/)
+        end
       end
     end
 

--- a/test/y2network/proposal_settings_test.rb
+++ b/test/y2network/proposal_settings_test.rb
@@ -353,14 +353,14 @@ describe Y2Network::ProposalSettings do
 
       context "and we are in a guest machine" do
         it "returns false" do
-          allow(Yast::Arch).to receive(:is_xen0).and_return(true)
+          allow(Yast::Arch).to receive(:is_xen0).and_return(false)
           expect(settings.virtual_proposal_required?).to eql(false)
         end
       end
 
       context "and we are in the host machine" do
         it "returns true" do
-          allow(Yast::Arch).to receive(:is_xen0).and_return(false)
+          allow(Yast::Arch).to receive(:is_xen0).and_return(true)
           expect(settings.virtual_proposal_required?).to eql(true)
         end
       end

--- a/test/y2network/proposal_settings_test.rb
+++ b/test/y2network/proposal_settings_test.rb
@@ -353,14 +353,14 @@ describe Y2Network::ProposalSettings do
 
       context "and we are in a guest machine" do
         it "returns false" do
-          allow(Yast::Arch).to receive(:is_xenU).and_return(true)
+          allow(Yast::Arch).to receive(:is_xen0).and_return(true)
           expect(settings.virtual_proposal_required?).to eql(false)
         end
       end
 
       context "and we are in the host machine" do
         it "returns true" do
-          allow(Yast::Arch).to receive(:is_xenU).and_return(false)
+          allow(Yast::Arch).to receive(:is_xen0).and_return(false)
           expect(settings.virtual_proposal_required?).to eql(true)
         end
       end

--- a/test/y2network/proposal_settings_test.rb
+++ b/test/y2network/proposal_settings_test.rb
@@ -320,4 +320,66 @@ describe Y2Network::ProposalSettings do
       end
     end
   end
+
+  describe "#virtual_proposal_required?" do
+    let(:settings) { described_class.instance }
+    let(:is_s390) { false }
+    let(:installed) { [] }
+
+    before do
+      allow(Yast::Arch).to receive(:s390).and_return(is_s390)
+      allow(settings).to receive(:package_selected?).and_return(false)
+      installed.map do |package|
+        allow(settings).to receive(:package_selected?).with(package).and_return(true)
+      end
+    end
+
+    context "in s390 arch" do
+      let(:is_s390) { true }
+
+      it "returns false" do
+        expect(settings.virtual_proposal_required?).to eql(false)
+      end
+    end
+
+    context "when KVM, Xen or QEMU packages are not installed" do
+      it "returns false" do
+        expect(settings.virtual_proposal_required?).to eql(false)
+      end
+    end
+
+    context "when XEN is installed" do
+      let(:installed) { ["xen"] }
+
+      context "and we are in a guest machine" do
+        it "returns false" do
+          allow(Yast::Arch).to receive(:is_xenU).and_return(true)
+          expect(settings.virtual_proposal_required?).to eql(false)
+        end
+      end
+
+      context "and we are in the host machine" do
+        it "returns true" do
+          allow(Yast::Arch).to receive(:is_xenU).and_return(false)
+          expect(settings.virtual_proposal_required?).to eql(true)
+        end
+      end
+
+      context "when KVM is installed" do
+        let(:installed) { ["kvm"] }
+
+        it "returns true" do
+          expect(settings.virtual_proposal_required?).to eql(true)
+        end
+      end
+
+      context "when QEMU is installed" do
+        let(:installed) { ["qemu"] }
+
+        it "returns true" do
+          expect(settings.virtual_proposal_required?).to eql(true)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

The network bridge configuration is the default configuration of SLE or openSUSE  when configured as a KVM or Xen hypervisor, and during an installation there is no way to disable the bridge configuration proposed by YaST.

This proposed configuration was in many cases transparent to the user and was somehow not noticed but since systemd MACAddressPolicy has changed and a bridge does not inherit the MAC address from its ports, it could be a problem to existent DHCP configurations based on mac addresses (see https://bugzilla.suse.com/show_bug.cgi?id=1136600)

- https://bugzilla.suse.com/show_bug.cgi?id=1178603

## Solution

- By now, we would like to permit the user to disable the current bridge config proposal (in a common installation or in AutoYaST). The link will not be shown in the installation summary unless some of the virtualization packages is selected to be installed.

Creating a link to modify the bridge MACAddress policy as suggested in the bug is out of the scope of this PBI (see also the link example here https://github.com/systemd/systemd/pull/12792/files)

## Screenshots

To be honest, I was not very creative, and use the same tests and links we have in the past which were remove by this commi (https://github.com/yast/yast-network/commit/4cc0a6e32be8bfe46314c9913a51c33712724d40)

![ProposeBride](https://user-images.githubusercontent.com/7056681/103080374-9b3cd700-45cd-11eb-9d88-27687a25c7fb.png)
![NotProposeBridge](https://user-images.githubusercontent.com/7056681/103080379-9d9f3100-45cd-11eb-9a73-a3d91fa60d0b.png)
