### PR TITLE
Add empty space before name servers frame 

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 12 11:35:19 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Add more space before the "Name Servers and Domain Search List"
+  frame (related to bsc#1183306).
+- 4.3.58
+
+-------------------------------------------------------------------
 Fri Mar 12 09:23:04 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix the VLAN interface renaming when suggested by a VLAN ID

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.57
+Version:        4.3.58
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -190,6 +190,7 @@ module Yast
         ),
         VSpacing(1),
         Left(HBox("MODIFY_RESOLV", HSpacing(1), "PLAIN_POLICY")),
+        VSpacing(1),
         Frame(
           _("Name Servers and Domain Search List"),
           VBox(

--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -190,18 +190,20 @@ module Yast
         ),
         VSpacing(1),
         Left(HBox("MODIFY_RESOLV", HSpacing(1), "PLAIN_POLICY")),
-        VSpacing(1),
-        Frame(
-          _("Name Servers and Domain Search List"),
-          VBox(
-            VSquash(
-              HBox(
-                HWeight(1, VBox("NAMESERVER_1", "NAMESERVER_2", "NAMESERVER_3")),
-                HSpacing(1),
-                HWeight(1, "SEARCHLIST_S")
+        MarginBox(
+          0.49,
+          0.49,
+          Frame(
+            _("Name Servers and Domain Search List"),
+            VBox(
+              VSquash(
+                HBox(
+                  HWeight(1, VBox("NAMESERVER_1", "NAMESERVER_2", "NAMESERVER_3")),
+                  HSpacing(1),
+                  HWeight(1, "SEARCHLIST_S")
+                )
               )
-            ),
-            VSpacing(0.49)
+            )
           )
         ),
         VStretch()


### PR DESCRIPTION
While working on https://github.com/yast/yast-theme/pull/144, I realize that there is no vertical space between _Modify DNS Configuration_ and "Name Servers and Domain Search List" in the `Hostname/DNS` tab of Network Settings.

Although it is a really small _cosmetic issue_ with which we can live, I fixed it because there enough room in both, TUI and GUI.


| Before | After |
|-|-|
| ![yast_lan_tui_before](https://user-images.githubusercontent.com/1691872/110830521-3706e680-8291-11eb-8e18-03717b7cad31.png) | ![yast_lan_tui_after](https://user-images.githubusercontent.com/1691872/110830514-353d2300-8291-11eb-9bf5-b7ded8bc447b.png) |
| ![yast_lan_before](https://user-images.githubusercontent.com/1691872/110830523-379f7d00-8291-11eb-8422-389585513efc.png) | ![yast_lan_after](https://user-images.githubusercontent.com/1691872/110830517-35d5b980-8291-11eb-9f98-ee9484ca7479.png) |



