### PR TITLE
Added the interface lladdr attribute to the networking schema

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,10 +1,16 @@
 -------------------------------------------------------------------
+Mon Feb  1 20:05:05 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Added lladdr attribute to the interface section in the networking
+  schema and honors it when importing the config (bsc#1179876)
+- 4.3.43
+
+-------------------------------------------------------------------
 Fri Jan 29 15:56:44 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Improved the NetworkManager wireless configuration writers adding
   support for writing WPA-EAP and open WEP authentication modes.
 - 4.3.42
-
 
 -------------------------------------------------------------------
 Tue Jan 26 11:23:33 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.42
+Version:        4.3.43
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -51,6 +51,7 @@ interface =
       element device { STRING }? &	#overloaded
       element name { STRING }? &
 
+      lladdr? &
       bootproto? &
       startmode? &
       ifplugd_priority? &
@@ -140,6 +141,7 @@ bootproto = element bootproto { STRING }
 broadcast = element broadcast { STRING }
 dhclient_set_down_link = element dhclient_set_down_link { STRING }
 dhclient_set_default_route = element dhclient_set_default_route { STRING_ATTR, ("yes" | "no") }
+lladdrr = element lladdr { STRING }
 ipaddr = element ipaddr { STRING }
 prefixlen = element prefixlen { STRING }
 usercontrol = element usercontrol { STRING }

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -86,6 +86,7 @@ module Y2Network
       def load_generic(config, interface_section)
         config.bootproto = BootProtocol.from_name(interface_section.bootproto)
         config.name = name_from_section(interface_section)
+        config.lladdress = interface_section.lladdr if !interface_section.to_s.empty?
         config.interface = config.name # in autoyast name and interface is same
         if config.bootproto == BootProtocol::STATIC
           if !interface_section.ipaddr

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -27,6 +27,7 @@ module Y2Network
     #    <bootproto>static</bootproto>
     #    <broadcast>127.255.255.255</broadcast>
     #    <device>lo</device>
+    #    <lladdr>02:02:02:02:02:02</lladdr>
     #    <firewall>no</firewall>
     #    <ipaddr>127.0.0.1</ipaddr>
     #    <netmask>255.0.0.0</netmask>
@@ -44,6 +45,7 @@ module Y2Network
           { name: :broadcast },
           { name: :device },
           { name: :name }, # has precedence over device
+          { name: :lladdr },
           { name: :ipaddr },
           { name: :remote_ipaddr },
           { name: :netmask },
@@ -123,6 +125,9 @@ module Y2Network
 
       # @!attribute name
       #  @return [String] device name.
+
+      # @!attribute lladdr
+      #  @return [String] ip address.
 
       # @!attribute ipaddr
       #  @return [String] ip address.
@@ -287,6 +292,7 @@ module Y2Network
         # nil bootproto is valid use case (missing explicit setup) - wicked defaults to static then
         @bootproto = config.bootproto&.name
         @name = config.name
+        @lladdr = config.lladdress
         if config.bootproto == BootProtocol::STATIC && config.ip
           # missing ip is valid scenario for wicked - so use empty string here
           @ipaddr = config.ip.address&.address.to_s

--- a/src/lib/y2network/autoinst_profile/interfaces_section.rb
+++ b/src/lib/y2network/autoinst_profile/interfaces_section.rb
@@ -36,6 +36,7 @@ module Y2Network
     #       <device>lo</device>
     #       <firewall>no</firewall>
     #       <ipaddr>127.0.0.1</ipaddr>
+    #       <lladdr>02:02:02:02:02:02</lladdr>
     #       <netmask>255.0.0.0</netmask>
     #       <network>127.0.0.0</network>
     #       <prefixlen>8</prefixlen>

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -45,6 +45,7 @@ describe Y2Network::Autoinst::InterfacesReader do
         "bootproto"             => "dhcp",
         "name"                  => "eth0",
         "startmode"             => "auto",
+        "lladdr"                => "02:0b:0c:0d:0e:02",
         "dhclient_set_hostname" => "yes",
         "aliases"               => {
           "alias0" => {
@@ -74,6 +75,7 @@ describe Y2Network::Autoinst::InterfacesReader do
       expect(eth0_config.bootproto).to eq Y2Network::BootProtocol.from_name("dhcp")
       expect(eth0_config.ip_aliases.size).to eq 2
       expect(eth0_config.dhclient_set_hostname).to eq true
+      expect(eth0_config.lladdress).to eq("02:0b:0c:0d:0e:02")
       eth1_config = subject.config.by_name("eth1")
       expect(eth1_config.name).to eq("eth1")
       expect(eth1_config.ip.address.to_s).to eq("192.168.10.10/24")

--- a/test/y2network/autoinst_profile/interface_section_test.rb
+++ b/test/y2network/autoinst_profile/interface_section_test.rb
@@ -34,6 +34,7 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
         c.firewall_zone = "DMZ"
         c.ethtool_options = "test=1"
         c.interface = "eth0"
+        c.lladdress = "02:0b:0c:0d:0e:02"
         c.ip = Y2Network::ConnectionConfig::IPConfig.new(
           Y2Network::IPAddress.from_string("10.100.0.1/24")
         )
@@ -55,6 +56,7 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
       expect(section.bootproto).to eq("static")
       expect(section.ipaddr).to eq("10.100.0.1")
       expect(section.prefixlen).to eq("24")
+      expect(section.lladdr).to eq("02:0b:0c:0d:0e:02")
       expect(section.aliases).to eq(
         "alias0" => { "IPADDR" => "10.100.0.1", "PREFIXLEN" => "24", "LABEL" => "test" },
         "alias1" => { "IPADDR" => "10.100.0.2", "PREFIXLEN" => "24", "LABEL" => "test1" }


### PR DESCRIPTION
## Problem

Using the LLADDR option in the AutoYaST control file causes validation error.

- https://trello.com/c/lS5KY6FR/2254-2-sles15-sp3-p5-1179876-sles-15-sp3-beta1-lladdr-option-in-autoyast-control-file-is-invalid

## Solution

Add the attribute to the networking schema and honors it in the interface section.