### PR TITLE
Support bridge_forwarddelay and bridge_forward_delay

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar  2 11:48:59 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Support both 'bridge_forwarddelay' and 'bridge_forward_delay'.
+  The latter takes precedence (bsc#1180944).
+- 4.2.93
+
+-------------------------------------------------------------------
 Fri Feb 26 15:23:33 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixes some usability issues (bsc#1177834, bsc#1182781):

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.92
+Version:        4.2.93
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -204,6 +204,8 @@ bridge_settings = (
   element bridge              { "yes" | "no" }? &
   element bridge_ports        { text }? &
   element bridge_stp          { "on" | "off" }? &
+  element bridge_forward_delay { text }? &
+  # backward compatibility (bsc#1180944)
   element bridge_forwarddelay { text }?
 )
 

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -272,7 +272,8 @@ module Y2Network
 
       # Overwrite base method to load also nested aliases
       def init_from_hashes(hash)
-        super
+        hash = rename_key(hash, "bridge_forwarddelay", "bridge_forward_delay")
+        super(hash)
 
         self.aliases = hash["aliases"] if hash["aliases"]
       end
@@ -392,6 +393,23 @@ module Y2Network
         # power dropped
         # peap version not supported yet
         # on other hand ap scan mode is not in autoyast
+      end
+
+      # Renames a key from the hash
+      #
+      # It returns a new hash with the key {old_name} renamed to {new_name}. The rename will
+      # not happen if the {to} key already exists.
+      #
+      # @param hash [Hash]
+      # @param old_name [String] Original key name
+      # @param new_name [String] New key name
+      # @return [Hash]
+      def rename_key(hash, old_name, new_name)
+        return hash if hash[new_name] || hash[old_name].nil?
+
+        new_hash = hash.clone
+        new_hash[new_name] = new_hash.delete(old_name)
+        new_hash
       end
     end
   end

--- a/test/y2network/autoinst_profile/interface_section_test.rb
+++ b/test/y2network/autoinst_profile/interface_section_test.rb
@@ -72,6 +72,37 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
       section = described_class.new_from_hashes(hash)
       expect(section.bootproto).to eq "dhcp4"
     end
+
+    context "when bridge_forwarddelay is set" do
+      let(:hash) do
+        {
+          "bootproto"           => "dhcp4",
+          "device"              => "br0",
+          "bridge_forwarddelay" => "4"
+        }
+      end
+
+      it "sets bridge_forward_delay to the given value" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.bridge_forward_delay).to eq("4")
+      end
+    end
+
+    context "when bridge_forwarddelay and bridge_forward_delay are both set" do
+      let(:hash) do
+        {
+          "bootproto"            => "dhcp4",
+          "device"               => "br0",
+          "bridge_forwarddelay"  => "4",
+          "bridge_forward_delay" => "5"
+        }
+      end
+
+      it "bridge_forward_delay takes precedence" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.bridge_forward_delay).to eq("5")
+      end
+    end
   end
 
   describe "#to_hashes" do


### PR DESCRIPTION
In network-ng refactorization, the section attribute was wrongly named (`bridge_forward_delay` instead of `bridge_forwarddelay`). The problem is that new profiles generated since then will have a different attribute than older ones. To fix the problem, we have decided to support both forms. The new one takes precedence.
