### PR TITLE
Fix minor usability issues

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Jan 26 11:23:33 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fixes some usability issues (bsc#1177834):
+  - Disable "Edit" and "Delete" buttons when no interfaces
+    are detected.
+  - Disable the "Scan Network" button when the interface does not
+    exist.
+
+-------------------------------------------------------------------
 Fri Jan 22 17:03:54 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Suggest to modify the VLAN interface name when the VLAN ID is

--- a/src/lib/y2network/widgets/delete_interface.rb
+++ b/src/lib/y2network/widgets/delete_interface.rb
@@ -38,6 +38,11 @@ module Y2Network
         Yast::Label.DeleteButton
       end
 
+      # @see CWM::AbstractWidget#init
+      def init
+        disable unless @table.value
+      end
+
       def handle
         config = Yast::Lan.yast_config
         connection_config = config.connections.by_name(@table.value)

--- a/src/lib/y2network/widgets/edit_interface.rb
+++ b/src/lib/y2network/widgets/edit_interface.rb
@@ -36,6 +36,11 @@ module Y2Network
         @table = table
       end
 
+      # @see CWM::AbstractWidget#init
+      def init
+        disable unless @table.value
+      end
+
       def label
         Yast::Label.EditButton
       end

--- a/src/lib/y2network/widgets/wireless_essid.rb
+++ b/src/lib/y2network/widgets/wireless_essid.rb
@@ -111,6 +111,10 @@ module Y2Network
         _("Scan Network")
       end
 
+      def init
+        disable if @settings.newly_added?
+      end
+
       def handle
         return unless scan_supported?
 

--- a/test/y2network/widgets/delete_interface_test.rb
+++ b/test/y2network/widgets/delete_interface_test.rb
@@ -27,8 +27,10 @@ require "y2network/virtual_interface"
 Yast.import "Lan"
 
 describe Y2Network::Widgets::DeleteInterface do
-  subject { described_class.new(double(value: interface_to_delete)) }
+  subject { described_class.new(table) }
 
+  let(:table) { double("table", value: selected) }
+  let(:selected) { "eth0" }
   let(:eth0) { Y2Network::Interface.new("eth0") }
   let(:br0) { Y2Network::VirtualInterface.new("br0", type: Y2Network::InterfaceType::BRIDGE) }
   let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, br0]) }
@@ -49,7 +51,7 @@ describe Y2Network::Widgets::DeleteInterface do
     Y2Network::Config.new(interfaces: interfaces, connections: connections, source: :testing)
   end
 
-  let(:interface_to_delete) { "eth0" }
+  let(:selected) { "eth0" }
 
   before do
     allow(Yast::Lan).to receive(:yast_config).and_return(config)
@@ -57,11 +59,29 @@ describe Y2Network::Widgets::DeleteInterface do
 
   include_examples "CWM::PushButton"
 
+  describe "#init" do
+    context "when an element is selected" do
+      it "does not disable the widget" do
+        expect(subject).to_not receive(:disable)
+        subject.init
+      end
+    end
+
+    context "when no element is selected" do
+      let(:selected) { nil }
+
+      it "disables the widget" do
+        expect(subject).to receive(:disable)
+        subject.init
+      end
+    end
+  end
+
   describe "#handle" do
     context "interface does not have connection config" do
       let(:eth1) { Y2Network::Interface.new("eth1") }
       let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, br0, eth1]) }
-      let(:interface_to_delete) { "eth1" }
+      let(:selected) { "eth1" }
 
       it "do nothing" do
         expect(config).to_not receive(:delete_interface)

--- a/test/y2network/widgets/edit_interface_test.rb
+++ b/test/y2network/widgets/edit_interface_test.rb
@@ -49,6 +49,24 @@ describe Y2Network::Widgets::EditInterface do
 
   include_examples "CWM::PushButton"
 
+  describe "#init" do
+    context "when an element is selected" do
+      it "does not disable the widget" do
+        expect(subject).to_not receive(:disable)
+        subject.init
+      end
+    end
+
+    context "when no element is selected" do
+      let(:selected) { nil }
+
+      it "disables the widget" do
+        expect(subject).to receive(:disable)
+        subject.init
+      end
+    end
+  end
+
   describe "#handle" do
     it "runs the interface edition sequence" do
       expect(sequence).to receive(:edit) do |builder|

--- a/test/y2network/widgets/wireless_essid_test.rb
+++ b/test/y2network/widgets/wireless_essid_test.rb
@@ -46,6 +46,30 @@ describe Y2Network::Widgets::WirelessScan do
     allow(essid).to receive(:update_essid_list)
   end
 
+  describe "#init" do
+    before do
+      allow(builder).to receive(:newly_added?).and_return(newly_added?)
+    end
+
+    context "when the interface exists" do
+      let(:newly_added?) { false }
+
+      it "does not disable the button" do
+        expect(subject).to_not receive(:disable)
+        subject.init
+      end
+    end
+
+    context "when the interface does not exist" do
+      let(:newly_added?) { true }
+
+      it "disables the button" do
+        expect(subject).to receive(:disable)
+        subject.init
+      end
+    end
+  end
+
   describe "#handle" do
     context "when the package for scanning wireless networks is not installed" do
       let(:installed) { false }


### PR DESCRIPTION
* When no interfaces are detected, the *Edit* and *Remove* buttons are disabled.
* The *Scan Network* button is disabled when the wireless interface is not
  present (so it is not possible to scan for ESSIDs).
  
Intentionally we are not bumping the version.
  
Related to https://trello.com/c/sWUhr8qn/1713-5-re-think-the-network-ui-approach
See [bsc#1177834](https://bugzilla.suse.com/show_bug.cgi?id=1177834)