### PR TITLE
Fix save_network unit test hosts mocking

### DIFF
--- a/test/host_test.rb
+++ b/test/host_test.rb
@@ -50,6 +50,7 @@ describe Yast::Host do
   end
 
   before do
+    allow(Yast::Host).to receive(:load_hosts).and_call_original
     allow(Yast::Lan).to receive(:Read)
     allow(Yast::Lan).to receive(:yast_config).and_return(lan_config)
     allow(Yast::SCR).to receive(:Read).with(path(".target.size"), "/etc/hosts").and_return(50)

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -222,6 +222,27 @@ describe Yast::NetworkAutoconfiguration do
     end
   end
 
+  describe "#configure_hosts" do
+    before do
+      allow(Yast::Host).to receive(:Write)
+    end
+
+    it "ensures the /etc/hosts configuration is read" do
+      expect(Yast::Host).to receive(:Read)
+      instance.configure_hosts
+    end
+
+    it "adds and entry for the static IP addresses without one pointing to the hostname" do
+      expect(Yast::Host).to receive(:ResolveHostnameToStaticIPs)
+      instance.configure_hosts
+    end
+
+    it "writes the /etc/hosts changes" do
+      expect(Yast::Host).to receive(:Write)
+      instance.configure_hosts
+    end
+  end
+
   describe "#configure_virtuals" do
     let(:routing) { Y2Network::Routing.new(tables: [table1]) }
     let(:table1) { Y2Network::RoutingTable.new(routes) }

--- a/test/network_autoyast_test.rb
+++ b/test/network_autoyast_test.rb
@@ -203,6 +203,13 @@ describe "NetworkAutoYast" do
     end
   end
 
+  describe "#configure_hosts" do
+    it "writes hosts config" do
+      expect(Yast::Host).to receive(:Write).with(gui: false)
+      network_autoyast.configure_hosts
+    end
+  end
+
   describe "#configure_lan" do
     before do
       Yast::Lan.autoinst = nil

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,6 +75,7 @@ RSpec.configure do |c|
     Y2Network::Hwinfo.reset
     allow(Yast::NetworkInterfaces).to receive(:Write)
     allow(Y2Network::Hwinfo).to receive(:hwinfo_from_hardware)
+    allow(Yast::Host).to receive(:load_hosts).and_return(true)
     Y2Storage::StorageManager.create_test_instance
   end
 end

--- a/test/y2network/wicked/connection_config_readers/ethernet_test.rb
+++ b/test/y2network/wicked/connection_config_readers/ethernet_test.rb
@@ -27,6 +27,10 @@ describe Y2Network::Wicked::ConnectionConfigReaders::Ethernet do
 
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
+  before do
+    allow(Yast::Host).to receive(:load_hosts).and_call_original
+  end
+
   around do |example|
     change_scr_root(scr_root, &example)
   end


### PR DESCRIPTION
## Problem

The build of the package is failing because a permissions problems when trying to read the system /etc/hosts.

https://build.suse.de/package/live_build_log/Devel:YaST:Head/yast2-network/SUSE_SLE-15-SP3_GA/ppc64le

## Solution

Mock as much of possible the access to /etc/hosts.