### PR TITLE
Cache the netcards 'hwinfo' speeding up the access to it (bsc#1180702)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  4 15:05:25 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Cache the hardware netcards information in order to speed up the
+  access (bsc#1180702)
+- 4.3.44
+
+-------------------------------------------------------------------
 Mon Feb  1 20:05:05 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Added lladdr attribute to the interface section in the networking

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.43
+Version:        4.3.44
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/hwinfo.rb
+++ b/src/lib/y2network/hwinfo.rb
@@ -113,6 +113,8 @@ module Y2Network
       #
       # @return [HardWrapper]
       def hardware_wrapper
+        return @hardware_wrapper if @hardware_wrapper
+
         @hardware_wrapper = HardwareWrapper.new
       end
 

--- a/src/lib/y2network/wicked/interfaces_reader.rb
+++ b/src/lib/y2network/wicked/interfaces_reader.rb
@@ -51,6 +51,7 @@ module Y2Network
       def config
         return @config if @config
 
+        Hwinfo.reset
         find_s390_devices
         find_physical_interfaces
         find_connections

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -72,6 +72,7 @@ RSpec.configure do |c|
 
   c.before do
     Yast::Lan.clear_configs
+    Y2Network::Hwinfo.reset
     allow(Yast::NetworkInterfaces).to receive(:Write)
     allow(Y2Network::Hwinfo).to receive(:hwinfo_from_hardware)
     Y2Storage::StorageManager.create_test_instance


### PR DESCRIPTION
## Problem

S390 Group device objects do not cache the hardware info but obtains it querying the Hwinfo class which according to documentation should memoize it. 

But we cannot reset the info forever as we need to reset the info because some device could be activated and we need to refresh the list of interfaces with the associated one.

- https://trello.com/c/eDUHOypB/2259-3-sles15-sp3-p2-1180702-network-configuration-does-not-accept-next-in-the-yast-console

## Solution

- Memoize the hardware wrapper object.
- Reset the hwinfo before obtaining a new interfaces config.
