### PR TITLE
Define the network configuration buttons

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar  5 15:46:19 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Define the network configuration buttons for the installer
+  console (related to jsc#PM-1895, jsc#SLE-16263)
+- 4.3.54
+
+-------------------------------------------------------------------
 Thu Mar  4 15:41:04 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not consider proposing 'nfsroot' as startmode when running on

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.53
+Version:        4.3.54
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/installation/console/plugins/network_button.rb
+++ b/src/lib/installation/console/plugins/network_button.rb
@@ -1,0 +1,57 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm"
+
+module Installation
+  module Console
+    module Plugins
+      # define a CWM widget for starting proxy configuration
+      class NetworkButton < CWM::PushButton
+        def initialize
+          textdomain "network"
+        end
+
+        def label
+          # TRANSLATORS: a button label, it starts the network configuration
+          _("Configure Network Devices...")
+        end
+
+        def help
+          # TRANSLATORS: help text
+          _("<p>The <b>Configure Network Devices</b> button starts the network " \
+            "configuration module. You can configure your network connection there.</p>")
+        end
+
+        def handle
+          Yast::WFM.call("inst_lan", [{ "skip_detection" => true }])
+          nil
+        end
+      end
+
+      # define a console plugin
+      class NetworkButtonPlugin < MenuPlugin
+        def widget
+          NetworkButton.new
+        end
+      end
+    end
+  end
+end

--- a/src/lib/installation/console/plugins/proxy_button.rb
+++ b/src/lib/installation/console/plugins/proxy_button.rb
@@ -26,7 +26,7 @@ module Installation
       # define a CWM widget for starting network configuration
       class ProxyButton < CWM::PushButton
         def initialize
-          textdomain "installation"
+          textdomain "network"
         end
 
         def label

--- a/src/lib/installation/console/plugins/proxy_button.rb
+++ b/src/lib/installation/console/plugins/proxy_button.rb
@@ -1,0 +1,57 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm"
+
+module Installation
+  module Console
+    module Plugins
+      # define a CWM widget for starting network configuration
+      class ProxyButton < CWM::PushButton
+        def initialize
+          textdomain "installation"
+        end
+
+        def label
+          # TRANSLATORS: a button label, it starts the proxy configuration
+          _("Configure Network Proxy...")
+        end
+
+        def help
+          # TRANSLATORS: help text
+          _("<p>Use the <b>Configure Network Proxy</b> button if you need " \
+            "a proxy for accessing the Internet servers.</p>")
+        end
+
+        def handle
+          Yast::WFM.call("proxy")
+          nil
+        end
+      end
+
+      # define a console plugin
+      class ProxyButtonPlugin < MenuPlugin
+        def widget
+          ProxyButton.new
+        end
+      end
+    end
+  end
+end

--- a/test/network_button_test.rb
+++ b/test/network_button_test.rb
@@ -1,0 +1,40 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+require "installation/console/plugins/network_button"
+
+require "cwm/rspec"
+
+describe Installation::Console::Plugins::NetworkButton do
+  before do
+    allow(Yast::WFM).to receive(:call)
+  end
+
+  include_examples "CWM::PushButton"
+end
+
+describe Installation::Console::Plugins::NetworkButtonPlugin do
+  context "#widget" do
+    it "returns a CWM widget" do
+      w = subject.widget
+      expect(w).to be_a(CWM::AbstractWidget)
+    end
+  end
+end

--- a/test/proxy_button_test.rb
+++ b/test/proxy_button_test.rb
@@ -1,0 +1,39 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+require_relative "test_helper"
+require "installation/console/plugins/proxy_button"
+
+require "cwm/rspec"
+
+describe Installation::Console::Plugins::ProxyButton do
+  before do
+    allow(Yast::WFM).to receive(:call)
+  end
+
+  include_examples "CWM::PushButton"
+end
+
+describe Installation::Console::Plugins::ProxyButtonPlugin do
+  context "#widget" do
+    it "returns a CWM widget" do
+      w = subject.widget
+      expect(w).to be_a(CWM::AbstractWidget)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -125,3 +125,13 @@ class SectionKeyValue
     section_hash[key] = value
   end
 end
+
+# mock empty class to avoid build dependency on yast2-installation
+module Installation
+  module Console
+    module Plugins
+      class MenuPlugin
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Define the network configuration buttons for the installer console
- See https://github.com/yast/yast-installation/pull/905
- [Internal Trello card](https://trello.com/c/TOdZIh98/2209-5-continue-with-an-easy-to-way-to-configure-and-in-installer)
- Jira: [SLE-16263](https://jira.suse.com/browse/SLE-16263), [SLE-16358](https://jira.suse.com/browse/SLE-16358)
- 4.3.54