### PR TITLE
Ay interfaces reader improvements

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 16 10:32:34 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Improve the AutoYaST interfaces reader handling better the IP
+  Addresses configuration. (bsc#1174353, bsc#1178107)
+- 4.2.91
+
+-------------------------------------------------------------------
 Fri Jan 22 17:03:54 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Suggest to modify the VLAN interface name when the VLAN ID is

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.90
+Version:        4.2.91
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -87,7 +87,7 @@ module Y2Network
         config.name = name_from_section(interface_section)
         config.interface = config.name # in autoyast name and interface is same
         if config.bootproto == BootProtocol::STATIC
-          # we need at leas some ip for the static configuration
+          # we need at least some ip for the static configuration
           if !interface_section.ipaddr && !interfaces_section.aliases
             msg = "Configuration for #{config.name} is invalid #{interface_section.inspect}"
             raise ArgumentError, msg
@@ -129,22 +129,19 @@ module Y2Network
       end
 
       # Loads and intializates interface_section's ipaddr attribute
+      #
+      # @param section [Hash] hash of AY profile's interface section as obtained from parser
+      #
       # @return [ConnectionConfig::IPConfig] created ipaddr object
-      def load_ipaddr(interface_section)
-        if !interface_section.ipaddr.empty?
-          ipaddr = IPAddress.from_string(interface_section.ipaddr)
-        end
+      def load_ipaddr(section)
+        ipaddr = IPAddress.from_string(section.ipaddr) if !section.ipaddr.empty?
+
         # Assign first netmask, as prefixlen has precedence so it will overwrite it
-        ipaddr.netmask = interface_section.netmask if !interface_section.netmask.to_s.empty?
-        if !interface_section.prefixlen.to_s.empty?
-          ipaddr.prefix = interface_section.prefixlen.to_i
-        end
-        if !interface_section.broadcast.empty?
-          broadcast = IPAddress.new(interface_section.broadcast)
-        end
-        if !interface_section.remote_ipaddr.empty?
-          remote = IPAddress.new(interface_section.remote_ipaddr)
-        end
+        ipaddr.netmask = section.netmask if !section.netmask.to_s.empty?
+        ipaddr.prefix = section.prefixlen.to_i if !section.prefixlen.to_s.empty?
+
+        broadcast = IPAddress.new(section.broadcast) if !section.broadcast.empty?
+        remote = IPAddress.new(section.remote_ipaddr) if !section.remote_ipaddr.empty?
 
         ConnectionConfig::IPConfig.new(
           ipaddr, broadcast: broadcast, remote_address: remote
@@ -152,6 +149,9 @@ module Y2Network
       end
 
       # Loads and initializates an IP alias according to given hash with alias details
+      #
+      # @param alias_h [Hash] hash of AY profile's alias section as obtained from parser
+      #
       # @return [ConnectionConfig::IPConfig] alias details
       def load_alias(alias_h, id: nil)
         ipaddr = IPAddress.from_string(alias_h["IPADDR"])

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -97,8 +97,8 @@ module Y2Network
         end
 
         # handle aliases
-        interface_section.aliases.each_value do |alias_h|
-          config.ip_aliases << load_alias(alias_h)
+        interface_section.aliases.values.each_with_index do |alias_h, index|
+          config.ip_aliases << load_alias(alias_h, id: "_#{index}")
         end
 
         # startmode
@@ -153,13 +153,13 @@ module Y2Network
 
       # Loads and initializates an IP alias according to given hash with alias details
       # @return [ConnectionConfig::IPConfig] alias details
-      def load_alias(alias_h)
+      def load_alias(alias_h, id: nil)
         ipaddr = IPAddress.from_string(alias_h["IPADDR"])
         # Assign first netmask, as prefixlen has precedence so it will overwrite it
         ipaddr.netmask = alias_h["NETMASK"] if alias_h["NETMASK"]
         ipaddr.prefix = alias_h["PREFIXLEN"].delete("/").to_i if alias_h["PREFIXLEN"]
 
-        ConnectionConfig::IPConfig.new(ipaddr, label: alias_h["LABEL"])
+        ConnectionConfig::IPConfig.new(ipaddr, id: id, label: alias_h["LABEL"])
       end
 
       def load_wireless(config, interface_section)

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -143,14 +143,18 @@ module Y2Network
         ConnectionConfig::IPConfig.new(ipaddr, broadcast: broadcast, remote_address: remote)
       end
 
+      # Converts a given IP Address netmask or prefix length in different
+      # formats to its prefix length value.
+      #
+      # @param value [String] IP Address prefix length or netmask in its different formats
+      # @return [Integer,nil] the given value in IP Address prefix length
+      #   format
       def prefix_for(value)
         if value.empty?
           nil
         elsif value.start_with?("/")
           value[1..-1].to_i
-        elsif value.size < 3 # one or two digits can be only prefixlen
-          value.to_i
-        elsif value =~ /^\d{3}$/
+        elsif value =~ /^\d{1,3}$/
           value.to_i
         else
           IPAddr.new("#{value}/#{value}").prefix

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -88,6 +88,7 @@ module Y2Network
       def load_generic(config, interface_section)
         config.bootproto = BootProtocol.from_name(interface_section.bootproto)
         config.name = name_from_section(interface_section)
+
         if config.name.empty?
           log.info "The interface section does not provide an interface name"
           return
@@ -106,9 +107,12 @@ module Y2Network
 
         # startmode
         if !interface_section.startmode.to_s.empty?
-          config.startmode = Startmode.create(interface_section.startmode)
+          startmode = Startmode.create(interface_section.startmode)
+          # Use proposed startmode in case that there is a typo
+          config.startmode = startmode if startmode
         end
-        if config.startmode.name == "ifplugd" && !interface_section.ifplugd_priority.to_s.empty?
+
+        if config.startmode&.name == "ifplugd" && !interface_section.ifplugd_priority.to_s.empty?
           config.startmode.priority = interface_section.ifplugd_priority
         end
 

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -52,7 +52,7 @@ module Y2Network
 
       # @return [BootProtocol] Bootproto
       attr_accessor :bootproto
-      # @return [IPConfig] Primary IP configuration
+      # @return [IPConfig, nil] Primary IP configuration
       attr_accessor :ip
       # @return [Array<IPConfig>] Additional IP configurations (also known as 'aliases')
       attr_accessor :ip_aliases

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -321,9 +321,7 @@ module Y2Network
         ip_config_default.address.prefix = nil
       elsif value.start_with?("/")
         ip_config_default.address.prefix = value[1..-1].to_i
-      elsif value.size < 3 # one or two digits can be only prefixlen
-        ip_config_default.address.prefix = value.to_i
-      elsif value =~ /^\d{3}$/
+      elsif value =~ /^\d{1,3}$/
         ip_config_default.address.prefix = value.to_i
       else
         ip_config_default.address.netmask = value

--- a/src/lib/y2network/sysconfig/connection_config_writers/base.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writers/base.rb
@@ -54,7 +54,7 @@ module Y2Network
           add_ips(conn)
 
           update_file(conn)
-          add_hostname(conn) if conn.bootproto.static?
+          add_hostname(conn) if conn.static?
         end
 
       private

--- a/src/lib/y2network/sysconfig/connection_config_writers/base.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writers/base.rb
@@ -45,7 +45,7 @@ module Y2Network
           file.lladdr = conn.lladdress
           file.startmode = conn.startmode.to_s
           file.dhclient_set_hostname = dhclient_set_hostname(conn)
-          file.ifplugd_priority = conn.startmode.priority if conn.startmode.name == "ifplugd"
+          file.ifplugd_priority = conn.startmode.priority if conn.startmode&.name == "ifplugd"
           if conn.ethtool_options && !conn.ethtool_options.empty?
             file.ethtool_options = conn.ethtool_options
           end

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -122,7 +122,7 @@ describe Y2Network::Autoinst::InterfacesReader do
     end
 
     context "when the interface section defines a set of IP aliases" do
-      it "initializes the IP aliases correctly" do
+      it "initializes the IPConfig object properly" do
         eth0_config = subject.config.by_name("eth0")
         expect(eth0_config.ip_aliases.size).to eq(3)
         expect(eth0_config.ip_aliases.map(&:id)).to eql(["_0", "_1", "_2"])
@@ -138,7 +138,7 @@ describe Y2Network::Autoinst::InterfacesReader do
           eth0["aliases"]["alias1"].delete("IPADDR")
         end
 
-        it "aliases without the IPADDR are skipped" do
+        it "skips those aliases with no IPADDR" do
           eth0_config = subject.config.by_name("eth0")
           expect(eth0_config.ip_aliases.size).to eq(2)
           expect(eth0_config.ip_aliases.map(&:id)).to eql(["_0", "_2"])

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -89,6 +89,16 @@ describe Y2Network::Autoinst::InterfacesReader do
       expect(eth1_config.dhclient_set_hostname).to eq false
     end
 
+    context "when a interface section does not provide an interface or device name" do
+      before do
+        eth1["device"] = ""
+      end
+
+      it "skips the connection configuration for that interface section" do
+        expect(subject.config.size).to eq(1)
+      end
+    end
+
     context "when an interface is configured using an static IP configuration" do
       context "but does not provide an ipaddr" do
         before do

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -30,37 +30,45 @@ describe Y2Network::Autoinst::InterfacesReader do
     Y2Network::AutoinstProfile::InterfacesSection.new_from_hashes(interfaces_profile)
   end
 
-  let(:interfaces_profile) do
-    [
-      {
-        "startmode"             => "auto",
-        "bootproto"             => "static",
-        "device"                => "eth1",
-        "name"                  => "",
-        "ipaddr"                => "192.168.10.10",
-        "dhclient_set_hostname" => "no",
-        "prefixlen"             => "24"
-      },
-      {
-        "bootproto"             => "dhcp",
-        "name"                  => "eth0",
-        "startmode"             => "auto",
-        "dhclient_set_hostname" => "yes",
-        "aliases"               => {
-          "alias0" => {
-            "IPADDR"    => "10.100.0.1",
-            "PREFIXLEN" => "24",
-            "LABEL"     => "test"
-          },
-          "alias1" => {
-            "IPADDR"    => "10.100.0.2",
-            "PREFIXLEN" => "24",
-            "LABEL"     => "test2"
-          }
+  let(:eth1) do
+    {
+      "startmode"             => "auto",
+      "bootproto"             => "static",
+      "device"                => "eth1",
+      "name"                  => "",
+      "ipaddr"                => "192.168.10.10",
+      "dhclient_set_hostname" => "no",
+      "netmask"               => "255.255.255.0"
+    }
+  end
+
+  let(:eth0) do
+    {
+      "bootproto"             => "dhcp",
+      "name"                  => "eth0",
+      "startmode"             => "auto",
+      "dhclient_set_hostname" => "yes",
+      "aliases"               => {
+        "alias0" => {
+          "IPADDR"    => "10.100.0.1",
+          "PREFIXLEN" => "24",
+          "LABEL"     => "test"
+        },
+        "alias1" => {
+          "IPADDR"    => "10.100.0.2",
+          "PREFIXLEN" => "/24",
+          "LABEL"     => "test2"
+        },
+        "alias2" => {
+          "IPADDR"  => "10.100.0.3",
+          "NETMASK" => "255.255.0.0",
+          "LABEL"   => "TEST3"
         }
       }
-    ]
+    }
   end
+
+  let(:interfaces_profile) { [eth1, eth0] }
 
   describe "#config" do
     it "builds a new Y2Network::ConnectionConfigsCollection" do
@@ -72,12 +80,60 @@ describe Y2Network::Autoinst::InterfacesReader do
       eth0_config = subject.config.by_name("eth0")
       expect(eth0_config.startmode).to eq Y2Network::Startmode.create("auto")
       expect(eth0_config.bootproto).to eq Y2Network::BootProtocol.from_name("dhcp")
-      expect(eth0_config.ip_aliases.size).to eq 2
+      expect(eth0_config.ip_aliases.size).to eq 3
       expect(eth0_config.dhclient_set_hostname).to eq true
       eth1_config = subject.config.by_name("eth1")
       expect(eth1_config.name).to eq("eth1")
+      expect(eth1_config.ip.address.prefix).to eql(24)
       expect(eth1_config.ip.address.to_s).to eq("192.168.10.10/24")
       expect(eth1_config.dhclient_set_hostname).to eq false
+    end
+
+    context "when an interface is configured using an static IP configuration" do
+      context "but does not provide an ipaddr" do
+        before do
+          eth1["ipaddr"] = ""
+        end
+
+        it "does not set any IPConfig at all" do
+          eth1_config = subject.config.by_name("eth1")
+          expect(eth1_config.ip).to eql(nil)
+        end
+      end
+
+      context "and provides a netmask in prefix length format" do
+        before { eth1["netmask"] = "16" }
+
+        it "initializes correctly the IPConfig" do
+          eth1_config = subject.config.by_name("eth1")
+          expect(eth1_config.ip.address.to_s).to eql("192.168.10.10/16")
+        end
+      end
+    end
+
+    context "when the interface section defines a set of IP aliases" do
+      it "initializes the IP aliases correctly" do
+        eth0_config = subject.config.by_name("eth0")
+        expect(eth0_config.ip_aliases.size).to eq(3)
+        expect(eth0_config.ip_aliases.map(&:id)).to eql(["_0", "_1", "_2"])
+        alias1 = eth0_config.ip_aliases.find { |a| a.id == "_1" }
+        expect(alias1.address.to_s).to eql("10.100.0.2/24")
+        expect(alias1.label).to eql("test2")
+        alias2 = eth0_config.ip_aliases.find { |a| a.label == "TEST3" }
+        expect(alias2.address.to_s).to eql("10.100.0.3/16")
+      end
+
+      context "and some of the aliases do not provide an IPADDR" do
+        before do
+          eth0["aliases"]["alias1"].delete("IPADDR")
+        end
+
+        it "aliases without the IPADDR are skipped" do
+          eth0_config = subject.config.by_name("eth0")
+          expect(eth0_config.ip_aliases.size).to eq(2)
+          expect(eth0_config.ip_aliases.map(&:id)).to eql(["_0", "_2"])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

The handling of the parsed AutoYAST network interfaces sections is very fragile and prone to errors, specially when the configuration is declared manually.

In case that some of the elements contain a typo it could crash miserably, we should handle it better.

- https://trello.com/c/1jEzPZ0Q/2302-l3-sles15-sp2-1174353-ipv6-installation-failed-new-64-64-ipaddrinvalidaddresserror
  - https://bugzilla.suse.com/show_bug.cgi?id=1174353
- https://trello.com/c/cu1axq4H/2261-sles15-sp2-p2-1178107-l3-autoyast-install-of-sles15-sp2-has-error-internal-error-caller-usr-lib64-ruby-250-ipaddrrb565in-initial 
  - https://bugzilla.suse.com/show_bug.cgi?id=1178107

## Solution

This PR just extends (https://github.com/yast/yast-network/pull/1144)

In the original PR the exception raised is useless as the section attributes are always defined as an empty object.

In this PR we basically will set the IPConfig to nil when the IPADDR is not defined or defined as empty allowing to write somethine like:

```xml
<interfaces config:type="list">
  <interface>
    <device>eth0</device>
    <bootproto>static</bootproto>
    <startmode>auto</bootproto>
  </interface>
</interfaces>
```

It also covers cases when the netmask provided uses the prefix length format:

```xml
<interfaces config:type="list">
  <interface>
    <device>eth1</device>
    <startmode>auto</startmode>
    <bootproto>static</bootproto>
    <ipaddr>192.168.1.100</ipaddr>
    <netmask>16</netmask>
  </interface>
```

It will skip aliases which do not define an IP address and interfaces sections that does not provide a device name.
Last but not least, in case of a typo when defining the startmode it will fallback to the proposed one.

## TODO

There are different scenarios that will not be rescued properly in case that some of the elements contain typos, like a wrong bootprotocol, startmode ... etc. We could pass the AutoYaST issues list as an argument to the AutoYaST config reader populating it will all the errors we found during a read. I will leave it to implement as a separate PR
