### PR TITLE
WIP: Fixed AY's interfaces reader

### DIFF
--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -87,7 +87,7 @@ module Y2Network
         config.name = name_from_section(interface_section)
         config.interface = config.name # in autoyast name and interface is same
         if config.bootproto == BootProtocol::STATIC
-          # we need at leas some ip for the static configuration
+          # we need at least some ip for the static configuration
           if !interface_section.ipaddr && !interfaces_section.aliases
             msg = "Configuration for #{config.name} is invalid #{interface_section.inspect}"
             raise ArgumentError, msg
@@ -129,22 +129,19 @@ module Y2Network
       end
 
       # Loads and intializates interface_section's ipaddr attribute
+      #
+      # @param section [Hash] hash of AY profile's interface section as obtained from parser
+      #
       # @return [ConnectionConfig::IPConfig] created ipaddr object
-      def load_ipaddr(interface_section)
-        if !interface_section.ipaddr.empty?
-          ipaddr = IPAddress.from_string(interface_section.ipaddr)
-        end
+      def load_ipaddr(section)
+        ipaddr = IPAddress.from_string(section.ipaddr) if !section.ipaddr.empty?
+
         # Assign first netmask, as prefixlen has precedence so it will overwrite it
-        ipaddr.netmask = interface_section.netmask if !interface_section.netmask.to_s.empty?
-        if !interface_section.prefixlen.to_s.empty?
-          ipaddr.prefix = interface_section.prefixlen.to_i
-        end
-        if !interface_section.broadcast.empty?
-          broadcast = IPAddress.new(interface_section.broadcast)
-        end
-        if !interface_section.remote_ipaddr.empty?
-          remote = IPAddress.new(interface_section.remote_ipaddr)
-        end
+        ipaddr.netmask = section.netmask if !section.netmask.to_s.empty?
+        ipaddr.prefix = section.prefixlen.to_i if !section.prefixlen.to_s.empty?
+
+        broadcast = IPAddress.new(section.broadcast) if !section.broadcast.empty?
+        remote = IPAddress.new(section.remote_ipaddr) if !section.remote_ipaddr.empty?
 
         ConnectionConfig::IPConfig.new(
           ipaddr, broadcast: broadcast, remote_address: remote
@@ -152,6 +149,9 @@ module Y2Network
       end
 
       # Loads and initializates an IP alias according to given hash with alias details
+      #
+      # @param alias_h [Hash] hash of AY profile's alias section as obtained from parser
+      #
       # @return [ConnectionConfig::IPConfig] alias details
       def load_alias(alias_h, id: nil)
         ipaddr = IPAddress.from_string(alias_h["IPADDR"])

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -97,8 +97,8 @@ module Y2Network
         end
 
         # handle aliases
-        interface_section.aliases.each_value do |alias_h|
-          config.ip_aliases << load_alias(alias_h)
+        interface_section.aliases.values.each_with_index do |alias_h, index|
+          config.ip_aliases << load_alias(alias_h, id: "_#{index}")
         end
 
         # startmode
@@ -153,13 +153,13 @@ module Y2Network
 
       # Loads and initializates an IP alias according to given hash with alias details
       # @return [ConnectionConfig::IPConfig] alias details
-      def load_alias(alias_h)
+      def load_alias(alias_h, id: nil)
         ipaddr = IPAddress.from_string(alias_h["IPADDR"])
         # Assign first netmask, as prefixlen has precedence so it will overwrite it
         ipaddr.netmask = alias_h["NETMASK"] if alias_h["NETMASK"]
         ipaddr.prefix = alias_h["PREFIXLEN"].delete("/").to_i if alias_h["PREFIXLEN"]
 
-        ConnectionConfig::IPConfig.new(ipaddr, label: alias_h["LABEL"])
+        ConnectionConfig::IPConfig.new(ipaddr, id: id, label: alias_h["LABEL"])
       end
 
       def load_wireless(config, interface_section)


### PR DESCRIPTION
[bnc#1178107](https://bugzilla.suse.com/show_bug.cgi?id=1178107)

## Problem

1) customer uses static configuration without "main" ip address but use aliases instead of that
2) bug in AY's interfaces reader

## Solution

ad 1) extended fix for [bnc#1175360](https://bugzilla.suse.com/show_bug.cgi?id=1175360). This fix introduced support for static configurations withou ip address defined in the profile. However, this fix ignored aliases. This was fixed
ad 2) There was an error in interfaces reader when aliases from profile where read in the interfaces reader but due to bad indexing (to be more precise: lack of a suffix definition) it was storing all ip addresses (aliases and "the main one") in one place. This lead to situation when only last address was stored for the further processing / writing

## TBD

[ ] tests especially for (2)