### PR TITLE
AutoYaST: write profile config to NM

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Mar 18 12:59:31 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
-AutoYaST: Write NetworkManager configuration according to the
+- AutoYaST: Write NetworkManager configuration according to the
   profile (bsc#1181701)
 - 4.3.62
 

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 18 12:59:31 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+AutoYaST: Write NetworkManager configuration according to the
+  profile (bsc#1181701)
+- 4.3.62
+
+-------------------------------------------------------------------
 Wed Mar 17 18:26:34 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Always provide the layer2 argument when activating a qeth device

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.61
+Version:        4.3.62
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -346,12 +346,7 @@ module Yast
 
     # Sets default network service
     def set_network_service
-      if Mode.autoinst && !Yast::Lan.autoinst.managed.nil?
-        log.info("Setting network service according to AutoYaST preferences")
-      else
-        log.info("Setting network service according to product preferences")
-      end
-
+      log.info("Setting target system network service")
       backend = Y2Network::ProposalSettings.instance.network_service
 
       # NetworkServices caches the selected backend. That is, it assumes the

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -346,14 +346,14 @@ module Yast
 
     # Sets default network service
     def set_network_service
-      if Mode.autoinst
-        NetworkAutoYast.instance.set_network_service
-        return
+      if Mode.autoinst && !Yast::Lan.autoinst.managed.nil?
+        log.info("Setting network service according to AutoYaST preferences")
+      else
+        log.info("Setting network service according to product preferences")
       end
 
-      log.info("Setting network service according to product preferences")
-
       backend = Y2Network::ProposalSettings.instance.network_service
+
       # NetworkServices caches the selected backend. That is, it assumes the
       # state in the inst-sys and the chroot is the same but that is not true
       # at all specially in a live installation where NM is the backend by

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -35,8 +35,6 @@ module Yast
 
     def initialize
       Yast.import "Lan"
-      Yast.import "NetworkInterfaces"
-      Yast.import "NetworkService"
       Yast.import "Package"
       Yast.import "DNS"
       Yast.import "Arch"

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -31,15 +31,17 @@ module Yast
     include Singleton
     include Logger
 
-    Yast.import "Lan"
-    Yast.import "NetworkInterfaces"
-    Yast.import "NetworkService"
-    Yast.import "Package"
-    Yast.import "DNS"
-    Yast.import "Arch"
-    Yast.import "Host"
-
     BASH_PATH = Path.new(".target.bash")
+
+    def initialize
+      Yast.import "Lan"
+      Yast.import "NetworkInterfaces"
+      Yast.import "NetworkService"
+      Yast.import "Package"
+      Yast.import "DNS"
+      Yast.import "Arch"
+      Yast.import "Host"
+    end
 
     # Checks if any of available interfaces is configured and active
     #

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -73,23 +73,6 @@ module Yast
       conf
     end
 
-    # Sets network service for target
-    def set_network_service
-      return if !Mode.autoinst
-
-      log.info("Setting network service according to AY profile")
-
-      if use_network_manager?
-        log.info("- using NetworkManager")
-      else
-        log.info("- using wicked")
-        Lan.yast_config&.backend = :wicked
-      end
-
-      NetworkService.use(Lan.yast_config&.backend&.id)
-      NetworkService.EnableDisableNow
-    end
-
     def use_network_manager?
       Y2Network::ProposalSettings.instance.network_service == :network_manager
     end

--- a/src/lib/network/network_autoyast.rb
+++ b/src/lib/network/network_autoyast.rb
@@ -91,8 +91,7 @@ module Yast
     end
 
     def use_network_manager?
-      @use_network_manager ||=
-        (Y2Network::ProposalSettings.instance.network_service == :network_manager)
+      Y2Network::ProposalSettings.instance.network_service == :network_manager
     end
 
     # Writes the autoyast network configuration according to the already
@@ -111,7 +110,6 @@ module Yast
       # We need to ensure the config translation is written to the target
       # system
       return false if !use_network_manager? && Lan.autoinst.before_proposal
-
 
       # force a write only as it is run at the end of the installation and it
       # is already chrooted in the target system where restarting services or

--- a/src/lib/y2network/autoinst/config.rb
+++ b/src/lib/y2network/autoinst/config.rb
@@ -36,6 +36,8 @@ module Y2Network
       # @return [Boolean] controls whether a bridge configuration for
       #   virtualization network should be proposed or not
       attr_accessor :virt_bridge_proposal
+      # @return [Boolean] returns whether the network is managed by NM or not
+      attr_accessor :managed
 
       # Constructor
       #
@@ -53,6 +55,7 @@ module Y2Network
         @keep_install_network = ay_options.fetch(:keep_install_network, true)
         @ip_check_timeout = ay_options.fetch(:ip_check_timeout, -1)
         @virt_bridge_proposal = ay_options.fetch(:virt_bridge_proposal, true)
+        @managed              = ay_options[:managed]
       end
 
       # Return whether the network should be copied at the end

--- a/src/lib/y2network/autoinst/config_reader.rb
+++ b/src/lib/y2network/autoinst/config_reader.rb
@@ -28,7 +28,7 @@ require "y2network/autoinst/udev_rules_reader"
 require "y2network/autoinst_profile/networking_section"
 require "y2network/wicked/interfaces_reader"
 
-Yast.import "Lan"
+Yast.import "Stage"
 
 module Y2Network
   module Autoinst
@@ -70,7 +70,10 @@ module Y2Network
           end
         end
 
-        config.backend = section.managed ? :network_manager : :wicked
+        # During the first stage of an autoinstallation we are not able to
+        # switch to NetworkManager and in case of setup_before_proposal the
+        # config should be written to the inst-sys (:wicked).
+        config.backend = (!Yast::Stage.initial && section.managed) ? :network_manager : :wicked
 
         config
       end

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -42,7 +42,7 @@ module Y2Network
       Yast.import "PackagesProposal"
       Yast.import "Lan"
 
-      @selected_backend = nil
+      @selected_backend = autoinst_backend
       @virt_bridge_proposal = autoinst_disabled_proposal? ? false : true
     end
 
@@ -123,12 +123,13 @@ module Y2Network
     # depending on the backend selected during the proposal and the packages
     # installed
     def network_service
-      case current_backend
-      when :network_manager
-        network_manager_installed? ? :network_manager : :wicked
-      else
-        :wicked
+      if current_backend == :network_manager
+        return :network_manager if network_manager_installed?
+        log.info("NetworkManager is the selected service but it is not installed")
+        log.info("- using wicked")
       end
+
+      :wicked
     end
 
     class << self
@@ -148,6 +149,12 @@ module Y2Network
     end
 
   private
+
+    def autoinst_backend
+      return if Yast::Lan.autoinst.managed.nil?
+
+      Yast::Lan.autoinst.managed ? :network_managed : false
+    end
 
     # Convenience method to check whether the bridge configuration proposal for
     # configuration was disabled in the AutoYaST profile.

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -125,6 +125,7 @@ module Y2Network
     def network_service
       if current_backend == :network_manager
         return :network_manager if network_manager_installed?
+
         log.info("NetworkManager is the selected service but it is not installed")
         log.info("- using wicked")
       end

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -154,7 +154,7 @@ module Y2Network
     def autoinst_backend
       return if Yast::Lan.autoinst.managed.nil?
 
-      Yast::Lan.autoinst.managed ? :network_managed : false
+      Yast::Lan.autoinst.managed ? :network_manager : :wicked
     end
 
     # Convenience method to check whether the bridge configuration proposal for

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -731,8 +731,7 @@ module Yast
     #
     # @see Y2Network::ConfigWriter
     def write_config(only: nil)
-      target = :wicked if Mode.auto
-      yast_config.write(original: system_config, target: target, only: only)
+      yast_config.write(original: system_config, only: only)
       # Force a refresh of the system_config bsc#1162987
       add_config(:system, yast_config.copy)
     end
@@ -795,7 +794,8 @@ module Yast
         start_immediately:    section.start_immediately,
         keep_install_network: section.keep_install_network,
         ip_check_timeout:     section.strict_ip_check_timeout,
-        virt_bridge_proposal: section.virt_bridge_proposal
+        virt_bridge_proposal: section.virt_bridge_proposal,
+        managed:              section.managed
       }.reject { |_k, v| v.nil? }
     end
 

--- a/test/lan_test.rb
+++ b/test/lan_test.rb
@@ -554,7 +554,7 @@ describe "LanClass" do
 
     it "writes the current yast_config passing the system config as the original" do
       expect(Yast::Lan.yast_config).to receive(:write)
-        .with(original: system_config, target: nil, only: nil)
+        .with(original: system_config, only: nil)
       subject.write_config
     end
 

--- a/test/y2network/autoinst/config_reader_test.rb
+++ b/test/y2network/autoinst/config_reader_test.rb
@@ -64,6 +64,12 @@ describe Y2Network::Autoinst::ConfigReader do
   end
 
   describe "#config" do
+    let(:first_stage) { true }
+
+    before do
+      allow(Yast::Stage).to receive(:initial).and_return(first_stage)
+    end
+
     it "builds a new Y2Network::Config from a Y2Networking::Section" do
       expect(subject.config).to be_a Y2Network::Config
       expect(subject.config.routing).to be_a Y2Network::Routing
@@ -78,8 +84,18 @@ describe Y2Network::Autoinst::ConfigReader do
         profile["managed"] = true
       end
 
-      it "selects :network_manager as the backend to be used" do
-        expect(subject.config.backend.id).to eq(:network_manager)
+      context "and run in the first stage of the installation" do
+        it "selects :wicked as the backend to be used" do
+          expect(subject.config.backend.id).to eq(:wicked)
+        end
+      end
+
+      context "and not run in the first stage of the installation" do
+        let(:first_stage) { false }
+
+        it "selects :network_manager as the backend to be used" do
+          expect(subject.config.backend.id).to eq(:network_manager)
+        end
       end
     end
   end

--- a/test/y2network/proposal_settings_test.rb
+++ b/test/y2network/proposal_settings_test.rb
@@ -72,11 +72,24 @@ describe Y2Network::ProposalSettings do
   describe ".create_instance" do
     let(:created_instance) { described_class.create_instance }
     let(:nm_available) { false }
+    let(:managed) { nil }
+
+    before do
+      allow(Yast::Lan.autoinst).to receive(:managed).and_return(managed)
+    end
 
     it "creates a new network proposal settings instance" do
       instance = described_class.instance
       expect(created_instance).to be_a(described_class)
       expect(created_instance).to_not equal(instance)
+    end
+
+    context "when NetworkManager is selected by AutoYaST" do
+      let(:managed) { true }
+
+      it "initializes the selected backend" do
+        expect(created_instance.selected_backend).to eql(:network_manager)
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

During an **autoinstallation** the network configuration is basically not written to **NetworkManager** because **wicked** is always considered as the target configuration.

During an **autoinstallation**, the translated network configuration has to be written at the very end of the first_stage as in case of done when still in the inst-sys (setup_before proposal or during the confirm dialog) then it should write wicked config.

- https://bugzilla.suse.com/show_bug.cgi?id=1181701

## Solution

- Store whether the backend selected according to **AutoYaST** is **NetworkManager** or not.
- During an autoinstallation and in case that **NetworkManager** is the backend selected to be used, set it at the very end of the installation being able to write wicked config if needed (setup it before or during the proposal dialog).

## Tests

- Adapted unit tests
- Tested manually

## TODO

Detected problems with DNS because the resolv.conf link is missing. The problem happens when the dns system config and the dns yast config looks the same according to the internal state but the fact is that in the target system the system config is not the one from the inst-sys so we probably should reflect that.

Update: NetworkManager does not call netconfig when the connections are configured using an static IP address. Copying the link at the end of the installation is useless as the run config will be empty after the reboot.
