### PR TITLE
Provides always the layer2 argument when activating a qeth device

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 17 18:26:34 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Always provide the layer2 argument when activating a qeth device
+  (bsc#1183639).
+- 4.3.61
+
+-------------------------------------------------------------------
 Wed Mar 17 09:52:08 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - NetworkManager: Added support to write bridge and bonding

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.60
+Version:        4.3.61
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/s390_device_activators/qeth.rb
+++ b/src/lib/y2network/s390_device_activators/qeth.rb
@@ -49,8 +49,7 @@ module Y2Network
         extra_attributes.concat(attributes.split(" ")) if attributes
         # Only set if enable
         extra_attributes << ipa_takeover_attribute if ipa_takeover
-        # Only set if enable
-        extra_attributes << layer2_attribute if layer2
+        extra_attributes << layer2_attribute
         extra_attributes << port_attribute if port_number.to_s != "0"
         extra_attributes
       end

--- a/src/lib/y2network/s390_device_activators/qeth.rb
+++ b/src/lib/y2network/s390_device_activators/qeth.rb
@@ -49,6 +49,9 @@ module Y2Network
         extra_attributes.concat(attributes.split(" ")) if attributes
         # Only set if enable
         extra_attributes << ipa_takeover_attribute if ipa_takeover
+        # By default the activation command uses layer2 autodetection but as
+        # this option is not exposed in the activation dialog we have to add it
+        # always (bsc#1183639)
         extra_attributes << layer2_attribute
         extra_attributes << port_attribute if port_number.to_s != "0"
         extra_attributes

--- a/test/y2network/s390_device_activators/qeth_test.rb
+++ b/test/y2network/s390_device_activators/qeth_test.rb
@@ -49,14 +49,14 @@ describe Y2Network::S390DeviceActivators::Qeth do
   describe "#configure" do
     it "tries to activate the group device associated with the defined device id" do
       expect(Yast::Execute).to receive(:on_target!)
-        .with("/sbin/chzdev", "qeth", subject.device_id, "-e",
+        .with("/sbin/chzdev", "qeth", subject.device_id, "-e", "layer2=0",
           stdout: :capture, stderr: :capture, allowed_exitstatus: 0..255)
       subject.configure
     end
 
     it "returns an array with the stdout, stderr, and command status" do
       expect(Yast::Execute).to receive(:on_target!)
-        .with("/sbin/chzdev", "qeth", subject.device_id, "-e",
+        .with("/sbin/chzdev", "qeth", subject.device_id, "-e", "layer2=0",
           stdout: :capture, stderr: :capture, allowed_exitstatus: 0..255)
         .and_return(chzdev_output)
 


### PR DESCRIPTION
## Problem

There is a checkbox in the s390 qeth activation dialog in order to enable "layer2" support. When the checkbox is checked we add the `layer2=1` argument to the activation call `czhdev -e group_device_id`, but in case of not checked we are using the auto-detection instead of giving the argument `layer2=0` explicitly.

The auto-detection could be fine in zVM but will not work on LPAR.

![S390QethActivationDialog](https://user-images.githubusercontent.com/7056681/111592491-c1cf7000-87c0-11eb-9024-81ebad96a0a9.png)

- https://bugzilla.suse.com/show_bug.cgi?id=1183639

## Solution

Add alwasy the argument `layer2` with the option selected to the activation call.

## Tests

- Adapted unit test
- Tested manually

```
y2network/s390_device_activator.rb(configure):80 Activating s390 device: 0.0.0700:0.0.0701:0.0.0702
lib/cheetah.rb(record_commands):160 Executing "/sbin/chzdev qeth 0.0.0700:0.0.0701:0.0.0702 -e layer2\=0".
```