### PR TITLE
Save network manager config

### DIFF
--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -105,13 +105,6 @@ module Yast
         { dir: ::File.join(ETC, "sysctl.d"), file: "70-yast.conf" }
       ]
 
-      # NetworkManager is usually the default in a live installation. Any
-      # configuration applied during the installation should be present in the
-      # target system.
-      if Y2Network::ProposalSettings.instance.network_service == :network_manager
-        copy_recipes << { dir: ::File.join(NETWORK_MANAGER, "system-connections"), file: "*" }
-      end
-
       # just copy files
       copy_recipes.each do |recipe|
         # can be shell pattern like ifcfg-*
@@ -298,10 +291,30 @@ module Yast
       # skipped or even only done in case of missing `networking -> interfaces`
       # section
       NetworkAutoconfiguration.instance.configure_virtuals
-      NetworkAutoconfiguration.instance.configure_dns unless Mode.autoinst
+
+      if !Mode.autoinst
+        NetworkAutoconfiguration.instance.configure_dns
+        configure_network_manager
+      end
 
       # this depends on DNS configuration
       configure_hosts
+    end
+
+    # Configures NetworkManager
+    #
+    # When running the live installation, it is just a matter of copying
+    # system-connections to the installed system. In a regular installation,
+    # write the settings in the Yast::Lan.yast_config object.
+    def configure_network_manager
+      return unless Y2Network::ProposalSettings.instance.network_service == :network_manager
+
+      if Yast::Mode.live_installation
+        copy_files_to_target(["*"], File.join(NETWORK_MANAGER, "system-connections"))
+      else
+        Yast::Lan.yast_config.backend = :network_manager
+        Yast::Lan.write_config
+      end
     end
 
     # It does an automatic configuration of installed system

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -309,7 +309,7 @@ module Yast
     def configure_network_manager
       return unless Y2Network::ProposalSettings.instance.network_service == :network_manager
 
-      if Yast::Mode.live_installation
+      if Yast::Lan.system_config.backend&.id == :network_manager
         copy_files_to_target(["*"], File.join(NETWORK_MANAGER, "system-connections"))
       else
         Yast::Lan.yast_config.backend = :network_manager

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -137,7 +137,7 @@ module Y2Network
     #
     # @see Y2Network::ConfigWriter
     def write(original: nil, target: nil, only: nil)
-      target ||= source
+      target = target || backend&.id || source
       Y2Network::ConfigWriter.for(target).write(self, original, only: only)
     end
 

--- a/test/save_network_test.rb
+++ b/test/save_network_test.rb
@@ -24,6 +24,7 @@ require "y2storage"
 
 require "yast"
 require "y2network/config"
+require "y2network/backends"
 require "network/clients/save_network"
 require "tmpdir"
 
@@ -35,7 +36,10 @@ describe Yast::SaveNetworkClient do
     let(:destdir_sysconfig) { File.join(destdir, "etc", "sysconfig", "network") }
     let(:scr_root) { File.join(DATA_PATH, "instsys") }
     let(:yast_config) { Y2Network::Config.new(source: :sysconfig) }
-    let(:system_config) { Y2Network::Config.new(source: :sysconfig) }
+    let(:system_config) do
+      Y2Network::Config.new(source: :sysconfig, backend: system_backend)
+    end
+    let(:system_backend) { Y2Network::Backends::Wicked.new }
     let(:s390) { false }
 
     before do
@@ -143,10 +147,8 @@ describe Yast::SaveNetworkClient do
         subject.main
       end
 
-      context "on live installation" do
-        before do
-          allow(Yast::Mode).to receive(:live_installation).and_return(true)
-        end
+      context "when running on network manager (e.g., live installation)" do
+        let(:system_backend) { Y2Network::Backends::NetworkManager.new }
 
         it "copies the NetworkManager configuration from the instsys" do
           expect(Yast::Lan).to_not receive(:write_config)

--- a/test/save_network_test.rb
+++ b/test/save_network_test.rb
@@ -131,6 +131,21 @@ describe Yast::SaveNetworkClient do
       end
     end
 
+    context "when the backend is network manager" do
+      before do
+        allow(Y2Network::ProposalSettings.instance).to receive(:network_service)
+          .and_return(:network_manager)
+        FileUtils.mkdir_p(File.join(destdir, "etc", "NetworkManager", "system-connections"))
+      end
+
+      it "copies the NetworkManager configuration from the instsys" do
+        subject.main
+        expect(File).to exist(
+          File.join(destdir, "etc", "NetworkManager", "system-connections", "wlan0.nmconnection")
+        )
+      end
+    end
+
     context "during update" do
       before do
         allow(Yast::Mode).to receive(:update).and_return(true)

--- a/test/save_network_test.rb
+++ b/test/save_network_test.rb
@@ -138,11 +138,23 @@ describe Yast::SaveNetworkClient do
         FileUtils.mkdir_p(File.join(destdir, "etc", "NetworkManager", "system-connections"))
       end
 
-      it "copies the NetworkManager configuration from the instsys" do
+      it "writes the configuration to the underlying system" do
+        expect(Yast::Lan).to receive(:write_config)
         subject.main
-        expect(File).to exist(
-          File.join(destdir, "etc", "NetworkManager", "system-connections", "wlan0.nmconnection")
-        )
+      end
+
+      context "on live installation" do
+        before do
+          allow(Yast::Mode).to receive(:live_installation).and_return(true)
+        end
+
+        it "copies the NetworkManager configuration from the instsys" do
+          expect(Yast::Lan).to_not receive(:write_config)
+          subject.main
+          expect(File).to exist(
+            File.join(destdir, "etc", "NetworkManager", "system-connections", "wlan0.nmconnection")
+          )
+        end
       end
     end
 


### PR DESCRIPTION
Write NetworkManager configuration at the end of the installation process.

* Live installer: just copy the files under `/etc/NetworkManager/system-connections` as it is already using NetworkManager.
* Normal installation: use the new support for NetworkManager to write the configuration.

Manually tested the regular and the live installer.

Trello: https://trello.com/c/EdjoT1NN/
