### PR TITLE
Fix the rename of the vlan interface when suggested

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 12 09:23:04 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix the VLAN interface renaming when suggested by a VLAN ID
+  change (bsc#1183357)
+- 4.3.57
+
+-------------------------------------------------------------------
 Thu Mar 11 15:52:10 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: allow the interfaces list in the profile to be

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.56
+Version:        4.3.57
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/address_tab.rb
+++ b/src/lib/y2network/widgets/address_tab.rb
@@ -33,6 +33,9 @@ require "y2network/widgets/vlan_interface"
 module Y2Network
   module Widgets
     class AddressTab < CWM::Tab
+      # Constructor
+      #
+      # @param settings [Y2Network::InterfaceConfigBuilder] Interface configuration builder object
       def initialize(settings)
         textdomain "network"
 

--- a/src/lib/y2network/widgets/vlan_id.rb
+++ b/src/lib/y2network/widgets/vlan_id.rb
@@ -22,6 +22,9 @@ require "cwm/common_widgets"
 module Y2Network
   module Widgets
     class VlanID < CWM::IntField
+      # Constructor
+      #
+      # @param config [Y2Network::InterfaceConfigBuilder] Interface configuration builder object
       def initialize(config)
         textdomain "network"
 
@@ -44,7 +47,7 @@ module Y2Network
       def store
         return unless modified?
 
-        @config.name = suggested_name if suggest_vlan_name
+        @config.rename_interface(suggested_name) if suggest_vlan_name
         @config.vlan_id = value
       end
 

--- a/src/lib/y2network/widgets/vlan_interface.rb
+++ b/src/lib/y2network/widgets/vlan_interface.rb
@@ -22,6 +22,9 @@ require "cwm/common_widgets"
 module Y2Network
   module Widgets
     class VlanInterface < CWM::ComboBox
+      # Constructor
+      #
+      # @param config [Y2Network::InterfaceConfigBuilder] Interface configuration builder object
       def initialize(config)
         textdomain "network"
 

--- a/test/y2network/widgets/vlan_id_test.rb
+++ b/test/y2network/widgets/vlan_id_test.rb
@@ -55,8 +55,10 @@ describe Y2Network::Widgets::VlanID do
           allow(Yast::Popup).to receive(:YesNo).and_return(true)
         end
 
-        it "modifies the vlan interface name" do
-          expect { subject.store }.to change { builder.name }.from("vlan0").to("vlan20")
+        it "renames the vlan interface name" do
+          expect(builder).to receive(:rename_interface).with("vlan20")
+
+          subject.store
         end
       end
     end


### PR DESCRIPTION
## Problem

[Recently](https://github.com/yast/yast-network/pull/1151) we have added a dialog to suggest the user to adapt the **VLAN** interface name in case that the **VLAN ID** was modified, that works fine in case it was newly added, but in case of edited it failed because we need to ensure we modify the old_name too.

- https://trello.com/c/FHg9gXbR/2343-sles15-sp3-p2-1183357-sles-15-sp3-snapshot11-installation-crashes-on-vlan-rename

## Solution

Do not change the builder interface name directly but call rename_interface instead.