### PR TITLE
Enhance NM writers supporting more authentication modes (WEP, WPA_EAP)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jan 29 15:56:44 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Improved the NetworkManager wireless configuration writers adding
+  support for writing WPA-EAP and open WEP authentication modes.
+- 4.3.42
+
+
+-------------------------------------------------------------------
 Tue Jan 26 11:23:33 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fixes some usability issues (bsc#1177834):

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.41
+Version:        4.3.42
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/cfa/interface_file.rb
+++ b/src/lib/cfa/interface_file.rb
@@ -264,6 +264,10 @@ module CFA
     #   @return [String] client private key used for encryption in TLS
     define_variable(:wireless_client_key)
 
+    # @!attribute [r] wireless_client_key_password
+    #   @return [String] client private key password used for encryption in TLS
+    define_variable(:wireless_client_key_password)
+
     # @!attribute [r] wireless_eap_mode
     #   @return [String] WPA-EAP outer authentication method
     define_variable(:wireless_eap_mode)

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -394,6 +394,7 @@ module Y2Network
         @wireless_channel = config.channel.to_s if config.channel
         @wireless_client_cert = config.client_cert
         @wireless_client_key = config.client_key
+        @wireless_client_key_password = config.client_key_password
         @wireless_essid = config.essid
         @wireless_auth_mode = config.auth_mode.to_s
         @wireless_nick = config.nick

--- a/src/lib/y2network/connection_config/wireless.rb
+++ b/src/lib/y2network/connection_config/wireless.rb
@@ -73,6 +73,8 @@ module Y2Network
       attr_accessor :client_cert
       # @return [String] client private key used to encrypt for TLS
       attr_accessor :client_key
+      # @return [String] client private key password
+      attr_accessor :client_key_password
 
       def initialize
         super

--- a/src/lib/y2network/connection_config/wireless.rb
+++ b/src/lib/y2network/connection_config/wireless.rb
@@ -100,7 +100,7 @@ module Y2Network
         [:mode, :essid, :nwid, :auth_mode, :wpa_psk, :key_length, :keys, :default_key, :nick,
          :eap_mode, :eap_auth, :channel, :frequency, :bitrate, :ap, :ap_scanmode,
          :wpa_password, :wpa_identity, :wpa_anonymous_identity, :ca_cert, :client_cert,
-         :client_key].all? do |method|
+         :client_key, :client_key_password].all? do |method|
           public_send(method) == other.public_send(method)
         end
       end

--- a/src/lib/y2network/connection_config/wireless.rb
+++ b/src/lib/y2network/connection_config/wireless.rb
@@ -88,7 +88,7 @@ module Y2Network
         self.keys = []
         self.default_key = 0
         self.eap_mode = "PEAP"
-        self.eap_auth = "MSCHAPV2"
+        self.eap_auth = "mschapv2"
         self.ap_scanmode = 1
         # For WIFI DHCP makes more sense as majority of wifi routers act as dhcp servers
         self.bootproto = BootProtocol::DHCP

--- a/src/lib/y2network/connection_config/wireless.rb
+++ b/src/lib/y2network/connection_config/wireless.rb
@@ -111,6 +111,13 @@ module Y2Network
       def mode=(wireless_mode)
         @mode = wireless_mode.to_s.downcase
       end
+
+      # Convenience method to check whether there are some WEP key defined
+      #
+      # @return [Boolean] return true if there is at least one not empty key
+      def keys?
+        !(keys || []).compact.all?(&:empty?)
+      end
     end
   end
 end

--- a/src/lib/y2network/interface_config_builders/wireless.rb
+++ b/src/lib/y2network/interface_config_builders/wireless.rb
@@ -53,6 +53,7 @@ module Y2Network
         :wpa_anonymous_identity, :wpa_anonymous_identity=,
         :ca_cert, :ca_cert=,
         :client_key, :client_key=,
+        :client_key_password, :client_key_password=,
         :client_cert, :client_cert=,
         :channel, :channel=,
         :bitrate, :bitrate=,

--- a/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
@@ -96,6 +96,7 @@ module Y2Network
           file.wifi_security["wep-tx-keyidx"] = default_key_idx.to_s if !default_key_idx.zero?
           conn.keys.each_with_index do |v, i|
             next if v.empty?
+
             file.wifi_security["wep-key#{i}"] = v.gsub(/^[sh:]/, "")
           end
           passphrase_used = conn.keys[default_key_idx].to_s.start_with?(/h:/)

--- a/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
@@ -109,7 +109,7 @@ module Y2Network
         #
         # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
         def write_open_auth_settings(conn)
-          return if !conn.keys?
+          return unless conn.keys?
 
           file.wifi_security["auth-alg"] = "open"
           write_wep_auth_settings(conn)
@@ -119,7 +119,7 @@ module Y2Network
         #
         # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
         def write_shared_auth_settings(conn)
-          return if !conn.keys?
+          return unless conn.keys?
 
           file.wifi_security["auth-alg"] = "shared"
           write_wep_auth_settings(conn)

--- a/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
@@ -51,7 +51,7 @@ module Y2Network
         # @see #write_shared_auth_settings
         def write_auth_settings(conn)
           auth_mode = conn.auth_mode || :open
-          meth = "write_#{auth_mode}_auth_settings".to_sym
+          meth = "write_#{auth_mode}_auth_settings"
           send(meth, conn) if respond_to?(meth, true)
         end
 
@@ -59,7 +59,6 @@ module Y2Network
         #
         # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
         def write_eap_auth_settings(conn)
-          # FIXME: incomplete
           file.wifi_security["key-mgmt"] = "wpa-eap"
           section = file.section_for("802-1x")
 
@@ -110,7 +109,7 @@ module Y2Network
         #
         # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
         def write_open_auth_settings(conn)
-          return if (conn.keys || []).compact.all?(&:empty?)
+          return if !conn.keys?
 
           file.wifi_security["auth-alg"] = "open"
           write_wep_auth_settings(conn)
@@ -120,7 +119,7 @@ module Y2Network
         #
         # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
         def write_shared_auth_settings(conn)
-          return if (conn.keys || []).compact.all?(&:empty?)
+          return if !conn.keys?
 
           file.wifi_security["auth-alg"] = "shared"
           write_wep_auth_settings(conn)

--- a/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
@@ -61,7 +61,7 @@ module Y2Network
           file.wifi_security["key-mgmt"] = "wpa-eap"
           section = file.section_for("802-1x")
 
-          section["eap"] = conn.eap_mode
+          section["eap"] = conn.eap_mode.downcase if conn.eap_mode
           section["phase2-auth"] = conn.eap_auth if conn.eap_auth
           section["password"] = conn.wpa_password if conn.wpa_password
           section["anonymous-identity"] = conn.wpa_anonymous_identity if conn.eap_mode == "TTLS"

--- a/src/lib/y2network/wicked/connection_config_readers/wireless.rb
+++ b/src/lib/y2network/wicked/connection_config_readers/wireless.rb
@@ -41,6 +41,7 @@ module Y2Network
           conn.ca_cert = file.wireless_ca_cert
           conn.client_cert = file.wireless_client_cert
           conn.client_key = file.wireless_client_key
+          conn.client_key_password = file.wireless_client_key_password
           conn.wpa_password = file.wireless_wpa_password
           conn.wpa_psk = file.wireless_wpa_psk
           conn.wpa_identity = file.wireless_wpa_identity

--- a/src/lib/y2network/wicked/connection_config_readers/wireless.rb
+++ b/src/lib/y2network/wicked/connection_config_readers/wireless.rb
@@ -57,7 +57,7 @@ module Y2Network
 
         # Reads the array of wireless keys from the file
         def wireless_keys
-          (0..MAX_WIRELESS_KEYS - 1).map { |i| file.wireless_keys["_#{i}"] }
+          (0..MAX_WIRELESS_KEYS - 1).map { |i| file.wireless_keys["_#{i}"].to_s }
         end
 
         BACKWARD_MAPPING = {

--- a/src/lib/y2network/wicked/connection_config_readers/wireless.rb
+++ b/src/lib/y2network/wicked/connection_config_readers/wireless.rb
@@ -57,7 +57,7 @@ module Y2Network
 
         # Reads the array of wireless keys from the file
         def wireless_keys
-          (0..MAX_WIRELESS_KEYS - 1).map { |i| file.wireless_keys["_#{i}"].to_s }
+          (0..MAX_WIRELESS_KEYS - 1).map { |i| file.wireless_keys["_#{i}"] }
         end
 
         BACKWARD_MAPPING = {

--- a/src/lib/y2network/wicked/connection_config_readers/wireless.rb
+++ b/src/lib/y2network/wicked/connection_config_readers/wireless.rb
@@ -31,7 +31,7 @@ module Y2Network
           conn.ap_scanmode = file.wireless_ap_scanmode
           conn.auth_mode = transform_auth_mode(file.wireless_auth_mode)
           conn.default_key = file.wireless_default_key
-          conn.eap_auth = file.wireless_eap_auth
+          conn.eap_auth = file.wireless_eap_auth if file.wireless_eap_auth
           conn.eap_mode = file.wireless_eap_mode
           conn.essid = file.wireless_essid
           conn.key_length = file.wireless_key_length

--- a/src/lib/y2network/wicked/connection_config_writers/wireless.rb
+++ b/src/lib/y2network/wicked/connection_config_writers/wireless.rb
@@ -34,7 +34,7 @@ module Y2Network
           file.wireless_nwid = conn.nwid
           file.wireless_channel = conn.channel
           file.wireless_rate = conn.bitrate
-          write_auth_settings(conn) if conn.auth_mode
+          write_auth_settings(conn)
         end
 
       private
@@ -50,8 +50,8 @@ module Y2Network
         # @see #write_psk_auth_settings
         # @see #write_shared_auth_settings
         def write_auth_settings(conn)
-          file.wireless_auth_mode = conn.auth_mode || :open
-          meth = "write_#{conn.auth_mode}_auth_settings".to_sym
+          file.wireless_auth_mode = conn.auth_mode
+          meth = "write_#{conn.auth_mode || :open}_auth_settings".to_sym
           send(meth, conn) if respond_to?(meth, true)
         end
 
@@ -83,22 +83,22 @@ module Y2Network
         #
         # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
         def write_wep_auth_settings(conn)
-          return if (conn.keys || []).empty?
+          return if (conn.keys || []).compact.all?(&:empty?)
 
           file.wireless_keys = conn.keys
           file.wireless_key_length = conn.key_length
           file.wireless_default_key = conn.default_key
         end
-      end
 
-      # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
-      def write_open_auth_settings(conn)
-        write_wep_auth_settings(conn)
-      end
+        # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
+        def write_open_auth_settings(conn)
+          write_wep_auth_settings(conn)
+        end
 
-      # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
-      def write_shared_auth_settings(conn)
-        write_wep_auth_settings(conn)
+        # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
+        def write_shared_auth_settings(conn)
+          write_wep_auth_settings(conn)
+        end
       end
     end
   end

--- a/src/lib/y2network/wicked/connection_config_writers/wireless.rb
+++ b/src/lib/y2network/wicked/connection_config_writers/wireless.rb
@@ -60,6 +60,7 @@ module Y2Network
         # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
         def write_eap_auth_settings(conn)
           file.wireless_eap_mode = conn.eap_mode
+          file.wireless_eap_auth = conn.eap_auth
           file.wireless_wpa_password = conn.wpa_password
           file.wireless_wpa_identity = conn.wpa_identity
           file.wireless_ca_cert = conn.ca_cert

--- a/src/lib/y2network/wicked/connection_config_writers/wireless.rb
+++ b/src/lib/y2network/wicked/connection_config_writers/wireless.rb
@@ -65,8 +65,11 @@ module Y2Network
           file.wireless_wpa_identity = conn.wpa_identity
           file.wireless_ca_cert = conn.ca_cert
           file.wireless_wpa_anonid = conn.wpa_anonymous_identity if conn.eap_mode == "TTLS"
-          file.wireless_client_cert = conn.client_cert if conn.eap_mode == "TLS"
-          file.wireless_client_key = conn.client_key if conn.eap_mode == "TLS"
+          return unless conn.eap_mode == "TLS"
+
+          file.wireless_client_cert = conn.client_cert
+          file.wireless_client_key = conn.client_key
+          file.wireless_client_key_password = conn.client_key_password
         end
 
         # Writes autentication settings for WPA-PSK networks

--- a/src/lib/y2network/wicked/connection_config_writers/wireless.rb
+++ b/src/lib/y2network/wicked/connection_config_writers/wireless.rb
@@ -79,14 +79,26 @@ module Y2Network
           file.wireless_wpa_psk = conn.wpa_psk
         end
 
-        # Writes autentication settings for WEP networks
+        # Writes autentication settings for WEP networks (open or shared)
         #
         # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
-        def write_shared_auth_settings(conn)
+        def write_wep_auth_settings(conn)
+          return if (conn.keys || []).empty?
+
           file.wireless_keys = conn.keys
           file.wireless_key_length = conn.key_length
           file.wireless_default_key = conn.default_key
         end
+      end
+
+      # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
+      def write_open_auth_settings(conn)
+        write_wep_auth_settings(conn)
+      end
+
+      # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
+      def write_shared_auth_settings(conn)
+        write_wep_auth_settings(conn)
       end
     end
   end

--- a/src/lib/y2network/widgets/client_key.rb
+++ b/src/lib/y2network/widgets/client_key.rb
@@ -21,6 +21,34 @@ require "y2network/widgets/path_widget"
 
 module Y2Network
   module Widgets
+    # Widget that represent EAP Client Key password
+    class ClientKeyPassword < CWM::Password
+      def initialize(builder)
+        @builder = builder
+        textdomain "network"
+      end
+
+      def opt
+        [:hstretch]
+      end
+
+      def label
+        _("Client Key Password")
+      end
+
+      def init
+        self.value = @builder.client_key_password
+      end
+
+      def store
+        @builder.client_key_password = value
+      end
+
+      def help
+        "" # TODO: write it
+      end
+    end
+
     class ClientKeyPath < PathWidget
       def initialize(builder)
         textdomain "network"

--- a/src/lib/y2network/widgets/path_widget.rb
+++ b/src/lib/y2network/widgets/path_widget.rb
@@ -33,8 +33,11 @@ module Y2Network
 
       def contents
         HBox(
-          InputField(Id(text_id), label),
-          PushButton(Id(button_id), button_label)
+          InputField(Id(text_id), Opt(:hstretch), label),
+          VBox(
+            VSpacing(1),
+            PushButton(Id(button_id), button_label)
+          )
         )
       end
 

--- a/src/lib/y2network/widgets/wireless_eap.rb
+++ b/src/lib/y2network/widgets/wireless_eap.rb
@@ -38,6 +38,7 @@ module Y2Network
       end
 
       def init
+        eap_mode.init
         refresh
       end
 
@@ -134,6 +135,7 @@ module Y2Network
       def contents
         VBox(
           HStretch(),
+          EapUser.new(@settings),
           ClientCertPath.new(@settings),
           HBox(
             ClientKeyPath.new(@settings),

--- a/src/lib/y2network/widgets/wireless_eap.rb
+++ b/src/lib/y2network/widgets/wireless_eap.rb
@@ -23,7 +23,7 @@ require "cwm/replace_point"
 require "y2network/widgets/wireless_eap_mode"
 require "y2network/widgets/server_ca_path"
 require "y2network/widgets/client_cert_path"
-require "y2network/widgets/client_key_path"
+require "y2network/widgets/client_key"
 
 module Y2Network
   module Widgets
@@ -50,6 +50,7 @@ module Y2Network
 
       def contents
         VBox(
+          HStretch(),
           eap_mode,
           VSpacing(0.2),
           replace_widget
@@ -99,7 +100,7 @@ module Y2Network
 
       def contents
         VBox(
-          HBox(EapUser.new(@settings), EapPassword.new(@settings)),
+          HBox(EapUser.new(@settings), HSpacing(1), EapPassword.new(@settings)),
           ServerCAPath.new(@settings)
         )
       end
@@ -115,7 +116,7 @@ module Y2Network
 
       def contents
         VBox(
-          HBox(EapUser.new(@settings), EapPassword.new(@settings)),
+          HBox(EapUser.new(@settings), HSpacing(1), EapPassword.new(@settings)),
           EapAnonymousUser.new(@settings),
           ServerCAPath.new(@settings)
         )
@@ -132,9 +133,12 @@ module Y2Network
 
       def contents
         VBox(
+          HStretch(),
+          ClientCertPath.new(@settings),
           HBox(
-            ClientCertPath.new(@settings),
-            ClientKeyPath.new(@settings)
+            ClientKeyPath.new(@settings),
+            HSpacing(1),
+            ClientKeyPassword.new(@settings)
           ),
           ServerCAPath.new(@settings)
         )
@@ -150,6 +154,10 @@ module Y2Network
 
       def label
         _("Password")
+      end
+
+      def opt
+        [:hstretch]
       end
 
       def init

--- a/test/y2network/connection_config/wireless_test.rb
+++ b/test/y2network/connection_config/wireless_test.rb
@@ -29,4 +29,23 @@ describe Y2Network::ConnectionConfig::Wireless do
       expect(config.type).to eq(Y2Network::InterfaceType::WIRELESS)
     end
   end
+
+  describe "#keys?" do
+    let(:keys) { [nil, nil, nil, ""] }
+    before { config.keys = keys }
+
+    context "when the connection has not defined any WEP key" do
+      it "returns false" do
+        expect(config.keys?).to eql(false)
+      end
+    end
+
+    context "when the connection has defined at least one WEP key" do
+      let(:keys) { ["0123456789", nil, nil, ""] }
+
+      it "returns true" do
+        expect(config.keys?).to eql(true)
+      end
+    end
+  end
 end

--- a/test/y2network/network_manager/connection_config_writers/wireless_test.rb
+++ b/test/y2network/network_manager/connection_config_writers/wireless_test.rb
@@ -43,7 +43,7 @@ describe Y2Network::NetworkManager::ConnectionConfigWriters::Wireless do
   end
 
   describe "#write" do
-    it "sets relevant attributes" do
+    it "sets device and IP relevant attributes" do
       handler.write(conn)
       expect(file.wifi["ssid"]).to eql(conn.essid)
       expect(file.wifi["mode"]).to eql("infrastructure")
@@ -51,7 +51,39 @@ describe Y2Network::NetworkManager::ConnectionConfigWriters::Wireless do
       expect(file.ipv6["method"]).to eql("auto")
     end
 
-    context "WPA-PSK network configuration" do
+    context "when configuring without encryption" do
+      it "does not set any authentication" do
+        handler.write(conn)
+        expect(file.wifi_security["auth-alg"]).to be(nil)
+      end
+    end
+
+    context "when configuring with WEP authentication (open or shared)" do
+      let(:conn) do
+        Y2Network::ConnectionConfig::Wireless.new.tap do |c|
+          c.startmode = Y2Network::Startmode.create("auto")
+          c.bootproto = Y2Network::BootProtocol::STATIC
+          c.mode = "managed"
+          c.auth_mode = "shared"
+          c.keys = ["123456", "s:abcdef"]
+          c.key_length = 128
+          c.default_key = 1
+        end
+      end
+
+      it "sets specific WEP wireless security attributes" do
+        handler.write(conn)
+        expect(file.wifi_security["auth-alg"]).to eql("shared")
+        expect(file.wifi_security["wep-tx-keyidx"]).to eql("1")
+        expect(file.wifi_security["wep-key1"]).to eql("abcdef")
+        expect(file.wifi_security["wep-key-type"]).to eql("1")
+        conn.auth_mode = :open
+        handler.write(conn)
+        expect(file.wifi_security["auth-alg"]).to eql("open")
+      end
+    end
+
+    context "when configuring with WPA-PSK authentication" do
       let(:conn) do
         Y2Network::ConnectionConfig::Wireless.new.tap do |c|
           c.startmode = Y2Network::Startmode.create("auto")
@@ -62,10 +94,122 @@ describe Y2Network::NetworkManager::ConnectionConfigWriters::Wireless do
         end
       end
 
-      it "sets specific WPA-PSK attributes" do
+      it "sets specific WPA-PSK wireless security attributes" do
         handler.write(conn)
         expect(file.wifi_security["key-mgmt"]).to eql("wpa-psk")
         expect(file.wifi_security["psk"]).to eql("example_psk")
+      end
+    end
+
+    context "when configuring with WPA-EAP authentication" do
+      let(:server_cert) { "/etc/raddb/certs/server.crt" }
+      let(:client_cert) { "/etc/raddb/certs/client.crt" }
+      let(:client_key) { "/etc/raddb/certs/client.key" }
+      let(:client_key_password) { "whatever" }
+      let(:eap_mode) { "PEAP" }
+      let(:section_802_1x) { file.section_for("802-1x") }
+
+      let(:conn) do
+        Y2Network::ConnectionConfig::Wireless.new.tap do |c|
+          c.startmode = Y2Network::Startmode.create("auto")
+          c.bootproto = Y2Network::BootProtocol::DHCP
+          c.mode = "managed"
+          c.auth_mode = "eap"
+          c.eap_mode = eap_mode
+          c.wpa_identity = "user@example.com"
+          c.wpa_password = "testing123"
+          c.wpa_anonymous_identity = "anonymous@example.com"
+        end
+      end
+
+      it "sets specific WPA-EAP wireless security attributes" do
+        handler.write(conn)
+        expect(file.wifi_security["key-mgmt"]).to eql("wpa-eap")
+        expect(section_802_1x["eap"]).to_not be_nil
+      end
+
+      context "using PEAP eap mode" do
+        it "sets the the eap mode to 'peap'" do
+          handler.write(conn)
+          expect(section_802_1x["eap"]).to eql("peap")
+        end
+
+        it "sets the identity and password" do
+          handler.write(conn)
+          expect(section_802_1x["identity"]).to eql("user@example.com")
+          expect(section_802_1x["password"]).to eql("testing123")
+        end
+
+        context "when defined a server certificate" do
+          it "sets it" do
+            conn.ca_cert = server_cert
+            handler.write(conn)
+            expect(section_802_1x["ca-cert"]).to eql(server_cert)
+          end
+        end
+      end
+
+      context "using TLS eap mode" do
+        let(:eap_mode) { "TLS" }
+        before do
+          conn.client_key = client_key
+          conn.client_key_password = client_key_password
+          conn.client_cert = client_cert
+          conn.ca_cert = server_cert
+        end
+
+        it "sets the the eap mode to 'tls'" do
+          handler.write(conn)
+          expect(section_802_1x["eap"]).to eql("tls")
+        end
+
+        it "sets the identity" do
+          handler.write(conn)
+          expect(section_802_1x["identity"]).to eql("user@example.com")
+        end
+
+        it "sets the client key, client key password and client certificate" do
+          handler.write(conn)
+          expect(section_802_1x["client-cert"]).to eql(client_cert)
+          expect(section_802_1x["private-key"]).to eql(client_key)
+          expect(section_802_1x["private-key-password"]).to eql(client_key_password)
+        end
+
+        context "when defined a server certificate" do
+          it "sets it" do
+            conn.ca_cert = server_cert
+            handler.write(conn)
+            expect(section_802_1x["ca-cert"]).to eql(server_cert)
+          end
+        end
+      end
+
+      context "using TTLS eap mode" do
+        let(:eap_mode) { "TTLS" }
+
+        before do
+          conn.ca_cert = server_cert
+        end
+
+        it "sets the the eap mode to 'tls'" do
+          handler.write(conn)
+          expect(section_802_1x["eap"]).to eql("ttls")
+        end
+
+        it "sets the identity, anonymous identity and password" do
+          handler.write(conn)
+          expect(section_802_1x["identity"]).to eql("user@example.com")
+          expect(section_802_1x["anonymous-identity"]).to eql("anonymous@example.com")
+          expect(section_802_1x["password"]).to eql("testing123")
+        end
+
+        context "when defined a server certificate" do
+          it "sets it" do
+            conn.ca_cert = server_cert
+            handler.write(conn)
+            expect(section_802_1x["ca-cert"]).to eql(server_cert)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Problem

In https://github.com/yast/yast-network/pull/1149 we added support for writing basic NM wireless configuration but writes for authentication methods like **WEP** or **WPA_EAP** were not implemented.

- https://trello.com/c/QVm1dv53/2264-2-networkmanager-write-wireless-security-settings

## Solution

- Added support for writing WEP config
- Added support for writing WPA_EAP config
- Added widget for EAP TLS client key password
- Some UI enhancement (fixed eap mode selection)

### WPA_EAP config screenshots

|               | Before | After |
| ----------- | --------- | ------- |
| TTLS | ![TTLS_before](https://user-images.githubusercontent.com/7056681/105998399-82c84c80-60a4-11eb-93c8-16066e61b869.png) | ![TTLS](https://user-images.githubusercontent.com/7056681/105998390-80fe8900-60a4-11eb-956d-d0db308fa3e1.png) |
| TLS | ![Screenshot from 2021-01-27 12-37-09](https://user-images.githubusercontent.com/7056681/105998402-8360e300-60a4-11eb-8a70-a402ea7265e8.png) | ![TLS](https://user-images.githubusercontent.com/7056681/105998395-822fb600-60a4-11eb-9bb0-6af4b808a82f.png) |
| PEAP | ![PEAP_before](https://user-images.githubusercontent.com/7056681/105998404-8360e300-60a4-11eb-95f9-0220974623bb.png) | ![PEAP](https://user-images.githubusercontent.com/7056681/105998398-822fb600-60a4-11eb-8ea9-158273a5562f.png) |


## TODO

- I have not tested it, but looks like WPA_EAP configuration using certificates should be broken after installation as we are not copying the files from the inst-sys to the target system.
- The "Details" button when using WPA_EAP with PEAP mode was removed during the network-ng refactorization, thus,there is not way to modify the authentication method or the PEAP version to be used.