### PR TITLE
Adapt unit test to recent changes in Yast::Report

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 19 10:28:29 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.47
+
+-------------------------------------------------------------------
 Wed Feb 10 10:30:53 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Allow to disable the proposal of the bridge network configuration

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.46
+Version:        4.3.47
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/test/y2network/wicked/config_reader_test.rb
+++ b/test/y2network/wicked/config_reader_test.rb
@@ -70,6 +70,14 @@ describe Y2Network::Wicked::ConfigReader do
   around { |e| change_scr_root(File.join(DATA_PATH, "scr_read"), &e) }
 
   describe "#config" do
+    let(:sysctl_file) do
+      instance_double(CFA::SysctlConfig, forward_ipv4: true).as_null_object
+    end
+
+    before do
+      allow(CFA::SysctlConfig).to receive(:new).and_return(sysctl_file)
+    end
+
     it "returns a configuration including network devices" do
       config = reader.config
       expect(config.interfaces.map(&:name)).to eq(["eth0", "wlan0"])


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-autoinstallation, yast-add-on, yast-bootloader, yast-configuration-management, yast-dns-server, yast-installation, yast-kdump, yast-network, yast-nfs-client, yast-ntp-client, yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager, yast-samba-server, yast-packager, yast-registration and yast-sysconfig.

This should fix the problem for this repository.