### PR TITLE
NM: add support to bridge and bonding configurations

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 17 09:52:08 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- NetworkManager: Added support to write bridge and bonding
+  configurations (bsc#1181701)
+- 4.3.60
+
+-------------------------------------------------------------------
 Mon Mar 15 08:18:11 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - AutoYaST: configure but not apply the network configuration at

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.59
+Version:        4.3.60
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/cfa/nm_connection.rb
+++ b/src/lib/cfa/nm_connection.rb
@@ -29,7 +29,7 @@ module CFA
   #   puts file.connection["id"]
   class NmConnection < BaseModel
     KNOWN_SECTIONS = [
-      "bridge", "connection", "ethernet", "ipv4", "ipv6", "vlan", "wifi", "wifi_security"
+      "bond", "bridge", "connection", "ethernet", "ipv4", "ipv6", "vlan", "wifi", "wifi_security"
     ].freeze
 
     # Constructor

--- a/src/lib/y2network/network_manager/config_writer.rb
+++ b/src/lib/y2network/network_manager/config_writer.rb
@@ -35,7 +35,11 @@ module Y2Network
       def write_connections(config, _old_config)
         writer = Y2Network::NetworkManager::ConnectionConfigWriter.new
         config.connections.each do |conn|
-          writer.write(conn, nil, routes_for(conn, config.routing.routes)) # FIXME
+          opts = {
+            routes: routes_for(conn, config.routing.routes),
+            parent: conn.find_master(config.connections)
+          }.reject { |_k, v| v.nil? }
+          writer.write(conn, nil, **opts) # FIXME
         end
       end
 

--- a/src/lib/y2network/network_manager/connection_config_writer.rb
+++ b/src/lib/y2network/network_manager/connection_config_writer.rb
@@ -35,9 +35,8 @@ module Y2Network
       #   written
       # @param old_conn [ConnectionConfig::Base] Original connection
       #   configuration
-      # @param routes [Array<Routes>] routes associated with the connection to be
-      #   written
-      def write(conn, old_conn = nil, routes = [])
+      # @param opts [Hash] writer options
+      def write(conn, old_conn = nil, **opts)
         return if conn == old_conn
 
         path = SYSTEM_CONNECTIONS_PATH.join(conn.name).sub_ext(FILE_EXT)
@@ -47,7 +46,7 @@ module Y2Network
 
         ensure_permissions(path) unless ::File.exist?(path)
 
-        handler_class.new(file).write(conn, routes)
+        handler_class.new(file).write(conn, **opts)
         file.save
       end
 

--- a/src/lib/y2network/network_manager/connection_config_writers/base.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/base.rb
@@ -50,7 +50,7 @@ module Y2Network
           file.connection["zone"] = conn.firewall_zone unless ["", nil].include? conn.firewall_zone
           conn.bootproto.dhcp? ? configure_dhcp(conn) : configure_ips(conn)
           configure_routes(routes)
-          configure_as_child(conn, parent) if parent
+          configure_as_child(parent) if parent
           update_file(conn)
         end
 
@@ -101,9 +101,8 @@ module Y2Network
 
         # Convenience method to configure the reference to the parent or master device
         #
-        # @param conn [Y2Network::ConnectionConfig::Base] Connection to take settings from
         # @param parent [Y2Network::ConnectionConfig::Base] Connection to take settings from
-        def configure_as_child(_conn, parent)
+        def configure_as_child(parent)
           slave_type = "bridge" if parent.type.br?
           slave_type = "bond" if parent.type.bonding?
           return unless slave_type

--- a/src/lib/y2network/network_manager/connection_config_writers/bonding.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/bonding.rb
@@ -1,0 +1,42 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/network_manager/connection_config_writers/base"
+
+module Y2Network
+  module NetworkManager
+    module ConnectionConfigWriters
+      # This class is responsible for writing the information from a ConnectionConfig::Bonding
+      # object to the underlying system.
+      class Bonding < Base
+        # @see Y2Network::ConnectionConfigWriters::Base#update_file
+        # @param conn [Y2Network::ConnectionConfig::Bonding] Configuration to write
+        def update_file(conn)
+          file.connection["type"] = "bond"
+          conn.options.to_s.split.each do |option|
+            k, v = option.split("=")
+            next if [k, v].any? { |o| o.to_s.empty? }
+
+            file.bond[k] = v
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2network/network_manager/connection_config_writers/bridge.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/bridge.rb
@@ -1,0 +1,38 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/network_manager/connection_config_writers/base"
+
+module Y2Network
+  module NetworkManager
+    module ConnectionConfigWriters
+      # This class is responsible for writing the information from a ConnectionConfig::Bridge
+      # object to the underlying system.
+      class Bridge < Base
+        # @see Y2Network::ConnectionConfigWriters::Base#update_file
+        # @param conn [Y2Network::ConnectionConfig::Bonding] Configuration to write
+        def update_file(conn)
+          file.connection["type"] = "bridge"
+          file.bridge["stp"] = conn.stp.to_s
+          file.bridge["forward-delay"] = conn.forward_delay.to_s
+        end
+      end
+    end
+  end
+end

--- a/test/y2network/network_manager/config_writer_test.rb
+++ b/test/y2network/network_manager/config_writer_test.rb
@@ -71,7 +71,7 @@ describe Y2Network::NetworkManager::ConfigWriter do
     end
 
     it "writes connections configuration" do
-      expect(conn_config_writer).to receive(:write).with(eth0_conn, nil, [])
+      expect(conn_config_writer).to receive(:write).with(eth0_conn, nil, routes: [])
       writer.write(config)
     end
   end

--- a/test/y2network/network_manager/connection_config_writer_test.rb
+++ b/test/y2network/network_manager/connection_config_writer_test.rb
@@ -75,7 +75,7 @@ describe Y2Network::NetworkManager::ConnectionConfigWriter do
 
     it "uses the appropiate handler" do
       expect(writer).to receive(:require).and_return(handler)
-      expect(handler).to receive(:write).with(conn, [])
+      expect(handler).to receive(:write).with(conn)
       writer.write(conn)
     end
 

--- a/test/y2network/network_manager/connection_config_writers/bonding_test.rb
+++ b/test/y2network/network_manager/connection_config_writers/bonding_test.rb
@@ -1,0 +1,52 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "y2network/network_manager/connection_config_writers/bonding"
+require "cfa/nm_connection"
+require "y2network/boot_protocol"
+require "y2network/startmode"
+require "y2network/connection_config/bonding"
+
+describe Y2Network::NetworkManager::ConnectionConfigWriters::Bonding do
+  subject(:handler) { described_class.new(file) }
+  let(:file) { CFA::NmConnection.new("bond0.nm_connection") }
+
+  let(:conn) do
+    Y2Network::ConnectionConfig::Bonding.new.tap do |c|
+      c.interface = "bond0"
+      c.description = "Bond 0"
+      c.startmode = Y2Network::Startmode.create("auto")
+      c.bootproto = Y2Network::BootProtocol::DHCP
+      c.options = "mode=active-backup miimon=100"
+      c.slaves = ["eth0"]
+    end
+  end
+
+  describe "#write" do
+    it "sets device and IP relevant attributes" do
+      handler.write(conn)
+      expect(file.connection["type"]).to eql("bond")
+      expect(file.bond["mode"]).to eql("active-backup")
+      expect(file.bond["miimon"]).to eql("100")
+      expect(file.ipv4["method"]).to eql("auto")
+      expect(file.ipv6["method"]).to eql("auto")
+    end
+  end
+end

--- a/test/y2network/network_manager/connection_config_writers/bridge_test.rb
+++ b/test/y2network/network_manager/connection_config_writers/bridge_test.rb
@@ -1,0 +1,53 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "y2network/network_manager/connection_config_writers/bridge"
+require "cfa/nm_connection"
+require "y2network/boot_protocol"
+require "y2network/startmode"
+require "y2network/connection_config/bridge"
+
+describe Y2Network::NetworkManager::ConnectionConfigWriters::Bridge do
+  subject(:handler) { described_class.new(file) }
+  let(:file) { CFA::NmConnection.new("br0.nm_connection") }
+
+  let(:conn) do
+    Y2Network::ConnectionConfig::Bridge.new.tap do |c|
+      c.interface = "br0"
+      c.description = "Bridge 0"
+      c.startmode = Y2Network::Startmode.create("auto")
+      c.bootproto = Y2Network::BootProtocol::DHCP
+      c.stp = true
+      c.forward_delay = 2
+      c.ports = ["eth0"]
+    end
+  end
+
+  describe "#write" do
+    it "sets device and IP relevant attributes" do
+      handler.write(conn)
+      expect(file.connection["type"]).to eql("bridge")
+      expect(file.bridge["stp"]).to eql("true")
+      expect(file.bridge["forward-delay"]).to eql("2")
+      expect(file.ipv4["method"]).to eql("auto")
+      expect(file.ipv6["method"]).to eql("auto")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

While in wicked the relationships are declared in the parent device, in NM it is done in the descendants (slaves or ports). Thus, it is not enough with the given configuration to write the settings but also the parent config needs to be provided.

- https://bugzilla.suse.com/show_bug.cgi?id=1181701

## Solution

Give the parent config as an argument in case of a bridge port or bond slave being able to write the relationship correctly.