### PR TITLE
bsc#1182818: it does not consider 'nfsroot' during installation

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  4 15:41:04 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not consider proposing 'nfsroot' as startmode when running on
+  installation (bsc#1182818).
+- 4.2.96
+
+-------------------------------------------------------------------
 Wed Mar  3 12:11:39 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not filter ethernet cards when configuring a bond in s390

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.95
+Version:        4.2.96
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -25,6 +25,8 @@ require "y2network/boot_protocol"
 require "y2network/startmode"
 require "y2network/connection_config/ip_config"
 
+Yast.import "Mode"
+
 module Y2Network
   module ConnectionConfig
     # This class is reponsible of a connection configuration
@@ -120,11 +122,10 @@ module Y2Network
 
       def propose_startmode
         Yast.import "ProductFeatures"
-        # see bsc#176804
-        devicegraph = Y2Storage::StorageManager.instance.staging
-        if devicegraph.filesystem_in_network?("/")
-          @startmode = Startmode.create("nfsroot")
+
+        if root_filesystem_in_network?
           log.info "startmode nfsroot"
+          @startmode = Startmode.create("nfsroot")
           return
         end
 
@@ -224,6 +225,14 @@ module Y2Network
 
         false
         # TODO: interface is just string so interface.hardware.hotplug does not work
+      end
+
+      def root_filesystem_in_network?
+        return false unless Yast::Mode.normal
+
+        # see bsc#176804
+        devicegraph = Y2Storage::StorageManager.instance.staging
+        devicegraph.filesystem_in_network?("/")
       end
     end
   end

--- a/test/support/connection_config_examples.rb
+++ b/test/support/connection_config_examples.rb
@@ -1,0 +1,59 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+RSpec.shared_examples "connection configuration" do
+  describe "#propose" do
+    context "startmode" do
+      let(:normal?) { true }
+      let(:root_in_network?) { false }
+
+      let(:storage_manager) do
+        instance_double(Y2Storage::StorageManager, staging: devicegraph)
+      end
+
+      let(:devicegraph) { instance_double(Y2Storage::Devicegraph) }
+
+      before do
+        allow(Yast::Mode).to receive(:normal).and_return(normal?)
+        allow(Y2Storage::StorageManager).to receive(:instance)
+          .and_return(storage_manager)
+        allow(devicegraph).to receive(:filesystem_in_network?).with("/")
+          .and_return(root_in_network?)
+      end
+
+      context "when root filesystem is on a network device" do
+        let(:root_in_network?) { true }
+
+        it "is set to 'nfsroot'" do
+          subject.propose
+          expect(subject.startmode.to_s).to eq("nfsroot")
+        end
+      end
+
+      context "when running on installation" do
+        let(:normal?) { false }
+
+        it "does not check whether the root filesystem is on a network device" do
+          expect(storage_manager).to_not receive(:staging)
+          subject.propose
+        end
+      end
+    end
+  end
+end

--- a/test/y2network/connection_config/bonding_test.rb
+++ b/test/y2network/connection_config/bonding_test.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/bonding"
 require "y2network/interface_type"
 

--- a/test/y2network/connection_config/ctc_test.rb
+++ b/test/y2network/connection_config/ctc_test.rb
@@ -18,10 +18,13 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/ctc"
 require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Ctc do
+  include_examples "connection configuration"
+
   describe "#type" do
     it "returns 'ctc'" do
       expect(subject.type).to eq(Y2Network::InterfaceType::CTC)

--- a/test/y2network/connection_config/dummy_test.rb
+++ b/test/y2network/connection_config/dummy_test.rb
@@ -18,11 +18,14 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/dummy"
 require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Dummy do
   subject(:config) { described_class.new }
+
+  include_examples "connection configuration"
 
   describe "#type" do
     it "returns 'dummy'" do

--- a/test/y2network/connection_config/ethernet_test.rb
+++ b/test/y2network/connection_config/ethernet_test.rb
@@ -18,11 +18,14 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/ethernet"
 require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Ethernet do
   subject(:config) { described_class.new }
+
+  include_examples "connection configuration"
 
   describe "#type" do
     it "returns 'ethernet'" do

--- a/test/y2network/connection_config/hsi_test.rb
+++ b/test/y2network/connection_config/hsi_test.rb
@@ -18,10 +18,14 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/hsi"
 require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Hsi do
+
+  include_examples "connection configuration"
+
   describe "#type" do
     it "returns 'hsi'" do
       expect(subject.type).to eq(Y2Network::InterfaceType::HSI)

--- a/test/y2network/connection_config/lcs_test.rb
+++ b/test/y2network/connection_config/lcs_test.rb
@@ -18,10 +18,14 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/lcs"
 require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Lcs do
+
+  include_examples "connection configuration"
+
   describe "#type" do
     it "returns 'lcs'" do
       expect(subject.type).to eq(Y2Network::InterfaceType::LCS)

--- a/test/y2network/connection_config/qeth_test.rb
+++ b/test/y2network/connection_config/qeth_test.rb
@@ -18,10 +18,14 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/qeth"
 require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Qeth do
+
+  include_examples "connection configuration"
+
   describe "#type" do
     it "returns 'qeth'" do
       expect(subject.type).to eq(Y2Network::InterfaceType::QETH)

--- a/test/y2network/connection_config/tap_test.rb
+++ b/test/y2network/connection_config/tap_test.rb
@@ -18,11 +18,14 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/tap"
 require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Tap do
   subject(:config) { described_class.new }
+
+  include_examples "connection configuration"
 
   describe "#type" do
     it "returns 'tap'" do

--- a/test/y2network/connection_config/tun_test.rb
+++ b/test/y2network/connection_config/tun_test.rb
@@ -18,11 +18,14 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/tun"
 require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Tun do
   subject(:config) { described_class.new }
+
+  include_examples "connection configuration"
 
   describe "#type" do
     it "returns 'tun'" do

--- a/test/y2network/connection_config/usb_test.rb
+++ b/test/y2network/connection_config/usb_test.rb
@@ -18,11 +18,14 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/usb"
 require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Usb do
   subject(:config) { described_class.new }
+
+  include_examples "connection configuration"
 
   describe "#type" do
     it "returns 'usb'" do

--- a/test/y2network/connection_config/vlan_test.rb
+++ b/test/y2network/connection_config/vlan_test.rb
@@ -18,11 +18,14 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/vlan"
 require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Vlan do
   subject(:config) { described_class.new }
+
+  include_examples "connection configuration"
 
   describe "#type" do
     it "returns 'vlan'" do

--- a/test/y2network/connection_config/wireless_test.rb
+++ b/test/y2network/connection_config/wireless_test.rb
@@ -18,11 +18,14 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
+require_relative "../../support/connection_config_examples"
 require "y2network/connection_config/wireless"
 require "y2network/interface_type"
 
 describe Y2Network::ConnectionConfig::Wireless do
   subject(:config) { described_class.new }
+
+  include_examples "connection configuration"
 
   describe "#type" do
     it "returns 'wireless'" do


### PR DESCRIPTION
Do not consider proposing 'nfsroot' during installation. The reason is that, at that point, it is not possible to know whether the root filesystem will be on a network device or not. Additionally, it triggers the storage probing without having activated multipath devices. See [bsc#1182818](https://bugzilla.suse.com/show_bug.cgi?id=1182818) for further details.