### PR TITLE
Do not apply changes at the end of the first stage.

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Mar 14 08:18:11 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Ensure that during an Autoinstallation the network configuration
+  declared in the profile is only written and not applied when it is
+  done at the end of the first stage (bsc#1180535)
+- 4.3.59
+
+-------------------------------------------------------------------
 Fri Mar 12 11:35:19 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Add more space before the "Name Servers and Domain Search List"

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,9 +1,8 @@
 -------------------------------------------------------------------
-Mon Mar 14 08:18:11 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+Mon Mar 15 08:18:11 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
-- Ensure that during an Autoinstallation the network configuration
-  declared in the profile is only written and not applied when it is
-  done at the end of the first stage (bsc#1180535)
+- AutoYaST: configure but not apply the network configuration at
+  the end of the 1st stage (bsc#1180535).
 - 4.3.59
 
 -------------------------------------------------------------------

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.58
+Version:        4.3.59
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -283,6 +283,8 @@ module Yast
     # It creates a proposal in case of common installation. In case of AY
     # installation it does full import of <networking> section
     def configure_lan
+      # Do not apply changes at the end of the first stage.
+      Yast::Lan.write_only = true
       copy_udev_rules if Mode.autoinst && NetworkAutoYast.instance.configure_lan
 
       # FIXME: Really make sense to configure it in autoinst mode? At least the

--- a/src/lib/y2network/autoinst/config.rb
+++ b/src/lib/y2network/autoinst/config.rb
@@ -46,7 +46,7 @@ module Y2Network
       # @option opts [Integer] :ip_check_timetout
       # @option opts [Boolean] :virt_bridge_proposal
       def initialize(opts = {})
-        ay_options = opts.delete_if { |_k, v| v.nil? }
+        ay_options = opts.reject { |_k, v| v.nil? }
 
         @before_proposal = ay_options.fetch(:before_proposal, false)
         @start_immediately = ay_options.fetch(:start_immediately, true)

--- a/src/lib/y2network/autoinst/config.rb
+++ b/src/lib/y2network/autoinst/config.rb
@@ -46,11 +46,13 @@ module Y2Network
       # @option opts [Integer] :ip_check_timetout
       # @option opts [Boolean] :virt_bridge_proposal
       def initialize(opts = {})
-        @before_proposal = opts.fetch(:before_proposal, false)
-        @start_immediately = opts.fetch(:start_immediately, false)
-        @keep_install_network = opts.fetch(:keep_install_network, true)
-        @ip_check_timeout = opts.fetch(:ip_check_timeout, -1)
-        @virt_bridge_proposal = opts.fetch(:virt_bridge_proposal, true)
+        ay_options = opts.delete_if { |_k, v| v.nil? }
+
+        @before_proposal = ay_options.fetch(:before_proposal, false)
+        @start_immediately = ay_options.fetch(:start_immediately, true)
+        @keep_install_network = ay_options.fetch(:keep_install_network, true)
+        @ip_check_timeout = ay_options.fetch(:ip_check_timeout, -1)
+        @virt_bridge_proposal = ay_options.fetch(:virt_bridge_proposal, true)
       end
 
       # Return whether the network should be copied at the end

--- a/src/lib/y2network/autoinst/config_reader.rb
+++ b/src/lib/y2network/autoinst/config_reader.rb
@@ -54,7 +54,7 @@ module Y2Network
         config.interfaces = @original_config.interfaces.copy
         # merge devices definitions obtained from inst-sys
         # and those which were read from AY profile. bnc#874259
-        config.connections = @original_config.connections.copy if section.keep_install_network
+        config.connections = @original_config.connections.copy if keep_configured_network?
 
         # apply at first udev rules, so interfaces names are correct
         UdevRulesReader.new(section.udev_rules).apply(config) if section.udev_rules
@@ -71,6 +71,16 @@ module Y2Network
         end
 
         config
+      end
+
+    private
+
+      # Convenience method to check whether the configured network should be
+      # keeped or not (by default returns true)
+      #
+      # @return [Boolean]
+      def keep_configured_network?
+        section.keep_install_network != false
       end
     end
   end

--- a/src/lib/y2network/autoinst/config_reader.rb
+++ b/src/lib/y2network/autoinst/config_reader.rb
@@ -76,7 +76,7 @@ module Y2Network
     private
 
       # Convenience method to check whether the configured network should be
-      # keeped or not (by default returns true)
+      # kept or not (by default returns true)
       #
       # @return [Boolean]
       def keep_configured_network?

--- a/src/lib/y2network/autoinst/config_reader.rb
+++ b/src/lib/y2network/autoinst/config_reader.rb
@@ -70,6 +70,8 @@ module Y2Network
           end
         end
 
+        config.backend = section.managed ? :network_manager : :wicked
+
         config
       end
 

--- a/src/lib/y2network/autoinst_profile/networking_section.rb
+++ b/src/lib/y2network/autoinst_profile/networking_section.rb
@@ -85,11 +85,11 @@ module Y2Network
       def self.new_from_hashes(hash)
         result = new
         result.managed = hash["managed"]
-        result.setup_before_proposal = hash.fetch("setup_before_proposal", false)
-        result.start_immediately = hash.fetch("start_immediately", false)
-        result.keep_install_network = hash.fetch("keep_install_network", true)
-        result.virt_bridge_proposal = hash.fetch("virt_bridge_proposal", true)
-        result.strict_ip_check_timeout = hash.fetch("strict_ip_check_timeout", -1)
+        result.setup_before_proposal = hash["setup_before_proposal"]
+        result.start_immediately = hash["start_immediately"]
+        result.keep_install_network = hash["keep_install_network"]
+        result.virt_bridge_proposal = hash["virt_bridge_proposal"]
+        result.strict_ip_check_timeout = hash["strict_ip_check_timeout"]
         result.routing = RoutingSection.new_from_hashes(hash["routing"], result) if hash["routing"]
         result.dns = DNSSection.new_from_hashes(hash["dns"], result) if hash["dns"]
         if hash["interfaces"]

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -800,7 +800,8 @@ module Yast
       !section.start_immediately.nil? ||
         !section.keep_install_network.nil? ||
         !section.setup_before_proposal.nil? ||
-        !section.virt_bridge_proposal.nil?
+        !section.virt_bridge_proposal.nil? ||
+        !section.strict_ip_check_timeout.nil?
     end
 
     def activate_network_service

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -783,25 +783,20 @@ module Yast
     attr_reader :configs
 
     def autoinst_config(section)
-      return unless autoinst_settings?(section)
+      ay_settings = autoinst_settings(section)
+      return if ay_settings.empty?
 
-      Y2Network::Autoinst::Config.new(
+      Y2Network::Autoinst::Config.new(ay_settings)
+    end
+
+    def autoinst_settings(section)
+      {
         before_proposal:      section.setup_before_proposal,
         start_immediately:    section.start_immediately,
         keep_install_network: section.keep_install_network,
         ip_check_timeout:     section.strict_ip_check_timeout,
         virt_bridge_proposal: section.virt_bridge_proposal
-      )
-    end
-
-    def autoinst_settings?(section)
-      return false unless section
-
-      !section.start_immediately.nil? ||
-        !section.keep_install_network.nil? ||
-        !section.setup_before_proposal.nil? ||
-        !section.virt_bridge_proposal.nil? ||
-        !section.strict_ip_check_timeout.nil?
+      }.reject { |_k, v| v.nil? }
     end
 
     def activate_network_service

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -825,6 +825,9 @@ module Yast
     end
 
     def select_network_service
+      # We cannot switch the service during installation
+      return true if Stage.initial
+
       NetworkService.use(yast_config&.backend&.id)
     end
 

--- a/test/save_network_test.rb
+++ b/test/save_network_test.rb
@@ -91,6 +91,12 @@ describe Yast::SaveNetworkClient do
       end
     end
 
+    it "ensures that the network configuration changes are written but not applied" do
+      Yast::Lan.write_only = false
+
+      expect { subject.main }.to change { Yast::Lan.write_only }.from(false).to(true)
+    end
+
     it "merges netconfig configuration" do
       subject.main
 

--- a/test/y2network/autoinst/config_reader_test.rb
+++ b/test/y2network/autoinst/config_reader_test.rb
@@ -70,6 +70,17 @@ describe Y2Network::Autoinst::ConfigReader do
       expect(subject.config.dns).to be_a Y2Network::DNS
       expect(subject.config.hostname.dhcp_hostname).to eq(:any)
       expect(subject.config.hostname.installer).to eq("host")
+      expect(subject.config.backend.id).to eq(:wicked)
+    end
+
+    context "when the networking section sets it to be managed" do
+      before do
+        profile["managed"] = true
+      end
+
+      it "selects :network_manager as the backend to be used" do
+        expect(subject.config.backend.id).to eq(:network_manager)
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

At the end of the first stage and when we configure the network according to the profile we should ensure that the configuration is only written but not applied as restarting the service does not makes sense at all at that point.

It was also found that the "default" value for applying the changes immediately when writing the network configuration through AutoYaST was not the same than the one declared in the network_section and that is because the Profile add it automatically:

https://github.com/yast/yast-autoinstallation/blob/master/src/modules/Profile.rb#L250

But it is not the only thing that we could improve. Currently we are initializing the network section values with the defaults, which means that we are not able to identify whether the options were explicitly requested or not.

- https://bugzilla.suse.com/show_bug.cgi?id=1180535

## Solution

- Ensure the configuration is written but not applied at the end of the first stage (configure_lan)
- Do not initialize networking_section values if not declared in the profile
- Modify the start_immediately default option to true as declared in the Profile.

