### PR TITLE
Write bonding slaves config properly

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Apr  9 11:22:42 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- bsc#1181956
+  - Omit empty values or the '0.0.0.0' IPADDR when writing ifcfg
+    files.
+  - Do not write empty ifroute files.
+- 4.4.2
+
+-------------------------------------------------------------------
 Thu Apr  8 09:27:47 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Display the network configuration in the installation summary

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/boot_protocol.rb
+++ b/src/lib/y2network/boot_protocol.rb
@@ -43,6 +43,7 @@ module Y2Network
 
     # @return [String] Returns protocol name
     attr_reader :name
+    alias_method :to_s, :name
 
     # Constructor
     #

--- a/src/lib/y2network/wicked/config_writer.rb
+++ b/src/lib/y2network/wicked/config_writer.rb
@@ -64,10 +64,12 @@ module Y2Network
           file = routes_file_for(dev)
 
           # Remove ifroutes-* if empty or interface is not configured
-          file.remove if routes.empty? || !config.configured_interface?(dev.name)
-
-          file.routes = routes
-          file.save
+          if routes.empty? || !config.configured_interface?(dev.name)
+            file.remove
+          else
+            file.routes = routes
+            file.save
+          end
         end
 
         # Actions needed for removed interfaces

--- a/test/y2network/wicked/connection_config_writers/bridge_test.rb
+++ b/test/y2network/wicked/connection_config_writers/bridge_test.rb
@@ -47,7 +47,7 @@ describe Y2Network::Wicked::ConnectionConfigWriters::Bridge do
     it "writes common properties" do
       handler.write(conn)
       expect(file).to have_attributes(
-        name:      conn.description,
+        name:      nil,
         startmode: "auto",
         bootproto: "dhcp"
       )


### PR DESCRIPTION
## Problem

When a connection config is written we are adding attributes with empty values which are irrelevant and could be omitted. In case of bonding we are also adding slaves with the _0.0.0.0_ **IPADDR** which is invalid.

- https://trello.com/c/KFilasdD/2381-3-network-ng-clean-up-configuration-to-be-written

## Solution

- Skip empty values when writing.
- Skip the write of the static _0.0.0.0_ **IPADDR**.
- Do not create empty ifroute files.

![Written bonding config](https://user-images.githubusercontent.com/7056681/114171959-f0a6b500-992c-11eb-8d49-a47f093123f9.png)

