### PR TITLE
Write DNS servers to NetworkManager configuration files

### DIFF
--- a/src/lib/cfa/nm_connection.rb
+++ b/src/lib/cfa/nm_connection.rb
@@ -21,6 +21,8 @@ require "cfa/base_model"
 require "pathname"
 require "y2network/connection_config/wireless"
 
+Yast.import "WFM"
+
 module CFA
   # Class to handle NetworkManager connection configuration files
   #
@@ -57,9 +59,7 @@ module CFA
       # @param conn [ConnectionConfig::Base]
       # @return [String]
       def file_basename_for(conn)
-        if conn.is_a?(Y2Network::ConnectionConfig::Wireless) && conn.essid
-          return conn.essid.to_s 
-        end
+        return conn.essid.to_s if conn.is_a?(Y2Network::ConnectionConfig::Wireless) && conn.essid
 
         conn.name
       end
@@ -117,7 +117,7 @@ module CFA
     #
     # @return [Boolean] true if the file exist, false otherwise
     def exist?
-      ::File.exist?(file_path)
+      ::File.exist?(::File.join(Yast::WFM.scr_root, file_path))
     end
 
     KNOWN_SECTIONS.each { |s| define_method(s) { section_for(s) } }

--- a/src/lib/cfa/nm_connection.rb
+++ b/src/lib/cfa/nm_connection.rb
@@ -72,7 +72,7 @@ module CFA
     def initialize(path, file_handler: nil)
       # FIXME: The Networkmanager lense writes the values surrounded by double
       # quotes which is not valid
-      super(AugeasParser.new("Puppet.lns"), path, file_handler: file_handler)
+      super(AugeasParser.new("Desktop.lns"), path, file_handler: file_handler)
     end
 
     # Returns the augeas tree for the given section

--- a/src/lib/y2network/connection_configs_collection.rb
+++ b/src/lib/y2network/connection_configs_collection.rb
@@ -72,6 +72,14 @@ module Y2Network
       select { |c| ids.include?(c.id) }
     end
 
+    # Returns connections with a given bootproto
+    #
+    # @param bootprotos [Array<BootProtocol>] Boot protocols
+    # @return [Array<ConnectionConfig::Base>] Connection configs with the given boot protocol
+    def by_bootproto(*bootprotos)
+      select { |c| bootprotos.include?(c.bootproto) }
+    end
+
     # Adds or updates a connection configuration
     #
     # @note It uses the name to do the matching.

--- a/src/lib/y2network/network_manager/connection_config_writer.rb
+++ b/src/lib/y2network/network_manager/connection_config_writer.rb
@@ -28,9 +28,6 @@ module Y2Network
     class ConnectionConfigWriter
       include Yast::Logger
 
-      SYSTEM_CONNECTIONS_PATH = Pathname.new("/etc/NetworkManager/system-connections").freeze
-      FILE_EXT = ".nmconnection".freeze
-
       # @param conn [ConnectionConfig::Base] Connection configuration to be
       #   written
       # @param old_conn [ConnectionConfig::Base] Original connection
@@ -39,12 +36,11 @@ module Y2Network
       def write(conn, old_conn = nil, opts = {})
         return if conn == old_conn
 
-        path = SYSTEM_CONNECTIONS_PATH.join(file_basename_for(conn)).sub_ext(FILE_EXT)
-        file = CFA::NmConnection.new(path)
+        file = CFA::NmConnection.for(conn)
         handler_class = find_handler_class(conn.type)
         return nil if handler_class.nil?
 
-        ensure_permissions(path) unless ::File.exist?(path)
+        ensure_permissions(file.file_path) unless file.file_path.exist?
 
         handler_class.new(file).write(conn, opts)
         file.save
@@ -73,16 +69,6 @@ module Y2Network
         log.info "Unknown connection type: '#{type}'. " \
                  "Connection handler could not be loaded: #{e.message}"
         nil
-      end
-
-      # Returns the file base name for the given connection
-      #
-      # @param conn [ConnectionConfig::Base]
-      # @return [String]
-      def file_basename_for(conn)
-        return conn.essid.to_s if conn.is_a?(ConnectionConfig::Wireless)
-
-        conn.name
       end
     end
   end

--- a/src/lib/y2network/network_manager/connection_config_writer.rb
+++ b/src/lib/y2network/network_manager/connection_config_writer.rb
@@ -40,7 +40,11 @@ module Y2Network
         handler_class = find_handler_class(conn.type)
         return nil if handler_class.nil?
 
-        ensure_permissions(file.file_path) unless file.file_path.exist?
+        if file.exist?
+          file.load
+        else
+          ensure_permissions(file.file_path)
+        end
 
         handler_class.new(file).write(conn, opts)
         file.save

--- a/test/cmdline_test.rb
+++ b/test/cmdline_test.rb
@@ -19,9 +19,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2network/interface_config_builder"
-
 require_relative "test_helper"
+require "y2network/interface_config_builder"
 
 class DummyClass < Yast::Module
   def initialize

--- a/test/support/config_writer_examples.rb
+++ b/test/support/config_writer_examples.rb
@@ -24,6 +24,7 @@ require "y2network/config_writers/dns_writer"
 require "y2network/connection_configs_collection"
 require "y2network/interfaces_collection"
 require "y2network/hostname"
+require "y2network/boot_protocol"
 
 RSpec.shared_examples "ConfigWriter" do
   subject(:writer) { described_class.new }
@@ -50,6 +51,7 @@ RSpec.shared_examples "ConfigWriter" do
     Y2Network::ConnectionConfig::Ethernet.new.tap do |conn|
       conn.interface = "eth0"
       conn.name = "eth0"
+      conn.bootproto = Y2Network::BootProtocol::DHCP
     end
   end
 

--- a/test/y2network/network_manager/config_writer_test.rb
+++ b/test/y2network/network_manager/config_writer_test.rb
@@ -24,6 +24,8 @@ require "y2network/config"
 require "y2network/connection_configs_collection"
 require "y2network/interface"
 require "y2network/interfaces_collection"
+require "y2network/boot_protocol"
+require "cfa/nm_connection"
 
 describe Y2Network::NetworkManager::ConfigWriter do
   subject(:writer) { described_class.new }
@@ -42,6 +44,7 @@ describe Y2Network::NetworkManager::ConfigWriter do
     let(:config) do
       old_config.copy.tap do |cfg|
         cfg.add_or_update_connection_config(eth0_conn)
+        cfg.dns = dns
       end
     end
 
@@ -49,9 +52,22 @@ describe Y2Network::NetworkManager::ConfigWriter do
       Y2Network::ConnectionConfig::Ethernet.new.tap do |conn|
         conn.interface = "eth0"
         conn.name = "eth0"
-        conn.bootproto = :static
+        conn.bootproto = Y2Network::BootProtocol::DHCP
         conn.ip = ip
       end
+    end
+
+    let(:nameserver1) { IPAddr.new("192.168.1.1") }
+    let(:nameserver2) { IPAddr.new("10.0.0.1") }
+    let(:nameserver3) { IPAddr.new("2000:e1dd:f002:0120:0000:0000:0000:0001") }
+    let(:nameserver4) { IPAddr.new("2000:e1dd:f002:0120:0000:0000:0000:0002") }
+
+    let(:dns) do
+      Y2Network::DNS.new(
+        nameservers: [
+          nameserver1, nameserver2, nameserver3, nameserver4
+        ]
+      )
     end
 
     let(:ip) { Y2Network::ConnectionConfig::IPConfig.new(address: IPAddr.new("192.168.122.2")) }
@@ -64,7 +80,6 @@ describe Y2Network::NetworkManager::ConfigWriter do
     before do
       allow(Y2Network::NetworkManager::ConnectionConfigWriter).to receive(:new)
         .and_return(conn_config_writer)
-      allow(writer).to receive(:write_dns)
       allow(writer).to receive(:write_drivers)
       allow(writer).to receive(:write_hostname)
       allow(writer).to receive(:write_routing)
@@ -74,5 +89,34 @@ describe Y2Network::NetworkManager::ConfigWriter do
       expect(conn_config_writer).to receive(:write).with(eth0_conn, nil, routes: [], parent: nil)
       writer.write(config)
     end
+
+    context "writes DNS configuration" do
+      context "when a connection has static configuration" do
+        let(:eth0_conn) do
+          Y2Network::ConnectionConfig::Ethernet.new.tap do |conn|
+            conn.interface = "eth0"
+            conn.name = "eth0"
+            conn.bootproto = Y2Network::BootProtocol::STATIC
+            conn.ip = ip
+          end
+        end
+
+        let(:file) do
+          CFA::NmConnection.new(File.join(DATA_PATH, "some_wifi.nmconnection"))
+        end
+
+        before do
+          allow(CFA::NmConnection).to receive(:for).and_return(file)
+          allow(file).to receive(:save)
+        end
+
+        it "includes DNS configuration in the configuration file" do
+          writer.write(config)
+          expect(file.ipv4["dns"]).to eq("#{nameserver1};#{nameserver2}")
+          expect(file.ipv6["dns"]).to eq("#{nameserver3};#{nameserver4}")
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Write DNS settings to NetworkManager configuration files when using static configuration.

~~TODO: augeas will use "quotes" when writing the values, and it will not work. However, if quotes are removed, augeas will crash. Should we use different parsers for reading/writing?~~ Using the *Desktop* lense, as suggested by @teclator, seems tow work.