### PR TITLE
/etc/hosts record not created automatically in AY installation

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Mar  3 09:45:02 UTC 2021 - Michal Filka <mfilka@suse.com>
+
+- bnc#1178260
+  - fixed writing a record into /etc/hosts for static ips during
+    AY installation
+- 4.2.94
+
+-------------------------------------------------------------------
 Tue Mar  2 11:48:59 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Support both 'bridge_forwarddelay' and 'bridge_forward_delay'.

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.93
+Version:        4.2.94
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -157,6 +157,8 @@ module Yast
       end
       hosts_config = hosts_config.to_h.delete_if { |k, v| k.empty? || v.empty? }
 
+      return false if hosts_config.empty?
+
       configure_submodule(Host, "hosts" => hosts_config, write: write)
     end
 

--- a/src/lib/y2network/clients/auto.rb
+++ b/src/lib/y2network/clients/auto.rb
@@ -23,6 +23,7 @@ Yast.import "Lan"
 Yast.import "Progress"
 Yast.import "Map"
 Yast.import "Host"
+Yast.import "Stage"
 
 module Y2Network
   module Clients
@@ -89,7 +90,7 @@ module Y2Network
 
         Yast::Lan.Import(modified_profile)
 
-        update_etc_hosts
+        update_etc_hosts if Yast::Stage.cont
 
         true
       end
@@ -124,12 +125,9 @@ module Y2Network
         return if !config
 
         static_connections = config.connections.select(&:static?)
-        static_ips = static_connections.map { |c| c.ip.address.address.to_s }
-
-        log.info("Updating /etc/hosts with #{static_ips} #{config.hostname.static}")
-
-        static_ips.each do |sip|
-          Yast::Host.Update(config.hostname.static, config.hostname.static, sip)
+        static_connections.each do |connection|
+          log.info("Updating /etc/hosts with #{connection.ip.address.address} #{config.hostname.static}")
+          connection.hostname = config.hostname.static
         end
 
         nil

--- a/src/lib/y2network/clients/auto.rb
+++ b/src/lib/y2network/clients/auto.rb
@@ -89,7 +89,7 @@ module Y2Network
 
         Yast::Lan.Import(modified_profile)
 
-        update_etc_hosts(profile)
+        update_etc_hosts
 
         true
       end
@@ -128,7 +128,9 @@ module Y2Network
 
         log.info("Updating /etc/hosts with #{static_ips} #{config.hostname.static}")
 
-        static_ips.each { |sip| Yast::Host.Update(config.hostname.static, config.hostname.static, sip) }
+        static_ips.each do |sip|
+          Yast::Host.Update(config.hostname.static, config.hostname.static, sip)
+        end
 
         nil
       end

--- a/src/lib/y2network/clients/auto.rb
+++ b/src/lib/y2network/clients/auto.rb
@@ -126,7 +126,8 @@ module Y2Network
 
         static_connections = config.connections.select(&:static?)
         static_connections.each do |connection|
-          log.info("Updating /etc/hosts with #{connection.ip.address.address} #{config.hostname.static}")
+          log.info("Updating /etc/hosts with" \
+                   " #{connection.ip.address.address} #{config.hostname.static}")
           connection.hostname = config.hostname.static
         end
 

--- a/src/lib/y2network/ip_address.rb
+++ b/src/lib/y2network/ip_address.rb
@@ -92,9 +92,15 @@ module Y2Network
 
     # Determines whether two addresses are equivalent
     #
-    # @param other [IPAddress] The address to compare with
+    # @param other [IPAddress, String] The address to compare with.
+    #                                  When string it can look like <ip>/<prefix>
     # @return [Boolean]
     def ==(other)
+      if other.is_a?(String)
+        param = other.split("/")
+        other = IPAddress.new(*param)
+      end
+
       address == other.address && prefix == other.prefix
     end
 

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -650,10 +650,10 @@ module Yast
 
       # FIXME: hotfix for Host::ResolveHostnameToStaticIPs - the functionality is
       # not implemented in new config readers/writers which are used in second stage
-      static_connections = config.connections.select { |c| c.static? }
+      static_connections = config.connections.select(&:static?)
       static_ips = static_connections.map { |c| c.ip.address.address.to_s }
 
-      log.info("Lan::Import: updating /etc/hosts with static ips #{static_ips} and hostname #{config.hostname.static}")
+      log.info("Lan::Import: updating /etc/hosts with #{static_ips} #{config.hostname.static}")
 
       static_ips.each { |sip| Host.Update(config.hostname.static, config.hostname.static, sip) }
 

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -648,15 +648,6 @@ module Yast
       # not defined <host> section (bsc#1058396)
       Host.Read
 
-      # FIXME: hotfix for Host::ResolveHostnameToStaticIPs - the functionality is
-      # not implemented in new config readers/writers which are used in second stage
-      static_connections = config.connections.select(&:static?)
-      static_ips = static_connections.map { |c| c.ip.address.address.to_s }
-
-      log.info("Lan::Import: updating /etc/hosts with #{static_ips} #{config.hostname.static}")
-
-      static_ips.each { |sip| Host.Update(config.hostname.static, config.hostname.static, sip) }
-
       @ipv6 = settings.fetch("ipv6", true)
 
       true


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1178260

## Problem ##

If you have static interface configuration and a hostname definition in AY profile it is expected to end up with record like

<ip> <hostname> ...

in /etc/hosts on the installed system

## Solution ##

Had two phases - for first stage only installation where a minor tweak in return value was enough. Second stage fix was a little bit more complicated as it was re-written to  use new network-ng. Also both fixes work only for installation workflows and not when running AY in installed system.