### PR TITLE
Hide the abort button in a network subworkflow during installation

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Mon Apr  5 15:21:47 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
-- Do not show the "Abort" button during installation (bsc#1183586).
+- Do not show the "Abort" button when the inst_lan client is called
+  from another installation step (bsc#1183586).
 - 4.4.0
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr  5 15:21:47 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not show the "Abort" button during installation (bsc#1183586).
+- 4.4.0
+
+-------------------------------------------------------------------
 Mon Mar 29 11:52:08 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use the ESSID to name the NetworkManager configuration files

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.63
+Version:        4.4.0
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -253,7 +253,7 @@ module Yast
       )
 
       if running_installer
-        Wizard.SetAbortButton(:abort, Label.AbortButton)
+        Wizard.HideAbortButton
       else
         Wizard.SetAbortButton(:abort, Label.CancelButton)
         Wizard.HideBackButton

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -287,7 +287,7 @@ module Yast
     def hide_abort_button?
       return false unless running_installer?
 
-      GetInstArgs.argmap["disable_abort_button"] == true
+      GetInstArgs.argmap["hide_abort_button"] == true
     end
 
     # Whether running during installation

--- a/src/lib/installation/console/plugins/network_button.rb
+++ b/src/lib/installation/console/plugins/network_button.rb
@@ -41,10 +41,7 @@ module Installation
         end
 
         def handle
-          Yast::WFM.call(
-            "inst_lan",
-            [{ "skip_detection" => true, "disable_abort_button" => true }]
-          )
+          Yast::WFM.call("inst_lan", [{ "skip_detection" => true, "hide_abort_button" => true }])
 
           nil
         end

--- a/src/lib/installation/console/plugins/network_button.rb
+++ b/src/lib/installation/console/plugins/network_button.rb
@@ -41,7 +41,11 @@ module Installation
         end
 
         def handle
-          Yast::WFM.call("inst_lan", [{ "skip_detection" => true }])
+          Yast::WFM.call(
+            "inst_lan",
+            [{ "skip_detection" => true, "disable_abort_button" => true }]
+          )
+
           nil
         end
       end

--- a/src/lib/network/clients/inst_lan.rb
+++ b/src/lib/network/clients/inst_lan.rb
@@ -32,10 +32,15 @@ module Yast
   # sequence.
   #
   # The configuration sequence can be forced passing the 'skip_detection'
-  # argument.
+  # argument. Additionally, the abort button could be hide passing the
+  # 'hide_abort_button' argument
   #
-  # @example calling the client forcing the configuration sequence
-  #   Yast::WFM.CallFunction("inst_lan", [args.merge("skip_detection" => true)])
+  # @example calling the client forcing the configuration sequence and hiding
+  # the abort button
+  #   Yast::WFM.CallFunction(
+  #     "inst_lan",
+  #     [args.merge("skip_detection" => true, "hide_abort_button" => true)]
+  #   )
   #
   # @example firsboot xml forcing the configuration sequence
   #   <module>

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -138,7 +138,10 @@ module Yast
     def launch_network_configuration(args)
       log.info "Launching network configuration"
       Yast::Wizard.OpenAcceptDialog
-      result = Yast::WFM.CallFunction("inst_lan", [args.merge("skip_detection" => true)])
+      result = Yast::WFM.CallFunction(
+        "inst_lan",
+        [args.merge("skip_detection" => true, "hide_abort_button" => true)]
+      )
       log.info "Returning from the network configuration with: #{result}"
       result
     ensure


### PR DESCRIPTION
### Problem

> When user presses Abort button on Network settings page, it works same way as "Back" button and returns to the previous dialog. — https://bugzilla.suse.com/show_bug.cgi?id=1183586

As stated in the [second comment](https://bugzilla.suse.com/show_bug.cgi?id=1183586#c2), this happens

>  because the network **subworkflow** should not use [Abort] (...) It should be possible to **abort only in the main workflow**.

### Solution

To use an installation argument (`hide_abort_button`) to set when the abort button should be hide, since hiding it always during installation will break the installation UI consistence when the client will be used in the main workflow.

### Notes

As it can be seen in the proposed changes, the call to `Yast::Wizard.HideAbortButton` has been placed in _src/include/network/lan/complex.rb_ [`#MainDialog`](https://github.com/yast/yast-network/blob/618c9d5432a59c179b80ca64e7372a0bc9f7cdec/src/include/network/lan/complex.rb#L256) method, since trying to place it somewhere before in the backtrace does not work (it worked for `Yast::Wizard::DisableAbortButton` but not for hiding it, which actually _worked_ partially being hide and displayed again :confused:).

For the record, the full _path_ is 

[_src/lib/network/clients/inst_lan.rb_](https://github.com/yast/yast-network/blob/618c9d5432a59c179b80ca64e7372a0bc9f7cdec/src/lib/network/clients/inst_lan.rb#L67) -> [_src/include/network/lan/wizards.rb_#LanSequences](https://github.com/yast/yast-network/blob/618c9d5432a59c179b80ca64e7372a0bc9f7cdec/src/include/network/lan/wizards.rb#L57) -> [_src/include/network/lan/wizards.rb_#MainSequence](https://github.com/yast/yast-network/blob/618c9d5432a59c179b80ca64e7372a0bc9f7cdec/src/include/network/lan/wizards.rb#L121) -> [_src/include/network/lan/complex.rb_#MainDialog](https://github.com/yast/yast-network/blob/618c9d5432a59c179b80ca64e7372a0bc9f7cdec/src/include/network/lan/complex.rb#L217)

### Tests

* Only tested manually using `yupdate` to apply changes in a SLE 15-SP3 Build 168.1 

### Screenshots

| Patching the installer | The client running in an installation sub-workflow, w/o the abort button |
|-|-|
| ![Patching the SUSE SLE installer via yupdate](https://user-images.githubusercontent.com/1691872/113743921-1a2cca00-96fc-11eb-808e-3add0d2ab531.png) | ![Network inst_lan client without the abort button](https://user-images.githubusercontent.com/1691872/113594004-02d3db00-962f-11eb-8e56-5d1483120f25.png) |

---

Related Trello card (internal link): https://trello.com/c/6M4weND5



