### PR TITLE
Do not crash when checking if an interface is a hotplug one (bsc#1184623)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 13 12:32:16 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not crash when checking if an interface is a hotplug one and
+  it is not present (bsc#1184623)
+- 4.4.3
+
+-------------------------------------------------------------------
 Fri Apr  9 11:22:42 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - bsc#1181956

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -57,31 +57,33 @@ module Yast
     def AddressDialog(builder:)
       ret = Y2Network::Dialogs::EditInterface.run(builder)
 
-      if ret != :back && ret != :abort
-        if builder.boot_protocol.dhcp? && !builder.interface.hotplug?
-          # fixed bug #73739 - if dhcp is used, dont set default gw statically
-          # but also: reset default gw only if DHCP* is used, this branch covers
-          #     "No IP address" case, then default gw must stay (#460262)
-          # and also: don't delete default GW for usb/pcmcia devices (#307102)
-          #
-          # Is check for hotplug really needed? It contained a typo up to SLE-15-SP4 and
-          # nobody complained - something to think of during next refactoring.
-          yast_config = Y2Network::Config.find(:yast)
-          if yast_config&.routing&.default_route
-            remove_gw = Popup.YesNo(
-              _(
-                "A static default route is defined.\n" \
-                "It is suggested to remove the static default route definition \n" \
-                "if one can be obtained also via DHCP.\n" \
-                "Do you want to remove the static default route?"
-              )
+      log.info "AddressDialog res: #{ret.inspect}"
+
+      return ret if [:back, :abort].include?(ret)
+      return ret if builder.interface&.hotplug?
+
+      if builder.boot_protocol.dhcp?
+        # fixed bug #73739 - if dhcp is used, dont set default gw statically
+        # but also: reset default gw only if DHCP* is used, this branch covers
+        #     "No IP address" case, then default gw must stay (#460262)
+        # and also: don't delete default GW for usb/pcmcia devices (#307102)
+        #
+        # Is check for hotplug really needed? It contained a typo up to SLE-15-SP4 and
+        # nobody complained - something to think of during next refactoring.
+        yast_config = Y2Network::Config.find(:yast)
+        if yast_config&.routing&.default_route
+          remove_gw = Popup.YesNo(
+            _(
+              "A static default route is defined.\n" \
+              "It is suggested to remove the static default route definition \n" \
+              "if one can be obtained also via DHCP.\n" \
+              "Do you want to remove the static default route?"
             )
-            yast_config.routing.remove_default_routes if remove_gw
-          end
+          )
+          yast_config.routing.remove_default_routes if remove_gw
         end
       end
 
-      log.info "AddressDialog res: #{ret.inspect}"
       ret
     end
   end

--- a/src/include/network/lan/address.rb
+++ b/src/include/network/lan/address.rb
@@ -60,28 +60,26 @@ module Yast
       log.info "AddressDialog res: #{ret.inspect}"
 
       return ret if [:back, :abort].include?(ret)
-      return ret if builder.interface&.hotplug?
+      return ret if builder.interface&.hotplug? || !builder.boot_protocol.dhcp?
 
-      if builder.boot_protocol.dhcp?
-        # fixed bug #73739 - if dhcp is used, dont set default gw statically
-        # but also: reset default gw only if DHCP* is used, this branch covers
-        #     "No IP address" case, then default gw must stay (#460262)
-        # and also: don't delete default GW for usb/pcmcia devices (#307102)
-        #
-        # Is check for hotplug really needed? It contained a typo up to SLE-15-SP4 and
-        # nobody complained - something to think of during next refactoring.
-        yast_config = Y2Network::Config.find(:yast)
-        if yast_config&.routing&.default_route
-          remove_gw = Popup.YesNo(
-            _(
-              "A static default route is defined.\n" \
-              "It is suggested to remove the static default route definition \n" \
-              "if one can be obtained also via DHCP.\n" \
-              "Do you want to remove the static default route?"
-            )
+      # fixed bug #73739 - if dhcp is used, dont set default gw statically
+      # but also: reset default gw only if DHCP* is used, this branch covers
+      #     "No IP address" case, then default gw must stay (#460262)
+      # and also: don't delete default GW for usb/pcmcia devices (#307102)
+      #
+      # Is check for hotplug really needed? It contained a typo up to SLE-15-SP4 and
+      # nobody complained - something to think of during next refactoring.
+      yast_config = Y2Network::Config.find(:yast)
+      if yast_config&.routing&.default_route
+        remove_gw = Popup.YesNo(
+          _(
+            "A static default route is defined.\n" \
+            "It is suggested to remove the static default route definition \n" \
+            "if one can be obtained also via DHCP.\n" \
+            "Do you want to remove the static default route?"
           )
-          yast_config.routing.remove_default_routes if remove_gw
-        end
+        )
+        yast_config.routing.remove_default_routes if remove_gw
       end
 
       ret


### PR DESCRIPTION
## Problem

When we try to configure a virtual interface or an interface which is not present it does not have an interface associated and the hotplug check produces a crash.

- https://bugzilla.suse.com/show_bug.cgi?id=1184623

## Solution

- Just do not crash when the interface is not present and return early in case of a hotplug interface.

## Tests

- Tested manually