### PR TITLE
Replace double splat argument as could be problematic

### DIFF
--- a/src/lib/y2network/network_manager/config_writer.rb
+++ b/src/lib/y2network/network_manager/config_writer.rb
@@ -38,8 +38,8 @@ module Y2Network
           opts = {
             routes: routes_for(conn, config.routing.routes),
             parent: conn.find_master(config.connections)
-          }.reject { |_k, v| v.nil? }
-          writer.write(conn, nil, **opts) # FIXME
+          }
+          writer.write(conn, nil, opts)
         end
       end
 

--- a/src/lib/y2network/network_manager/connection_config_writer.rb
+++ b/src/lib/y2network/network_manager/connection_config_writer.rb
@@ -36,7 +36,7 @@ module Y2Network
       # @param old_conn [ConnectionConfig::Base] Original connection
       #   configuration
       # @param opts [Hash] writer options
-      def write(conn, old_conn = nil, **opts)
+      def write(conn, old_conn = nil, opts = {})
         return if conn == old_conn
 
         path = SYSTEM_CONNECTIONS_PATH.join(conn.name).sub_ext(FILE_EXT)
@@ -46,7 +46,7 @@ module Y2Network
 
         ensure_permissions(path) unless ::File.exist?(path)
 
-        handler_class.new(file).write(conn, **opts)
+        handler_class.new(file).write(conn, opts)
         file.save
       end
 

--- a/src/lib/y2network/network_manager/connection_config_writers/base.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/base.rb
@@ -40,17 +40,20 @@ module Y2Network
         # Writes connection information to the interface configuration file
         #
         # @param conn [Y2Network::ConnectionConfig::Base] Connection to take settings from
-        # @param routes [<Array<Y2Network::Route>] routes associated with the connection
-        # @param parent [Y2Network::ConnectionConfig::Bonding, Y2Network::ConnectionConfig::Bridge]
-        def write(conn, routes: [], parent: nil)
+        # @param opts [Hash] additional options needed to write properly the
+        #   connection config
+        # @param opts [<Array<Y2Network::Route>] :routes associated with the connection
+        # @param opts [Y2Network::ConnectionConfig::Base] :parent device in
+        #   case that the connection to be written is an slave one.
+        def write(conn, opts = {})
           file.connection["id"] = conn.name
           file.connection["autoconnect"] = "false" if ["manual", "off"].include? conn.startmode.name
           file.connection["permissions"] = nil
           file.connection["interface-name"] = conn.interface
           file.connection["zone"] = conn.firewall_zone unless ["", nil].include? conn.firewall_zone
           conn.bootproto.dhcp? ? configure_dhcp(conn) : configure_ips(conn)
-          configure_routes(routes)
-          configure_as_child(parent) if parent
+          configure_routes(opts[:routes] || [])
+          configure_as_child(opts[:parent]) if opts[:parent]
           update_file(conn)
         end
 

--- a/src/lib/y2network/network_manager/connection_config_writers/base.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/base.rb
@@ -42,8 +42,8 @@ module Y2Network
         # @param conn [Y2Network::ConnectionConfig::Base] Connection to take settings from
         # @param opts [Hash] additional options needed to write properly the
         #   connection config
-        # @param opts [<Array<Y2Network::Route>] :routes associated with the connection
-        # @param opts [Y2Network::ConnectionConfig::Base] :parent device in
+        # @option opts [<Array<Y2Network::Route>] :routes associated with the connection
+        # @option opts [Y2Network::ConnectionConfig::Base] :parent device in
         #   case that the connection to be written is an slave one.
         def write(conn, opts = {})
           file.connection["id"] = conn.name

--- a/test/y2network/network_manager/config_writer_test.rb
+++ b/test/y2network/network_manager/config_writer_test.rb
@@ -71,7 +71,7 @@ describe Y2Network::NetworkManager::ConfigWriter do
     end
 
     it "writes connections configuration" do
-      expect(conn_config_writer).to receive(:write).with(eth0_conn, nil, routes: [])
+      expect(conn_config_writer).to receive(:write).with(eth0_conn, nil, routes: [], parent: nil)
       writer.write(config)
     end
   end

--- a/test/y2network/network_manager/connection_config_writer_test.rb
+++ b/test/y2network/network_manager/connection_config_writer_test.rb
@@ -75,7 +75,7 @@ describe Y2Network::NetworkManager::ConnectionConfigWriter do
 
     it "uses the appropiate handler" do
       expect(writer).to receive(:require).and_return(handler)
-      expect(handler).to receive(:write).with(conn)
+      expect(handler).to receive(:write).with(conn, {})
       writer.write(conn)
     end
 


### PR DESCRIPTION
## Problem

When the PR #1186 was merged the submission to IBS failed because **ruby2.5** and **ruby2.7** differs in the way double splat arguments are handled.

See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Basically a test failed because while in **ruby2.7** it expected the method to not receive any argument with `**empty_hash`, in case of **ruby2.5** it passes an empty hash argument.

## Solution

As in **ruby3.0** positional and keyword arguments will be separated and just to avoid possible issues we will use a hash argument instead of a double splat one.