### PR TITLE
Use the ESSID to name the NM config file

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 29 11:52:08 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use the ESSID to name the NetworkManager configuration files
+  for wireless networks (bsc#1183733).
+- 4.3.63
+
+-------------------------------------------------------------------
 Thu Mar 18 12:59:31 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - AutoYaST: Write NetworkManager configuration according to the

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.62
+Version:        4.3.63
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/network_manager/connection_config_writer.rb
+++ b/src/lib/y2network/network_manager/connection_config_writer.rb
@@ -39,7 +39,7 @@ module Y2Network
       def write(conn, old_conn = nil, opts = {})
         return if conn == old_conn
 
-        path = SYSTEM_CONNECTIONS_PATH.join(conn.name).sub_ext(FILE_EXT)
+        path = SYSTEM_CONNECTIONS_PATH.join(file_basename_for(conn)).sub_ext(FILE_EXT)
         file = CFA::NmConnection.new(path)
         handler_class = find_handler_class(conn.type)
         return nil if handler_class.nil?
@@ -73,6 +73,16 @@ module Y2Network
         log.info "Unknown connection type: '#{type}'. " \
                  "Connection handler could not be loaded: #{e.message}"
         nil
+      end
+
+      # Returns the file base name for the given connection
+      #
+      # @param conn [ConnectionConfig::Base]
+      # @return [String]
+      def file_basename_for(conn)
+        return conn.essid.to_s if conn.is_a?(ConnectionConfig::Wireless)
+
+        conn.name
       end
     end
   end


### PR DESCRIPTION
Instead of the interface name, use the ESSID to name the `NetworkManager` configuration file. So it will use `MY_WIRELESS.nmconnection` instead of `wlo1.nmconnection`. It keeps the interface name for the rest of the devices.

Bug: [bsc#1183733](https://bugzilla.opensuse.org/show_bug.cgi?id=1183733)
Related to: https://trello.com/c/jrNQOjfN/