### PR TITLE
Fix read steps

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 11 13:28:26 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix network configuration progress bar steps (bsc#1180702)
+- 4.2.89
+
+-------------------------------------------------------------------
 Tue Dec 15 08:38:07 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix prefix length assignation when the alias netmask uses

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.88
+Version:        4.2.89
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -220,19 +220,15 @@ module Yast
 
     def read_step_labels
       steps = [
-        # Progress stage 1/7
+        # Progress stage 1/5
         _("Detect network devices"),
-        # Progress stage 2/7
+        # Progress stage 2/5
         _("Read driver information"),
-        # Progress stage 3/7 - multiple devices may be present, really plural
+        # Progress stage 3/5 - multiple devices may be present, really plural
         _("Read device configuration"),
-        # Progress stage 4/7
+        # Progress stage 4/5
         _("Read network configuration"),
-        # Progress stage 5/7
-        _("Read installation information"),
-        # Progress stage 6/7
-        _("Read routing configuration"),
-        # Progress stage 7/7
+        # Progress stage 5/5
         _("Detect current status")
       ]
 


### PR DESCRIPTION
## Problem

When we moved to network-ng some of the progress steps were moved to the 'read network configuration' one but the list was not updated accordingly.

- https://bugzilla.suse.com/show_bug.cgi?id=1180702

## Solution

Remove out of date progress steps.