### PR TITLE
Permit to slave an ethernet card in s390 arch

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -3,6 +3,7 @@ Wed Mar  3 12:11:39 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not filter ethernet cards when configuring a bond in s390
   (bsc#1182911).
+- Only propose a 1492 MTU size when configuring an LCS interface.
 - 4.2.95
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar  3 12:11:39 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not filter ethernet cards when configuring a bond in s390
+  (bsc#1182911).
+- 4.2.95
+
+-------------------------------------------------------------------
 Wed Mar  3 09:45:02 UTC 2021 - Michal Filka <mfilka@suse.com>
 
 - bnc#1178260

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.94
+Version:        4.2.95
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -115,7 +115,7 @@ module Y2Network
       #   defaults and propose have more tricky config that depends on env, product, etc.
       def propose
         propose_startmode
-        self.mtu = PROPOSED_PPPOE_MTU if Yast::Arch.s390 && (type.lcs? || type.ethernet?)
+        self.mtu = PROPOSED_PPPOE_MTU if Yast::Arch.s390 && type.lcs?
       end
 
       def propose_startmode

--- a/src/lib/y2network/interface_config_builders/bonding.rb
+++ b/src/lib/y2network/interface_config_builders/bonding.rb
@@ -97,7 +97,7 @@ module Y2Network
         Yast.include self, "network/lan/s390.rb"
 
         # check if the device is L2 capable on s390
-        if Yast::Arch.s390
+        if Yast::Arch.s390 && !iface.type.ethernet?
           s390_config = s390_ReadQethConfig(iface.name)
 
           # only devices with L2 support can be enslaved in bond. See bnc#719881

--- a/test/y2network/interface_config_builders/bonding_test.rb
+++ b/test/y2network/interface_config_builders/bonding_test.rb
@@ -72,7 +72,7 @@ describe Y2Network::InterfaceConfigBuilders::Bonding do
 
   describe "#bondable_interfaces" do
     shared_examples "interface filters" do
-      context "when an interface does not have a connection config yet" do
+      context "and the interface does not have a connection config yet" do
         let(:connection_name) { "iface2" } # only iface2 has a config
 
         it "includes the interface without a connection config" do
@@ -80,7 +80,7 @@ describe Y2Network::InterfaceConfigBuilders::Bonding do
         end
       end
 
-      context "when an interface has a connection config" do
+      context "and the interface has a connection config" do
         let(:connection_name) { "iface1" }
 
         context "and there already is a master connection" do
@@ -109,6 +109,8 @@ describe Y2Network::InterfaceConfigBuilders::Bonding do
 
     context "when the architecture is s390" do
       let(:s390) { true }
+      let(:interface1) { Y2Network::Interface.new("iface1", type: Y2Network::InterfaceType::QETH) }
+      let(:interface2) { Y2Network::Interface.new("iface1", type: Y2Network::InterfaceType::QETH) }
 
       before do
         allow(Yast::FileUtils).to receive(:IsDirectory).and_return(true)
@@ -133,7 +135,7 @@ describe Y2Network::InterfaceConfigBuilders::Bonding do
       end
     end
 
-    context "when the architecture is not s390" do
+    context "when the architecture is not s390 or the interface is an ethernet one" do
       let(:s390) { false }
 
       include_examples "interface filters"


### PR DESCRIPTION
## Problem

When configuring a bond in s390, only **qeth** devices with Layer2 support are considered as valid slave candidates. In case of PCIe devices like the RoCe ones them are recognized as ethernet interfaces and should be offered.

- https://bugzilla.suse.com/show_bug.cgi?id=1182911
- https://trello.com/c/cDgMQdNf

## Solution

- Do not filter out **Ethernet** interfaces when configuring a bond in (s390)
- Do not propose a 1492 MTU size for ethernet devices (LCS ethernet should be detected as LCS connections)