### PR TITLE
Suggest to modify the VLAN interface name when the VLAN ID is modified

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 22 17:03:54 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Suggest to modify the VLAN interface name when the VLAN ID is
+  modified (bsc#1174363)
+- 4.2.90
+
+-------------------------------------------------------------------
 Mon Jan 11 13:28:26 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix network configuration progress bar steps (bsc#1180702)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.89
+Version:        4.2.90
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/vlan_id.rb
+++ b/src/lib/y2network/widgets/vlan_id.rb
@@ -42,6 +42,9 @@ module Y2Network
       end
 
       def store
+        return unless modified?
+
+        @config.name = suggested_name if suggest_vlan_name
         @config.vlan_id = value
       end
 
@@ -51,6 +54,25 @@ module Y2Network
 
       def maximum
         9999
+      end
+
+    private
+
+      def modified?
+        @config.vlan_id != value
+      end
+
+      def suggested_name
+        "vlan#{value}"
+      end
+
+      def suggest_vlan_name
+        Yast::Popup.YesNo(
+          format(
+            _("Would you like to adapt the interface name from '%s' to '%s'?"),
+            @config.name, suggested_name
+          )
+        )
       end
     end
   end

--- a/src/lib/y2network/widgets/vlan_id.rb
+++ b/src/lib/y2network/widgets/vlan_id.rb
@@ -67,10 +67,19 @@ module Y2Network
       end
 
       def suggest_vlan_name
+        # If the interface name is modified before the VLAN ID, we should not
+        # suggest any change
+        return false if @config.name == suggested_name
+
         Yast::Popup.YesNo(
           format(
-            _("Would you like to adapt the interface name from '%s' to '%s'?"),
-            @config.name, suggested_name
+            # TRANSLATORS: Suggest the user to modify the interface name
+            # %{vlanid} is the modified VLAN ID, %{name} is the current
+            # interface name and %{sname} is the interface name
+            # proposed based on the new VLAN ID
+            _("VLAN with ID '%{vlanid}' has been defined.\n\n" \
+              "Would you like to adapt the interface name from '%{name}' to '%{sname}'?"),
+            vlanid: value, name: @config.name, sname: suggested_name
           )
         )
       end

--- a/test/y2network/widgets/vlan_id_test.rb
+++ b/test/y2network/widgets/vlan_id_test.rb
@@ -24,8 +24,50 @@ require "y2network/widgets/vlan_id"
 require "y2network/interface_config_builder"
 
 describe Y2Network::Widgets::VlanID do
-  let(:builder) { Y2Network::InterfaceConfigBuilder.for("vlan") }
+  let(:builder) do
+    Y2Network::InterfaceConfigBuilder.for("vlan").tap do |vlan|
+      vlan.name = "vlan0"
+    end
+  end
+
   subject { described_class.new(builder) }
 
   include_examples "CWM::IntField"
+
+  describe "#store" do
+    let(:value) { 0 }
+
+    before do
+      allow(subject).to receive(:value).and_return(value)
+    end
+
+    context "when the value is modified since read" do
+      let(:value) { 20 }
+
+      it "suggest the user to modify also the interface name" do
+        expect(Yast::Popup).to receive(:YesNo).with(/from 'vlan0' to 'vlan20'/)
+
+        subject.store
+      end
+
+      context "and the user accepts the suggestion" do
+        before do
+          allow(Yast::Popup).to receive(:YesNo).and_return(true)
+        end
+
+        it "modifies the vlan interface name" do
+          expect { subject.store }.to change { builder.name }.from("vlan0").to("vlan20")
+        end
+      end
+    end
+
+    context "when the value is not modified since read" do
+      it "does nothing" do
+        expect(Yast::Popup).to_not receive(:YesNo)
+        expect(builder).to_not receive(:vlan_id=)
+
+        subject.store
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

The VLAN ID and the interface name are configured in different tabs, thus, it is very common to have a misleading interface name when the VLAN ID is modified.

- https://bugzilla.suse.com/show_bug.cgi?id=1174363

## Solution

Suggest a interface name based on the new 'VLAN ID' when it is modified.

## Screenshot

![SuggestVlanInterfaceName](https://user-images.githubusercontent.com/7056681/105521054-5642b800-5cd3-11eb-85c1-0704932c4f79.png)
![ModifiedInterfaceName](https://user-images.githubusercontent.com/7056681/105521060-580c7b80-5cd3-11eb-8944-840bfb9d07d7.png)
