### PR TITLE
Fix the disable of the "Scan Network" button

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb  9 08:18:26 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix check for not present interfaces when deciding if disable
+  the "Scan Network" button during a wireless configuration.
+  (bsc#1177834).
+- 4.3.45
+
+-------------------------------------------------------------------
 Thu Feb  4 15:05:25 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Cache the hardware netcards information in order to speed up the

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,9 +1,9 @@
 -------------------------------------------------------------------
 Tue Feb  9 08:18:26 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
-- Fix check for not present interfaces when deciding if disable
-  the "Scan Network" button during a wireless configuration.
-  (bsc#1177834).
+- Fix for not present interfaces when deciding whether
+  the "Scan Network" button should be disabled or not during a
+  wireless configuration (bsc#1177834).
 - 4.3.45
 
 -------------------------------------------------------------------

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.44
+Version:        4.3.45
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/wireless_essid.rb
+++ b/src/lib/y2network/widgets/wireless_essid.rb
@@ -112,7 +112,7 @@ module Y2Network
       end
 
       def init
-        disable if @settings.newly_added?
+        disable unless present?
       end
 
       def handle
@@ -125,6 +125,10 @@ module Y2Network
     private
 
       IWLIST_PKG = "wireless-tools".freeze
+
+      def present?
+        !!@settings.interface&.hardware&.present?
+      end
 
       def scan_supported?
         return true if install_needed_packages

--- a/test/y2network/widgets/wireless_essid_test.rb
+++ b/test/y2network/widgets/wireless_essid_test.rb
@@ -48,11 +48,11 @@ describe Y2Network::Widgets::WirelessScan do
 
   describe "#init" do
     before do
-      allow(builder).to receive(:newly_added?).and_return(newly_added?)
+      allow(subject).to receive(:present?).and_return(iface_present?)
     end
 
     context "when the interface exists" do
-      let(:newly_added?) { false }
+      let(:iface_present?) { true }
 
       it "does not disable the button" do
         expect(subject).to_not receive(:disable)
@@ -61,7 +61,7 @@ describe Y2Network::Widgets::WirelessScan do
     end
 
     context "when the interface does not exist" do
-      let(:newly_added?) { true }
+      let(:iface_present?) { false }
 
       it "disables the button" do
         expect(subject).to receive(:disable)


### PR DESCRIPTION
## Problem

When a new configuration for a Wireless card is created associated to an interface which is not present, then the "Scan Network" button should be disabled. 

The problem is that the current check relies on the builder **newly_added** state which is valid for new connection configs but not for checking if a interface is physical or not.

- https://bugzilla.suse.com/show_bug.cgi?id=1177834

## Solution

- Use the hardware information for checking if the associated interface is present or not.
