### PR TITLE
Installation path and routes

### DIFF
--- a/src/lib/cfa/nm_connection.rb
+++ b/src/lib/cfa/nm_connection.rb
@@ -32,18 +32,14 @@ module CFA
       "bridge", "connection", "ethernet", "ipv4", "ipv6", "vlan", "wifi", "wifi_security"
     ].freeze
 
-    # @return [String] file path
-    attr_reader :path
-
     # Constructor
     #
     # @param path [String] File path
     # @param file_handler [.read, .write] Object to read/write the file.
     def initialize(path, file_handler: nil)
-      @path = path
       # FIXME: The Networkmanager lense writes the values surrounded by double
       # quotes which is not valid
-      super(AugeasParser.new("Puppet.lns"), @path, file_handler: file_handler)
+      super(AugeasParser.new("Puppet.lns"), path, file_handler: file_handler)
     end
 
     # Returns the augeas tree for the given section

--- a/src/lib/y2network/network_manager/config_writer.rb
+++ b/src/lib/y2network/network_manager/config_writer.rb
@@ -35,8 +35,17 @@ module Y2Network
       def write_connections(config, _old_config)
         writer = Y2Network::NetworkManager::ConnectionConfigWriter.new
         config.connections.each do |conn|
-          writer.write(conn, nil, config.routing.routes) # FIXME
+          writer.write(conn, nil, routes_for(conn, config.routing.routes)) # FIXME
         end
+      end
+
+      # Finds routes for a given connection
+      #
+      # @param conn [ConnectionConfig::Base] Connection configuration
+      # @param routes [Array<Route>] List of routes to search in
+      # @return [Array<Route>] List of routes for the given connection
+      def routes_for(conn, routes)
+        routes.select { |r| r.interface&.name == conn.name }
       end
     end
   end

--- a/src/lib/y2network/network_manager/config_writer.rb
+++ b/src/lib/y2network/network_manager/config_writer.rb
@@ -35,7 +35,7 @@ module Y2Network
       def write_connections(config, _old_config)
         writer = Y2Network::NetworkManager::ConnectionConfigWriter.new
         config.connections.each do |conn|
-          writer.write(conn, nil) # FIXME
+          writer.write(conn, nil, config.routing.routes) # FIXME
         end
       end
     end

--- a/src/lib/y2network/network_manager/connection_config_writer.rb
+++ b/src/lib/y2network/network_manager/connection_config_writer.rb
@@ -40,6 +40,12 @@ module Y2Network
         @basedir = basedir
       end
 
+      # @param conn [ConnectionConfig::Base] Connection configuration to be
+      #   written
+      # @param old_conn [ConnectionConfig::Base] Original connection
+      #   configuration
+      # @param routes [Array<Routes>] routes associated with the connection to be
+      #   written
       def write(conn, old_conn = nil, routes = [])
         return if conn == old_conn
 
@@ -56,12 +62,18 @@ module Y2Network
 
     private
 
+      # Convenience method to obtain the path for writing the given connection
+      # configuration
+      #
+      # @param conn [ConnectionConfig::Base] Connection config to be written
       def path_for(conn)
-        Yast.import "Installation"
         conn_file_path = SYSTEM_CONNECTIONS_PATH.join(conn.name).sub_ext(FILE_EXT)
         Pathname.new(File.join(basedir, conn_file_path))
       end
 
+      # Convenience method to ensure the new configuration file permissions
+      #
+      # @param path [Pathname] connection configuration file path
       def ensure_permissions(path)
         ::FileUtils.touch(path)
         ::File.chmod(0o600, path)

--- a/src/lib/y2network/wicked/config_writer.rb
+++ b/src/lib/y2network/wicked/config_writer.rb
@@ -107,7 +107,7 @@ module Y2Network
       #
       # @param iface  [Interface,nil] Interface to search routes for; nil will
       #   return the global routes file
-      # @return [Y2Network::ConfigWriters::RoutesFile]
+      # @return [CFA::RoutesFile]
       def routes_file_for(iface)
         return CFA::RoutesFile.new unless iface
 

--- a/test/y2network/network_manager/config_writer_test.rb
+++ b/test/y2network/network_manager/config_writer_test.rb
@@ -71,7 +71,7 @@ describe Y2Network::NetworkManager::ConfigWriter do
     end
 
     it "writes connections configuration" do
-      expect(conn_config_writer).to receive(:write).with(eth0_conn, nil)
+      expect(conn_config_writer).to receive(:write).with(eth0_conn, nil, [])
       writer.write(config)
     end
   end

--- a/test/y2network/network_manager/connection_config_writer_test.rb
+++ b/test/y2network/network_manager/connection_config_writer_test.rb
@@ -54,7 +54,7 @@ describe Y2Network::NetworkManager::ConnectionConfigWriter do
   let(:path) { "/etc/NetworkManager/system-connections/eth0.nmconnection" }
 
   let(:file) do
-    instance_double(CFA::NmConnection, save: nil, path: path)
+    instance_double(CFA::NmConnection, save: nil)
   end
 
   describe "#write" do

--- a/test/y2network/network_manager/connection_config_writer_test.rb
+++ b/test/y2network/network_manager/connection_config_writer_test.rb
@@ -75,7 +75,7 @@ describe Y2Network::NetworkManager::ConnectionConfigWriter do
 
     it "uses the appropiate handler" do
       expect(writer).to receive(:require).and_return(handler)
-      expect(handler).to receive(:write).with(conn)
+      expect(handler).to receive(:write).with(conn, [])
       writer.write(conn)
     end
 


### PR DESCRIPTION
- Added support for writing device default routes when writing the NetworkManager config (it needs more work for writing all the routes)
- Take into account the installation destination directory when writing the NetworkManager configuration at the end of the installation.