### PR TITLE
Do not require to set a MAC address when L2 support is enabled

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 12 12:05:02 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not require a MAC address when activating a qeth device
+  with layer2 support (bsc#1184474).
+- 4.3.65
+
+-------------------------------------------------------------------
 Wed Apr  7 11:27:26 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Write DNS servers to NetworkManager connection files when using

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.64
+Version:        4.3.65
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/s390_common.rb
+++ b/src/lib/y2network/widgets/s390_common.rb
@@ -272,9 +272,9 @@ module Y2Network
           Yast::Label.WarningMsg,
           wrap_text(format(
             # TRANSLATORS: Popup trying to prevent the user to set an specific MAC address
-            _("Specifying a MAC address is optional. \n\n" \
+            _("Specifying a MAC address is optional.\n\n" \
               "In most cases, leaving it empty and taking the default " \
-              "assigned by the system is the correct choice. \n\n" \
+              "assigned by the system is the correct choice.\n\n" \
               "Do you really want to set it to '%s'?"),
             mac_address_widget.value
           ))

--- a/src/lib/y2network/widgets/s390_common.rb
+++ b/src/lib/y2network/widgets/s390_common.rb
@@ -244,11 +244,18 @@ module Y2Network
         nil
       end
 
+      # @see CWM::AbstractWidget
       def validate
         return true if !layer2? || valid_mac?(mac_address_widget.value)
 
         report_mac_error
         false
+      end
+
+      # @see CWM::AbstractWidget
+      def store
+        @settings.layer2 = layer2?
+        @settings.lladdress = layer2? ? lladdress_for(mac_address_widget.value) : nil
       end
 
     private
@@ -272,10 +279,21 @@ module Y2Network
       # @return [Boolean] true when valid; false otherwise
       # @param mac_address [String]
       def valid_mac?(mac_address)
-        return false if mac_address.to_s.empty?
-        return false if mac_address == "00:00:00:00:00:00"
+        return true unless lladdress_for(mac_address)
 
         !!(mac_address =~ /^([0-9a-fA-F]{2}[:-]){5}[0-9a-fA-F]{2}$/i)
+      end
+
+      # Return the MAC address in case it is not empty or a zero's MAC address
+      # otherwise it returns nil.
+      #
+      # @param mac_widget_value [String]
+      # @return [String, nil] the MAC address in case it is not empty or a
+      #   zero's MAC address; nil otherwise
+      def lladdress_for(mac_widget_value)
+        return if ["", "00:00:00:00:00:00"].include?(mac_widget_value.to_s)
+
+        mac_widget_value
       end
 
       # Convenience method to enable or disable the mac address widget when the
@@ -326,11 +344,6 @@ module Y2Network
         "<p>Select <b>Enable Layer 2 Support</b> if this card has been " \
          "configured with layer 2 support.</p>"
       end
-
-      # @see CWM::AbstractWidget
-      def store
-        @settings.layer2 = value
-      end
     end
 
     # Widget for setting the mac address to be used in case of layer2 supported
@@ -357,11 +370,6 @@ module Y2Network
       def help
         _("<p>Enter the <b>Layer 2 MAC Address</b> if this card has been " \
           "configured with layer 2 support.</p>")
-      end
-
-      # @see CWM::AbstractWidget
-      def store
-        @settings.lladdress = value
       end
     end
   end

--- a/src/lib/y2network/widgets/s390_common.rb
+++ b/src/lib/y2network/widgets/s390_common.rb
@@ -19,6 +19,7 @@
 
 require "cwm/common_widgets"
 require "cwm/custom_widget"
+require "ui/text_helpers"
 
 module Y2Network
   module Widgets
@@ -212,6 +213,7 @@ module Y2Network
     # and an input field for setting the mac address to be used in case of
     # enablement.
     class S390Layer2 < CWM::CustomWidget
+      include ::UI::TextHelpers
       # Constructor
       #
       # @param settings [Y2Network::InterfaceConfigBuilder]
@@ -268,13 +270,14 @@ module Y2Network
       def use_selected_mac?
         Yast::Popup.YesNoHeadline(
           Yast::Label.WarningMsg,
-          format(
+          wrap_text(format(
             # TRANSLATORS: Popup trying to prevent the user to set an specific MAC address
-            _("Specifying a MAC address is optional. \n" \
-            "In most cases, letting it empty (default) is the correct choice. \n\n" \
-            "Do you really want to set it to '%s'?"),
+            _("Specifying a MAC address is optional. \n\n" \
+              "In most cases, leaving it empty and taking the default " \
+              "assigned by the system is the correct choice. \n\n" \
+              "Do you really want to set it to '%s'?"),
             mac_address_widget.value
-          )
+          ))
         )
       end
 

--- a/src/lib/y2network/widgets/s390_common.rb
+++ b/src/lib/y2network/widgets/s390_common.rb
@@ -381,7 +381,7 @@ module Y2Network
 
       # @see CWM::AbstractWidget
       def label
-        _("Layer2 MAC Address")
+        _("Layer2 MAC Address (optional)")
       end
 
       # @see CWM::AbstractWidget

--- a/src/lib/y2network/widgets/s390_common.rb
+++ b/src/lib/y2network/widgets/s390_common.rb
@@ -246,10 +246,15 @@ module Y2Network
 
       # @see CWM::AbstractWidget
       def validate
-        return true if !layer2? || valid_mac?(mac_address_widget.value)
+        return true if !layer2? || !lladdress_for(mac_address_widget.value)
 
-        report_mac_error
-        false
+        unless valid_mac?(mac_address_widget.value)
+          report_mac_error
+
+          return false
+        end
+
+        use_selected_mac?
       end
 
       # @see CWM::AbstractWidget
@@ -259,6 +264,19 @@ module Y2Network
       end
 
     private
+
+      def use_selected_mac?
+        Yast::Popup.YesNoHeadline(
+          Yast::Label.WarningMsg,
+          format(
+            # TRANSLATORS: Popup trying to prevent the user to set an specific MAC address
+            _("Specifying a MAC address is optional. \n" \
+            "In most cases letting it empty (default) is the correct choice. \n\n" \
+            "Do you really want to set it it '%s'?"),
+            mac_address_widget.value
+          )
+        )
+      end
 
       def report_mac_error
         # TRANSLATORS: Popup error about not valid MAC address provided

--- a/src/lib/y2network/widgets/s390_common.rb
+++ b/src/lib/y2network/widgets/s390_common.rb
@@ -271,8 +271,8 @@ module Y2Network
           format(
             # TRANSLATORS: Popup trying to prevent the user to set an specific MAC address
             _("Specifying a MAC address is optional. \n" \
-            "In most cases letting it empty (default) is the correct choice. \n\n" \
-            "Do you really want to set it it '%s'?"),
+            "In most cases, letting it empty (default) is the correct choice. \n\n" \
+            "Do you really want to set it to '%s'?"),
             mac_address_widget.value
           )
         )

--- a/src/lib/y2network/widgets/s390_common.rb
+++ b/src/lib/y2network/widgets/s390_common.rb
@@ -369,7 +369,7 @@ module Y2Network
       # @see CWM::AbstractWidget
       def help
         _("<p>Enter the <b>Layer 2 MAC Address</b> if this card has been " \
-          "configured with layer 2 support.</p>")
+          "configured with layer 2 support <b>(optional)</b>.</p>")
       end
     end
   end

--- a/test/y2network/widgets/s390_common_test.rb
+++ b/test/y2network/widgets/s390_common_test.rb
@@ -177,7 +177,7 @@ describe Y2Network::Widgets::S390Layer2 do
         subject.store
       end
 
-      context "and the MAC address is not empty and neither is it '00:00:00:00:00:00'" do
+      context "and the MAC address is not empty and neither it is '00:00:00:00:00:00'" do
         let(:layer2_address) { "02:00:00:00:01" }
 
         it "sets the builder lladdress attribute to the MAC address widget value" do

--- a/test/y2network/widgets/s390_common_test.rb
+++ b/test/y2network/widgets/s390_common_test.rb
@@ -138,8 +138,19 @@ describe Y2Network::Widgets::S390Layer2 do
       context "and the MAC provided is a valid one" do
         let(:layer2_address) { "02:00:00:00:01:FD" }
 
-        it "returns true" do
+        it "requests user confirmation before storing the defined MAC" do
+          expect(subject).to receive(:use_selected_mac?)
+          subject.validate
+        end
+
+        it "returns true if the user accepts" do
+          allow(subject).to receive(:use_selected_mac?).and_return(true)
           expect(subject.validate).to eql(true)
+        end
+
+        it "returns false if the user reject" do
+          allow(subject).to receive(:use_selected_mac?).and_return(false)
+          expect(subject.validate).to eql(false)
         end
       end
 

--- a/test/y2network/widgets/s390_common_test.rb
+++ b/test/y2network/widgets/s390_common_test.rb
@@ -121,7 +121,21 @@ describe Y2Network::Widgets::S390Layer2 do
     end
 
     context "when the layer2 support is enabled" do
-      context "and the MAC provided is valid" do
+      context "and the MAC address is empty" do
+        let(:layer2_address) { "" }
+
+        it "returns true" do
+          expect(subject.validate).to eql(true)
+        end
+      end
+
+      context "and the MAC address is '00:00:00:00:00:00'" do
+        it "returns true" do
+          expect(subject.validate).to eql(true)
+        end
+      end
+
+      context "and the MAC provided is a valid one" do
         let(:layer2_address) { "02:00:00:00:01:FD" }
 
         it "returns true" do
@@ -130,6 +144,8 @@ describe Y2Network::Widgets::S390Layer2 do
       end
 
       context "and the MAC address provided is invalid" do
+        let(:layer2_address) { "02:00:00:00:01" }
+
         it "returns false" do
           allow(Yast::Popup).to receive(:Error)
           expect(subject.validate).to eql(false)
@@ -139,6 +155,45 @@ describe Y2Network::Widgets::S390Layer2 do
           expect(Yast::Popup).to receive(:Error).with(/MAC address provided is not valid/)
           expect(subject.validate).to eql(false)
         end
+      end
+    end
+  end
+
+  describe "#store" do
+    context "when the layer2 support checkbox is checked" do
+      it "sets the builder layer2 attribute to true" do
+        expect(builder).to receive("layer2=").with(true)
+        subject.store
+      end
+
+      context "and the MAC address is not empty and neither is it '00:00:00:00:00:00'" do
+        let(:layer2_address) { "02:00:00:00:01" }
+
+        it "sets the builder lladdress attribute to the MAC address widget value" do
+          expect(builder).to receive("lladdress=").with("02:00:00:00:01")
+          subject.store
+        end
+      end
+
+      context "and the MAC address is empty or '00:00:00:00:00:00'" do
+        it "sets the builder lladdress attribute to nil" do
+          expect(builder).to receive("lladdress=").with(nil)
+          subject.store
+        end
+      end
+    end
+
+    context "when the layer2 support checkbox is not checked" do
+      let(:layer2_support) { false }
+
+      it "sets the builder layer2 attribute to false" do
+        expect(builder).to receive("layer2=").with(false)
+        subject.store
+      end
+
+      it "sets the builder lladdress attribute to nil" do
+        expect(builder).to receive("lladdress=").with(nil)
+        subject.store
       end
     end
   end


### PR DESCRIPTION
## Problem

It is required to enter a valid **MAC** address when activating a **qeth** device with **L2** support. This MAC in case of a zVM is usually assigned and specifying a different one is not authorized.

![S390QethActivation](https://user-images.githubusercontent.com/7056681/114558669-d5a4af80-9c62-11eb-8da6-6ffd4550ed68.png)

- https://bugzilla.suse.com/show_bug.cgi?id=1184474

## Solution

- Establishing a **MAC** address is not required anymore.
- Request confirmation for storing the selected **MAC** address.

## Screenshots

![S390QethMACConfirmation](https://user-images.githubusercontent.com/7056681/114675748-82813a00-9d00-11eb-9c0a-85e41ff633ae.png)
![S390QethActivationHelpText](https://user-images.githubusercontent.com/7056681/114559111-4ba91680-9c63-11eb-8a33-b98b40f56250.png)


