### PR TITLE
Better readers

### DIFF
--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -264,6 +264,31 @@ module Y2Network
       @backend = Y2Network::Backend.all.find { |b| b.id == id }
     end
 
+    # Updates configuration section
+    #
+    # This method returns a new instance of Config, leaving the received
+    # as it is.
+    #
+    # @example Update interfaces list
+    #   config.update(interfaces: InterfacesCollection.new)
+    #
+    # @param changes [Hash<Symbol,Object>] A hash where the keys are the
+    #   sections to update and the values are the new values
+    # @return [Y2Network::Config]
+    def update(changes = {})
+      self.class.new(
+        interfaces:   changes[:interfaces] || interfaces,
+        connections:  changes[:connections] || connections,
+        s390_devices: changes[:s390_devices] || s390_devices,
+        drivers:      changes[:drivers] || drivers,
+        routing:      changes[:routing] || routing,
+        dns:          changes[:dns] || dns,
+        hostname:     changes[:hostname] || hostname,
+        source:       changes[:source] || source,
+        backend:      changes[:backend] || backend
+      )
+    end
+
     alias_method :eql?, :==
 
   private

--- a/src/lib/y2network/config_reader.rb
+++ b/src/lib/y2network/config_reader.rb
@@ -16,18 +16,41 @@
 #
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
+
+require "yast"
+
 module Y2Network
-  module ConfigReader
-    # Config reader for a given source
+  # This class is responsible for reading the configuration from the system
+  #
+  # It implements a {#config} method which returns a configuration object
+  # containing the information from the corresponding backend.
+  #
+  # It is expect that a configuration reader exists for each supported backend
+  # by inheriting from this class.
+  class ConfigReader
+    include Yast::Logger
+
+    class << self
+      # Returns a configuration reader for a given source
+      #
+      # @param source [Symbol] Source name (e.g., :wicked)
+      # @param opts  [Array<Object>] Reader options
+      # @return [Y2Network::Autoinst::ConfigReader,Y2Network::Wicked::ConfigReader]
+      def for(source, *opts)
+        require "y2network/#{source}/config_reader"
+        modname = source.to_s.split("_").map(&:capitalize).join
+        klass = Y2Network.const_get("#{modname}::ConfigReader")
+        klass.new(*opts)
+      end
+    end
+
+    def initialize(_opts = {}); end
+
+    # Returns the configuration from the given backend
     #
-    # @param source [Symbol] Source name (e.g., :wicked)
-    # @param opts  [Array<Object>] Reader options
-    # @return [Y2Network::Autoinst::ConfigReader,Y2Network::Wicked::ConfigReader]
-    def self.for(source, *opts)
-      require "y2network/#{source}/config_reader"
-      modname = source.to_s.split("_").map(&:capitalize).join
-      klass = Y2Network.const_get("#{modname}::ConfigReader")
-      klass.new(*opts)
+    # @return [Y2Network::Config] Network configuration
+    def config
+      Y2Network::Config.new
     end
   end
 end

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -197,5 +197,13 @@ module Y2Network
         return result if result.size == count
       end
     end
+
+    # Returns a new collection including elements from both collections
+    #
+    # @param other [InterfacesCollection] Other interfaces collection
+    # @return [InterfacesCollection] New interfaces collection
+    def +(other)
+      self.class.new(to_a + other.to_a)
+    end
   end
 end

--- a/src/lib/y2network/wicked/config_reader.rb
+++ b/src/lib/y2network/wicked/config_reader.rb
@@ -18,7 +18,7 @@
 # find current contact information at www.suse.com.
 require "yast"
 require "cfa/sysctl_config"
-require "y2network/config"
+require "y2network/config_reader"
 require "y2network/interface"
 require "y2network/routing"
 require "y2network/routing_table"
@@ -34,10 +34,12 @@ Yast.import "Host"
 module Y2Network
   module Wicked
     # This class reads the current configuration from `/etc/sysconfig` files
-    class ConfigReader
+    class ConfigReader < Y2Network::ConfigReader
       include Yast::Logger
 
-      def initialize(_opts = {}); end
+      SECTIONS = [
+        :interfaces, :connections, :drivers, :routing, :dns, :hostname
+      ].freeze
 
       # @return [Y2Network::Config] Network configuration
       def config
@@ -45,31 +47,80 @@ module Y2Network
         # NOTE: /etc/hosts cache - nothing to do with /etc/hostname
         Yast::Host.Read
 
-        interfaces = interfaces_reader.interfaces
-        s390_devices = interfaces_reader.s390_devices
-        connections = connections_configs_reader.connections(interfaces)
-        add_missing_interfaces(interfaces, connections)
+        initial_config = Config.new(source: :wicked)
 
-        routing_tables = find_routing_tables(interfaces)
+        result = SECTIONS.reduce(initial_config) do |current_config, section|
+          send("read_#{section}", current_config)
+        end
+
+        log.info "Sysconfig reader result: #{result.inspect}"
+        result
+      end
+
+    protected
+
+      # Reads the network interfaces
+      #
+      # @param config [Y2Network::Config] Initial configuration object
+      # @return [Y2Network::Config] A new configuration object including the interfaces
+      def read_interfaces(config)
+        config.update(
+          interfaces:   interfaces_reader.interfaces,
+          s390_devices: interfaces_reader.s390_devices
+        )
+      end
+
+      # Reads the connections
+      #
+      # @param config [Y2Network::Config] Initial configuration object
+      # @return [Y2Network::Config] A new configuration object including the connections
+      def read_connections(config)
+        connections = connection_configs_reader.connections(config.interfaces)
+        missing_interfaces = find_missing_interfaces(
+          connections, config.interfaces
+        )
+        config.update(
+          interfaces:  config.interfaces + missing_interfaces,
+          connections: connections
+        )
+      end
+
+      # Reads the drivers
+      #
+      # @param config [Y2Network::Config] Initial configuration object
+      # @return [Y2Network::Config] A new configuration object including the connections
+      def read_drivers(config)
+        config.update(drivers: interfaces_reader.drivers)
+      end
+
+      # Reads the routing information
+      #
+      # @param config [Y2Network::Config] Initial configuration object
+      # @return [Y2Network::Config] A new configuration object including the routing information
+      def read_routing(config)
+        routing_tables = find_routing_tables(config.interfaces)
         routing = Routing.new(
           tables:       routing_tables,
           forward_ipv4: sysctl_config_file.forward_ipv4,
           forward_ipv6: sysctl_config_file.forward_ipv6
         )
+        config.update(routing: routing)
+      end
 
-        result = Config.new(
-          interfaces:   interfaces,
-          connections:  connections,
-          s390_devices: s390_devices,
-          drivers:      interfaces_reader.drivers,
-          routing:      routing,
-          dns:          dns,
-          hostname:     hostname,
-          source:       :wicked
-        )
+      # Reads the DNS information
+      #
+      # @param config [Y2Network::Config] Initial configuration object
+      # @return [Y2Network::Config] A new configuration object including the DNS configuration
+      def read_dns(config)
+        config.update(dns: Y2Network::Wicked::DNSReader.new.config)
+      end
 
-        log.info "Sysconfig reader result: #{result.inspect}"
-        result
+      # Returns the Hostname configuration
+      #
+      # @param config [Y2Network::Config] Initial configuration object
+      # @return [Y2Network::Config] A new configuration object including the hostname information
+      def read_hostname(config)
+        config.update(hostname: Y2Network::Wicked::HostnameReader.new.config)
       end
 
     private
@@ -81,18 +132,18 @@ module Y2Network
         @interfaces_reader ||= Y2Network::Wicked::InterfacesReader.new
       end
 
-      # @param interfaces [Y2Network::InterfacesCollection] Known interfaces
       # @return [Y2Network::ConnectionConfigsCollection] Connection configurations collection
-      def connections_configs_reader
+      def connection_configs_reader
         @connection_configs_reader ||= Y2Network::Wicked::ConnectionConfigsReader.new
       end
 
       # Adds missing interfaces from connections
       #
-      # @param interfaces [Y2Network::InterfacesCollection] Known interfaces
+      # @param connections [Y2Network::InterfacesCollection] Known interfaces
       # @param interfaces [Y2Network::ConnectionConfigsCollection] Known interfaces
-      def add_missing_interfaces(interfaces, connections)
-        connections.each do |conn|
+      def find_missing_interfaces(connections, interfaces)
+        empty_collection = Y2Network::InterfacesCollection.new
+        connections.to_a.each_with_object(empty_collection) do |conn, all|
           interface = interfaces.by_name(conn.interface)
           next if interface
 
@@ -102,7 +153,7 @@ module Y2Network
             else
               PhysicalInterface.new(conn.name, hardware: Hwinfo.for(conn.name))
             end
-          interfaces << missing_interface
+          all << missing_interface
         end
       end
 
@@ -151,20 +202,6 @@ module Y2Network
           interface = interfaces.by_name(route.interface.name)
           route.interface = interface if interface
         end
-      end
-
-      # Returns the DNS configuration
-      #
-      # @return [Y2Network::DNS]
-      def dns
-        Y2Network::Wicked::DNSReader.new.config
-      end
-
-      # Returns the Hostname configuration
-      #
-      # @return [Y2Network::Hostname]
-      def hostname
-        Y2Network::Wicked::HostnameReader.new.config
       end
 
       # Returns the Sysctl_Config file class

--- a/src/lib/y2network/wicked/connection_configs_reader.rb
+++ b/src/lib/y2network/wicked/connection_configs_reader.rb
@@ -1,0 +1,51 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cfa/interface_file"
+require "y2network/connection_configs_collection"
+require "y2network/wicked/connection_config_reader"
+
+module Y2Network
+  module Wicked
+    # This class reads connection configurations from sysconfig files
+    #
+    # @see Y2Network::ConnectionConfigsCollection
+    class ConnectionConfigsReader
+      # Returns the connection configurations from sysconfig
+      #
+      # It needs the list of known interfaces in order to infer
+      # the type of the connection.
+      #
+      # @param interfaces [Y2Network::InterfacesCollection] Known interfaces
+      # @return [Y2Network::ConnectionConfigsCollection]
+      def connections(interfaces)
+        empty_collection = ConnectionConfigsCollection.new([])
+        CFA::InterfaceFile.all.each_with_object(empty_collection) do |file, conns|
+          interface = interfaces.by_name(file.interface)
+          connection = ConnectionConfigReader.new.read(
+            file.interface,
+            interface ? interface.type : nil
+          )
+          conns << connection if connection
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2network/wicked/interfaces_reader.rb
+++ b/src/lib/y2network/wicked/interfaces_reader.rb
@@ -25,84 +25,39 @@ require "y2network/physical_interface"
 require "y2network/s390_group_device"
 require "y2network/wicked/connection_config_reader"
 require "cfa/interface_file"
-require "y2network/interfaces_collection"
 require "y2network/connection_configs_collection"
+require "y2network/hwinfo"
+require "y2network/interfaces_collection"
 require "y2network/s390_group_devices_collection"
-require "y2network/wicked/type_detector"
 require "y2network/udev_rule"
+require "y2network/wicked/type_detector"
 
 Yast.import "Arch"
 
 module Y2Network
   module Wicked
-    # This class reads interfaces configuration from sysconfig files
-    #
-    # * Physical interfaces are read from the hardware.
-    # * Virtual interfaces + Connections are read from sysconfig.
+    # This class reads physical interfaces and drivers
     #
     # @see Y2Network::InterfacesCollection
-    # @see Y2Network::ConnectionConfig
     class InterfacesReader
-      # Returns the interfaces and connections configuration
-      #
-      # @return [Hash<Symbol,Object>] Returns a hash containing
-      #   an interfaces collection (with the key `:interfaces`)
-      #   and an array of connection config objects.
-      def config
-        return @config if @config
-
-        Hwinfo.reset
-        find_s390_devices
-        find_physical_interfaces
-        find_connections
-        find_drivers
-        @config = { interfaces: @interfaces, connections: @connections,
-                    drivers: @drivers, s390_devices: @s390_devices }
-      end
-
-      # Convenience method to get the s390 group devices collection
+      # Returns the collection of s390 group devices
       #
       # @return [Array<Y2Network::ConnectionConfig::Base>] Array of connection
       #   config objects.
-
       def s390_devices
-        config[:s390_devices]
-      end
+        return @s390_devices if @s390_devices
 
-      # Convenience method to get connections configuration
-      #
-      # @return [Array<Y2Network::ConnectionConfig::Base>] Array of connection
-      #   config objects.
-      def connections
-        config[:connections]
-      end
-
-      # Convenience method to get the interfaces list
-      #
-      # @return [Y2Network::InterfacesCollection]
-      def interfaces
-        config[:interfaces]
-      end
-
-      # Convenience method to get the drivers list
-      #
-      # @return [Array<Y2Network::Driver>]
-      def drivers
-        config[:drivers]
-      end
-
-    private
-
-      # Finds the s390 group devices that are not active
-      def find_s390_devices
         devices = Yast::Arch.s390 ? S390GroupDevice.all : []
         @s390_devices = Y2Network::S390GroupDevicesCollection.new(devices)
       end
 
-      # Finds the physical interfaces
-      def find_physical_interfaces
-        return if @interfaces
+      # Returns the collection of physical interfaces
+      #
+      # @return [Y2Network::InterfacesCollection]
+      def interfaces
+        return @interfaces if @interfaces
 
+        Hwinfo.reset
         physical_interfaces = Hwinfo.netcards.each_with_object([]) do |hwinfo, interfaces|
           physical_interface = build_physical_interface(hwinfo)
           next if physical_interface.type == InterfaceType::UNKNOWN
@@ -114,34 +69,23 @@ module Y2Network
         @interfaces = Y2Network::InterfacesCollection.new(physical_interfaces)
       end
 
-      # Finds the connections configurations
-      def find_connections
-        empty_collection = ConnectionConfigsCollection.new([])
-        @connections =
-          CFA::InterfaceFile.all.each_with_object(empty_collection) do |file, conns|
-            interface = @interfaces.by_name(file.interface)
-            connection = ConnectionConfigReader.new.read(
-              file.interface,
-              interface ? interface.type : nil
-            )
-            next unless connection
-
-            add_interface(connection) if interface.nil?
-            conns << connection
-          end
-      end
-
       # Finds the available drivers
-      def find_drivers
-        physical_interfaces = @interfaces.physical
-        drivers_names = physical_interfaces.flat_map(&:drivers).map(&:name)
-        drivers_names += @interfaces.physical.map(&:custom_driver).compact
-        drivers_names.uniq!
+      #
+      # The available drivers are extracted from the physical interface
+      # drivers.
+      #
+      # @return [Array<Y2Network::Driver>] List of drivers
+      def drivers
+        return @drivers if @drivers
 
-        @drivers = drivers_names.map do |name|
-          Y2Network::Driver.from_system(name)
-        end
+        physical_interfaces = interfaces.physical
+        drivers_names = physical_interfaces.flat_map(&:drivers).map(&:name)
+        drivers_names += interfaces.physical.map(&:custom_driver).compact
+        drivers_names.uniq!
+        @drivers = drivers_names.map { |n| Y2Network::Driver.from_system(n) }
       end
+
+    private
 
       # Instantiates an interface given a hash containing hardware details
       #
@@ -154,24 +98,6 @@ module Y2Network
           iface.type = InterfaceType.from_short_name(hwinfo.type) ||
             TypeDetector.type_of(iface.name) || InterfaceType::UNKNOWN
         end
-      end
-
-      # Adds a fake or virtual interface for a given connection
-      #
-      # It may happen that a configured interface is not plugged
-      # while reading the configuration. In such situations, a fake one
-      # should be added.
-      #
-      # @param conn [ConnectionConfig] Connection configuration related to the
-      #   network interface
-      def add_interface(conn)
-        interface =
-          if conn.virtual?
-            VirtualInterface.from_connection(conn)
-          else
-            PhysicalInterface.new(conn.name, hardware: Hwinfo.for(conn.name))
-          end
-        @interfaces << interface
       end
 
       # Detects the renaming mechanism used by the interface

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -583,4 +583,22 @@ describe Y2Network::Config do
       end
     end
   end
+
+  describe "#update" do
+    let(:wlan0) { Y2Network::PhysicalInterface.new("wlan0") }
+    let(:wlan0_conn) { Y2Network::ConnectionConfig::Wireless.new }
+    let(:updated_interfaces) { Y2Network::InterfacesCollection.new([wlan0]) }
+    let(:updated_connections) { Y2Network::ConnectionConfigsCollection.new([wlan0_conn]) }
+
+    it "returns an updated configuration" do
+      new_config = config.update(
+        interfaces:  updated_interfaces,
+        connections: updated_connections,
+        source:      :network_manager
+      )
+      expect(config.interfaces).to eq(interfaces)
+      expect(new_config.interfaces).to eq(updated_interfaces)
+      expect(new_config.connections).to eq(updated_connections)
+    end
+  end
 end

--- a/test/y2network/interfaces_collection_test.rb
+++ b/test/y2network/interfaces_collection_test.rb
@@ -148,4 +148,14 @@ describe Y2Network::InterfacesCollection do
       expect(collection.free_names("eth", 3)).to eq(["eth1", "eth2", "eth3"])
     end
   end
+
+  describe "#+" do
+    let(:interfaces) { [eth0] }
+    let(:other) { Y2Network::InterfacesCollection.new([br0]) }
+
+    it "returns a collection containing all the objects" do
+      new_collection = collection + other
+      expect(new_collection.to_a).to eq([eth0, br0])
+    end
+  end
 end

--- a/test/y2network/wicked/config_reader_test.rb
+++ b/test/y2network/wicked/config_reader_test.rb
@@ -19,6 +19,9 @@
 require_relative "../../test_helper"
 require "y2network/wicked/config_reader"
 require "y2network/wicked/dns_reader"
+require "y2network/connection_configs_collection"
+require "y2network/interfaces_collection"
+require "y2network/s390_group_devices_collection"
 
 describe Y2Network::Wicked::ConfigReader do
   subject(:reader) { described_class.new }
@@ -32,8 +35,8 @@ describe Y2Network::Wicked::ConfigReader do
       conn.name = "eth0"
     end
   end
-  let(:connections) { [eth0_conn] }
-  let(:s390_devices) { [] }
+  let(:connections) { Y2Network::ConnectionConfigsCollection.new([eth0_conn]) }
+  let(:s390_devices) { Y2Network::S390GroupDevicesCollection.new([]) }
   let(:drivers) { Y2Network::Driver.new("virtio_net", "") }
   let(:routes_file) { instance_double(CFA::RoutesFile, load: nil, routes: []) }
   let(:dns_reader) { instance_double(Y2Network::Wicked::DNSReader, config: dns) }
@@ -74,11 +77,13 @@ describe Y2Network::Wicked::ConfigReader do
 
     it "returns a configuration including connection configurations" do
       config = reader.config
-      expect(config.connections).to eq([eth0_conn])
+      expect(config.connections.to_a).to eq([eth0_conn])
     end
 
     context "when a connection for a not existing device is found" do
-      let(:connections) { [eth0_conn, extra_config] }
+      let(:connections) do
+        Y2Network::ConnectionConfigsCollection.new([eth0_conn, extra_config])
+      end
 
       context "and it is a virtual connection" do
         let(:extra_config) do

--- a/test/y2network/wicked/connection_configs_reader_test.rb
+++ b/test/y2network/wicked/connection_configs_reader_test.rb
@@ -1,0 +1,75 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/wicked/connection_configs_reader"
+require "y2network/physical_interface"
+require "y2network/interfaces_collection"
+require "y2network/connection_config"
+
+describe Y2Network::Wicked::ConnectionConfigsReader do
+  subject(:reader) { described_class.new }
+
+  let(:eth0) do
+    Y2Network::PhysicalInterface.new("eth0")
+  end
+
+  let(:ifcfg_eth0) do
+    instance_double(
+      CFA::InterfaceFile,
+      interface: "eth0"
+    )
+  end
+
+  let(:ifcfg_br0) do
+    instance_double(
+      CFA::InterfaceFile,
+      interface: "br0"
+    )
+  end
+
+  let(:interfaces) { Y2Network::InterfacesCollection.new([eth0]) }
+  let(:ifcfg_files) { [ifcfg_eth0, ifcfg_br0] }
+
+  let(:connection_config_reader) do
+    instance_double(Y2Network::Wicked::ConnectionConfigReader)
+  end
+  let(:conn_eth0) { instance_double(Y2Network::ConnectionConfig) }
+  let(:conn_br0) { instance_double(Y2Network::ConnectionConfig) }
+
+  describe "#connections" do
+    before do
+      allow(CFA::InterfaceFile).to receive(:all).and_return(ifcfg_files)
+      allow(Y2Network::Wicked::ConnectionConfigReader)
+        .to receive(:new).and_return(connection_config_reader)
+    end
+
+    it "returns a connection for each file" do
+      expect(connection_config_reader).to receive(:read)
+        .with("eth0", Y2Network::InterfaceType::ETHERNET)
+        .and_return(conn_eth0)
+      expect(connection_config_reader).to receive(:read)
+        .with("br0", nil)
+        .and_return(conn_br0)
+
+      connections = reader.connections(interfaces)
+      expect(connections.to_a).to eq([conn_eth0, conn_br0])
+    end
+  end
+end

--- a/test/y2network/wicked/interfaces_reader_test.rb
+++ b/test/y2network/wicked/interfaces_reader_test.rb
@@ -114,34 +114,6 @@ describe Y2Network::Wicked::InterfacesReader do
         expect(interfaces.size).to eq(1)
       end
     end
-
-    context "when a connection for a not existing device is found" do
-      let(:configured_interfaces) { ["lo", "eth0", "eth1"] }
-
-      context "and it is a virtual connection" do
-        it "creates a virtual interface" do
-          vlan = reader.interfaces.by_name("eth0.100")
-          expect(vlan).to_not be_nil
-          expect(vlan).to be_a Y2Network::VirtualInterface
-        end
-      end
-
-      context "and it is not a virtual connection" do
-        it "creates a not present physical interface" do
-          eth1 = reader.interfaces.by_name("eth1")
-          expect(eth1).to be_a Y2Network::PhysicalInterface
-          expect(eth1).to_not be_present
-        end
-      end
-    end
-  end
-
-  describe "#connections" do
-    it "reads ethernet connections" do
-      connections = reader.connections
-      conn = connections.by_name("eth0")
-      expect(conn.interface).to eq("eth0")
-    end
   end
 
   describe "#drivers" do


### PR DESCRIPTION
Initially, this code was part of #1160. However, given that we are not going to read NetworkManager settings by now, I have decided to extract only the useful bits (basically some refactoring and clean-up).

* InterfacesReader does not read connections any more. Now there is a ConnectionConfigsReader which takes care of reading the connections.
* Prepare Y2Network::Wicked::ConfigReader so it is easy to extract logic to the base class Y2Network::ConfigReader.