### PR TITLE
bsc#1183257: empty interfaces list

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 11 15:52:10 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: allow the interfaces list in the profile to be
+  empty (bsc#1183257).
+- 4.3.56
+
+-------------------------------------------------------------------
 Thu Mar 11 09:33:05 UTC 2021 - Michal Filka <mfilka@suse.com>
 
 - bnc#1180085

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.55
+Version:        4.3.56
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -42,7 +42,7 @@ strict_IP_check_timeout =
 interfaces =
   element interfaces {
     LIST,
-    interface+
+    interface*
   }
 
 interface =


### PR DESCRIPTION
Allow the interfaces list to be empty. As the element is annotated (`config:type`), it is not a problem.

See [bsc#1183257](https://bugzilla.suse.com/show_bug.cgi?id=1183257).