### PR TITLE
AY: Add the errors found during the read to the AutoInstall issues list

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 22 13:53:49 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Added AutoYaST interfaces section errors reporting (bsc#1174353,
+  bsc#1178107).
+- 4.3.49
+
+-------------------------------------------------------------------
 Mon Feb 22 09:32:34 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Improve the AutoYaST interfaces reader handling better the IP

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.48
+Version:        4.3.49
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -101,7 +101,7 @@ module Y2Network
             config.bootproto = bootproto
           else
             issues_list.add(Y2Storage::AutoinstIssues::InvalidValue,
-              interface_section, :bootproto, config.bootproto)
+              interface_section, :bootproto, config.bootproto&.name)
           end
         else
           issues_list.add(Y2Storage::AutoinstIssues::MissingValue, interface_section, :bootproto)
@@ -132,7 +132,7 @@ module Y2Network
             config.startmode = startmode
           else
             issues_list.add(Y2Storage::AutoinstIssues::InvalidValue,
-              interface_section, :startmode, config.startmode)
+              interface_section, :startmode, config.startmode&.name)
           end
         end
 

--- a/src/lib/y2network/autoinst_profile/networking_section.rb
+++ b/src/lib/y2network/autoinst_profile/networking_section.rb
@@ -36,29 +36,46 @@ module Y2Network
     #
     # @see RoutingSection
     class NetworkingSection < Installation::AutoinstProfile::SectionWithAttributes
-      # @return [Boolean]
-      attr_accessor :setup_before_proposal
-      # @return [Boolean]
-      attr_accessor :start_immediately
-      # @return [Boolean]
-      attr_accessor :keep_install_network
-      # @return [Boolean]
-      attr_accessor :virt_bridge_proposal
-      # @return [Integer]
-      attr_accessor :strict_ip_check_timeout
+      def self.attributes
+        [
+          { name: :setup_before_proposal },
+          { name: :start_immediately },
+          { name: :keep_install_network },
+          { name: :virt_bridge_proposal },
+          { name: :strict_ip_check_timeout },
+          { name: :routing },
+          { name: :dns },
+          { name: :interfaces },
+          { name: :udev_rules },
+          { name: :s390_devices },
+          { name: :managed }
+        ]
+      end
 
-      # @return [RoutingSection]
-      attr_accessor :routing
-      # @return [DNSSection]
-      attr_accessor :dns
-      # @return [InterfacesSection]
-      attr_accessor :interfaces
-      # @return [UdevRulesSection]
-      attr_accessor :udev_rules
-      # @return [S390DevicesSection]
-      attr_accessor :s390_devices
-      # @return [Boolean]
-      attr_accessor :managed
+      define_attr_accessors
+
+      # @!attribute setup_before_proposal
+      #  @return [Boolean]
+      # @!attribute start_immediately
+      #  @return [Boolean]
+      # @!attribute keep_install_network
+      #  @return [Boolean]
+      # @!attribute virt_bridge_proposal
+      #  @return [Boolean]
+      # @!attribute strict_ip_check_timeout
+      #  @return [Boolean]
+      # @!attribute routing
+      #   @return [RoutingSection]
+      # @!attribute dns
+      #   @return [DNSSection]
+      # @!attribute interfaces
+      #   @return [InterfacesSection]
+      # @!attribute udev_rules
+      #   @return [UdevRulesSection]
+      # @!attribute s390_devices
+      #   @return [S390DevicesSection]
+      # @!attribute managed
+      #  @return [Boolean]
 
       # Creates an instance based on the profile representation used by the AutoYaST modules
       # (hash with nested hashes and arrays).

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -72,6 +72,14 @@ describe Y2Network::Autoinst::InterfacesReader do
   let(:interfaces_profile) { [eth1, eth0] }
 
   describe "#config" do
+    let(:i_list) { double("IssuesList", add: nil) }
+    let(:missing_value) { Y2Storage::AutoinstIssues::MissingValue }
+    let(:invalid_value) { Y2Storage::AutoinstIssues::InvalidValue }
+
+    before do
+      allow(Yast::AutoInstall).to receive(:issues_list).and_return(i_list)
+    end
+
     it "builds a new Y2Network::ConnectionConfigsCollection" do
       expect(subject.config).to be_a Y2Network::ConnectionConfigsCollection
       expect(subject.config.size).to eq(2)
@@ -91,59 +99,111 @@ describe Y2Network::Autoinst::InterfacesReader do
       expect(eth1_config.dhclient_set_hostname).to eq false
     end
 
-    context "when a interface section does not provide an interface or device name" do
-      before do
-        eth1["device"] = ""
-      end
-
-      it "skips the connection configuration for that interface section" do
-        expect(subject.config.size).to eq(1)
-      end
-    end
-
-    context "when an interface is configured using an static IP configuration" do
-      context "but does not provide an ipaddr" do
+    context "when reading an interface section" do
+      context "which does not provide an interface or device name" do
         before do
-          eth1["ipaddr"] = ""
+          eth1["device"] = ""
         end
 
-        it "does not set any IPConfig at all" do
-          eth1_config = subject.config.by_name("eth1")
-          expect(eth1_config.ip).to eql(nil)
+        it "skips the connection configuration for that interface section" do
+          expect(subject.config.size).to eq(1)
+        end
+
+        it "adds an missing value issue to the AutoInstall issues list" do
+          expect(i_list).to receive(:add).with(missing_value, anything, :name)
+          subject.config
         end
       end
 
-      context "and provides a netmask in prefix length format" do
-        before { eth1["netmask"] = "16" }
-
-        it "initializes correctly the IPConfig" do
-          eth1_config = subject.config.by_name("eth1")
-          expect(eth1_config.ip.address.to_s).to eql("192.168.10.10/16")
-        end
-      end
-    end
-
-    context "when the interface section defines a set of IP aliases" do
-      it "initializes the IPConfig object properly" do
-        eth0_config = subject.config.by_name("eth0")
-        expect(eth0_config.ip_aliases.size).to eq(3)
-        expect(eth0_config.ip_aliases.map(&:id)).to eql(["_0", "_1", "_2"])
-        alias1 = eth0_config.ip_aliases.find { |a| a.id == "_1" }
-        expect(alias1.address.to_s).to eql("10.100.0.2/24")
-        expect(alias1.label).to eql("test2")
-        alias2 = eth0_config.ip_aliases.find { |a| a.label == "TEST3" }
-        expect(alias2.address.to_s).to eql("10.100.0.3/16")
-      end
-
-      context "and some of the aliases do not provide an IPADDR" do
+      context "which does not provide a bootproto attr" do
         before do
-          eth0["aliases"]["alias1"].delete("IPADDR")
+          eth1["bootproto"] = ""
         end
 
-        it "skips those aliases with no IPADDR" do
+        it "adds an missing value issue to the AutoInstall issues list" do
+          expect(i_list).to receive(:add).with(missing_value, anything, :bootproto)
+          subject.config
+        end
+      end
+
+      context "which provides a wrong bootproto attr" do
+        let(:default) { Y2Network::BootProtocol.from_name("static") }
+
+        before do
+          eth1["bootproto"] = "dchp"
+        end
+
+        it "does not touch the bootproto keeping the default connection config value" do
+          eth1_config = subject.config.by_name("eth1")
+          expect(eth1_config.bootproto).to eql(default)
+        end
+
+        it "adds an invalid value issue to the AutoInstall issues list" do
+          expect(i_list).to receive(:add).with(invalid_value, anything, :bootproto, default)
+          subject.config
+        end
+      end
+
+      context "which provides a wrong startmode attr" do
+        before do
+          eth1["startmode"] = "auo"
+        end
+
+        it "does not touch the bootproto keeping the default connection config value" do
+          eth1_config = subject.config.by_name("eth1")
+          expect(eth1_config.startmode).to be_a(Y2Network::Startmode)
+        end
+
+        it "adds an invalid value issue to the AutoInstall issues list" do
+          expect(i_list).to receive(:add).with(invalid_value, anything, :startmode, anything)
+          subject.config
+        end
+      end
+
+      context "and it provides an static IP configuration" do
+        context "but does not provide an ipaddr" do
+          before do
+            eth1["ipaddr"] = ""
+          end
+
+          it "does not set any IPConfig at all" do
+            eth1_config = subject.config.by_name("eth1")
+            expect(eth1_config.ip).to eql(nil)
+          end
+        end
+
+        context "and provides a netmask in prefix length format" do
+          before { eth1["netmask"] = "16" }
+
+          it "initializes correctly the IPConfig" do
+            eth1_config = subject.config.by_name("eth1")
+            expect(eth1_config.ip.address.to_s).to eql("192.168.10.10/16")
+          end
+        end
+      end
+
+      context "which defines a set of IP aliases" do
+        it "initializes the IPConfig objects for each of those aliases correctly" do
           eth0_config = subject.config.by_name("eth0")
-          expect(eth0_config.ip_aliases.size).to eq(2)
-          expect(eth0_config.ip_aliases.map(&:id)).to eql(["_0", "_2"])
+          expect(eth0_config.ip_aliases.size).to eq(3)
+          expect(eth0_config.ip_aliases.map(&:id)).to eql(["_0", "_1", "_2"])
+          alias1 = eth0_config.ip_aliases.find { |a| a.id == "_1" }
+          expect(alias1.address.to_s).to eql("10.100.0.2/24")
+          expect(alias1.label).to eql("test2")
+          alias2 = eth0_config.ip_aliases.find { |a| a.label == "TEST3" }
+          expect(alias2.address.to_s).to eql("10.100.0.3/16")
+        end
+
+        context "and some of the aliases do not provide an IPADDR" do
+          before do
+            eth0["aliases"]["alias1"].delete("IPADDR")
+          end
+
+          it "skips those aliases with no IPADDR" do
+            eth0_config = subject.config.by_name("eth0")
+            expect(eth0_config.ip_aliases.size).to eq(2)
+            expect(eth0_config.ip_aliases.map(&:id)).to eql(["_0", "_2"])
+          end
         end
       end
     end

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -73,8 +73,8 @@ describe Y2Network::Autoinst::InterfacesReader do
 
   describe "#config" do
     let(:i_list) { double("IssuesList", add: nil) }
-    let(:missing_value) { Y2Storage::AutoinstIssues::MissingValue }
-    let(:invalid_value) { Y2Storage::AutoinstIssues::InvalidValue }
+    let(:missing_value) { ::Installation::AutoinstIssues::MissingValue }
+    let(:invalid_value) { ::Installation::AutoinstIssues::InvalidValue }
 
     before do
       allow(Yast::AutoInstall).to receive(:issues_list).and_return(i_list)
@@ -110,7 +110,9 @@ describe Y2Network::Autoinst::InterfacesReader do
         end
 
         it "adds an missing value issue to the AutoInstall issues list" do
-          expect(i_list).to receive(:add).with(missing_value, anything, :name)
+          eth1_section = interfaces_section.interfaces[0]
+          expect(i_list).to receive(:add)
+            .with(missing_value, eth1_section, :name, "The section will be skipped")
           subject.config
         end
       end
@@ -121,7 +123,8 @@ describe Y2Network::Autoinst::InterfacesReader do
         end
 
         it "adds an missing value issue to the AutoInstall issues list" do
-          expect(i_list).to receive(:add).with(missing_value, anything, :bootproto)
+          eth1_section = interfaces_section.interfaces[0]
+          expect(i_list).to receive(:add).with(missing_value, eth1_section, :bootproto)
           subject.config
         end
       end
@@ -139,7 +142,9 @@ describe Y2Network::Autoinst::InterfacesReader do
         end
 
         it "adds an invalid value issue to the AutoInstall issues list" do
-          expect(i_list).to receive(:add).with(invalid_value, anything, :bootproto, "static")
+          eth1_section = interfaces_section.interfaces[0]
+          expect(i_list).to receive(:add)
+            .with(invalid_value, eth1_section, :bootproto, "dchp", "replaced by 'static'")
           subject.config
         end
       end
@@ -155,7 +160,8 @@ describe Y2Network::Autoinst::InterfacesReader do
         end
 
         it "adds an invalid value issue to the AutoInstall issues list" do
-          expect(i_list).to receive(:add).with(invalid_value, anything, :startmode, anything)
+          eth1_section = interfaces_section.interfaces[0]
+          expect(subject).to receive(:add_invalid_issue).with(eth1_section, :startmode, anything)
           subject.config
         end
       end

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -139,7 +139,7 @@ describe Y2Network::Autoinst::InterfacesReader do
         end
 
         it "adds an invalid value issue to the AutoInstall issues list" do
-          expect(i_list).to receive(:add).with(invalid_value, anything, :bootproto, default)
+          expect(i_list).to receive(:add).with(invalid_value, anything, :bootproto, "static")
           subject.config
         end
       end

--- a/test/y2network/autoinst_profile/networking_section_test.rb
+++ b/test/y2network/autoinst_profile/networking_section_test.rb
@@ -65,16 +65,9 @@ describe Y2Network::AutoinstProfile::NetworkingSection do
     let(:dns_section) { double("DNSSection") }
     let(:net_udev) { {} }
 
-    before do
-      allow(Y2Network::AutoinstProfile::RoutingSection).to receive(:new_from_hashes)
-        .with(routing, described_class).and_return(routing_section)
-      allow(Y2Network::AutoinstProfile::DNSSection).to receive(:new_from_hashes)
-        .with(dns, described_class).and_return(dns_section)
-    end
-
     it "initializes the routing section" do
       section = described_class.new_from_hashes(hash)
-      expect(section.routing).to eq(routing_section)
+      expect(section.routing).to be_a(Y2Network::AutoinstProfile::RoutingSection)
     end
 
     context "when no routing section is present" do
@@ -88,7 +81,7 @@ describe Y2Network::AutoinstProfile::NetworkingSection do
 
     it "initializes the dns section" do
       section = described_class.new_from_hashes(hash)
-      expect(section.dns).to eq(dns_section)
+      expect(section.dns).to be_a(Y2Network::AutoinstProfile::DNSSection)
     end
 
     context "when no dns section is present" do


### PR DESCRIPTION
It extends #1165 adding the errors found to the Yast::AutoInstall.issues_list.

## Example

```xml
    <interfaces config:type="list">
      <interface>
        <bootproto>stratic</bootproto>
        <startmode>auto</startmode>
        <device>enp1s0</device>
        <ipaddr>192.168.122.10</ipaddr>
        <netmask>24</netmask>
      </interface>
      <interface>
        <bootproto>static</bootproto>
        <startmode>auh</startmode>
        <device>enp1s1</device>
      </interface>
      <interface>
        <bootproto>dhcp</bootproto>
        <startmode>hotplug</startmode>
      </interface>
    </interfaces>
```

![AutoYaSTIssuesReportLast](https://user-images.githubusercontent.com/7056681/108834977-bb394880-75c6-11eb-836c-dea45c7d79fc.png)