### PR TITLE
Display network configuration in the summary screen for NetworkManager

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Apr  8 09:27:47 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Display the network configuration in the installation summary
+  screen even if NetworkManager is the selected backend
+  (bsc#1181354).
+- 4.4.1
+
+-------------------------------------------------------------------
 Wed Apr  7 11:27:26 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Write DNS servers to NetworkManager connection files when using

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -96,7 +96,7 @@ module Yast
 
       proposal_text = switch_backend_link
       proposal_text << toggle_virt_proposal_link if settings.virtual_proposal_required?
-      proposal_text.prepend(proposal_summary.text) if wicked_backend?
+      proposal_text.prepend(proposal_summary.text)
       proposal_text
     end
 
@@ -120,7 +120,7 @@ module Yast
       # TRANSLATORS: information about the network backend in use. %s is the name of backend,
       # example "wicked" or "NetworkManager"
       backend_in_use = _("Using <b>%s</b>")
-      # TRANSLATORS: text of link for switch to another network backend. %s is the name of backend,
+      # TRANSLATORS: text of link to switch to another network backend. %s is the name of backend,
       # example "wicked" or "NetworkManager"
       switch_to = _("switch to %s")
 

--- a/test/network_proposal_test.rb
+++ b/test/network_proposal_test.rb
@@ -79,11 +79,11 @@ describe Yast::NetworkProposal do
         expect(proposal["preformatted_proposal"]).to include("rich_text_summary")
       end
 
-      it "includes a link for switch to NetworkManager" do
+      it "includes a link to switch to NetworkManager" do
         expect(proposal["preformatted_proposal"]).to match(/.*href.*NetworkManager.*/)
       end
 
-      it "does not include a link for switch to wicked" do
+      it "does not include a link to switch to wicked" do
         expect(proposal["preformatted_proposal"]).to_not match(/.*href.*wicked.*/)
       end
 
@@ -99,15 +99,11 @@ describe Yast::NetworkProposal do
     context "when using the NetworkManager backend" do
       let(:current_backend) { :network_manager }
 
-      it "does not include the Yast::Lan proposal summary" do
-        expect(proposal["preformatted_proposal"]).to_not include("rich_text_summary")
-      end
-
-      it "does not include a link for switch to NetworkManager" do
+      it "does not include a link to switch to NetworkManager" do
         expect(proposal["preformatted_proposal"]).to_not match(/.*href.*NetworkManager.*/)
       end
 
-      it "includes a link for switch to wicked" do
+      it "includes a link to switch to wicked" do
         expect(proposal["preformatted_proposal"]).to match(/.*href.*wicked.*/)
       end
     end


### PR DESCRIPTION
Until now, YaST did not show the network configuration details in the summary screen when NetworkManager was the selected backend. Now, that's not the case anymore, and the network configuration is shown always.

* [bsc#1181354](https://bugzilla.suse.com/show_bug.cgi?id=1181354)
* Trello: https://trello.com/c/xM0pDT6t/

![Installation summary](https://user-images.githubusercontent.com/15836/114017479-f6849380-9863-11eb-9bed-6024153868fa.png)

