### PR TITLE
Reading errors

### DIFF
--- a/src/lib/y2network/config_reader.rb
+++ b/src/lib/y2network/config_reader.rb
@@ -48,9 +48,10 @@ module Y2Network
 
     # Returns the configuration from the given backend
     #
-    # @return [Y2Network::Config] Network configuration
+    # @return [Y2Network::ReadingResult] Network configuration
+    # @raise NotImplementedError
     def config
-      Y2Network::Config.new
+      raise NotImplementedError
     end
   end
 end

--- a/src/lib/y2network/errors.rb
+++ b/src/lib/y2network/errors.rb
@@ -1,0 +1,137 @@
+# encoding: utf-8
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2network/wicked/connection_config_reader"
+require "forwardable"
+
+module Y2Network
+  module Errors
+    class List
+      include Enumerable
+      extend Forwardable
+
+      def_delegators :@items, :each, :empty?, :<<
+
+      # Constructor
+      #
+      # @param [Array<Error>] List of errors
+      def initialize(items = [])
+        @items = items
+      end
+
+      # Concats two lists into a new one
+      #
+      # @return [List]
+      def +(other)
+        List.new(@items + other.items)
+      end
+    end
+
+    class Base
+      include Yast::I18n
+
+      # @return [Symbol]
+      def severity
+        raise NotImplementedError
+      end
+
+      # @return [String]
+      def message
+        raise NotImplementedError
+      end
+    end
+
+    # Represents an invalid value
+    class InvalidValue < Base
+      attr_reader :subject
+      attr_reader :value
+      attr_reader :fallback
+
+      def initialize(subject, value, fallback = nil)
+        @subject = subject
+        @value = value
+        @fallback = fallback
+      end
+
+      def severity
+        :warn
+      end
+
+      def message
+        msg = format(_("Invalid value '%{value}' for '%{subject}'."), value: value, subject: subject)
+        if fallback
+          msg << " " + format(_("Using '%{fallback}' instead."), fallback: fallback)
+        end
+        msg
+      end
+    end
+
+    # Represents an invalid value
+    class MissingValue < Base
+      attr_reader :subject
+      attr_reader :fallback
+
+      def initialize(subject, fallback = nil)
+        @subject = subject
+        @fallback = fallback
+      end
+
+      def severity
+        :warn
+      end
+
+      def message
+        msg = format(_("Missing '%{subject}'."), subject: subject)
+        if fallback
+          msg << " " + format(_("Using '%{fallback}' instead."), fallback: fallback)
+        end
+        msg
+      end
+    end
+
+    # Formats a list of error to be presented to the user
+    class Presenter
+      include Yast::I18n
+
+      attr_reader :list
+
+      def initialize(list)
+        @list = list
+      end
+
+      def to_s
+        lines = list.map do |error|
+          "* #{error.severity}: #{error.message}"
+        end
+        message + lines.join("\n")
+      end
+
+      def to_html
+        Yast::HTML.Para(message) + Yast::HTML.List(list.map(&:message))
+      end
+
+      def message
+        _("The following errors were detected while reading the network configuration:")
+      end
+    end
+  end
+end

--- a/src/lib/y2network/reading_result.rb
+++ b/src/lib/y2network/reading_result.rb
@@ -1,0 +1,55 @@
+# encoding: utf-8
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2network/errors"
+
+module Y2Network
+  class ReadingResult
+    attr_reader :config, :errors
+
+    # Represents a reading operation result
+    #
+    # @fixme does it make sense when writing changes?
+    #
+    # @param config [Config] Read configuration
+    # @param errors [Errors::List] Errors list
+    def initialize(config, errors = Errors::List.new)
+      @config = config
+      @errors = errors
+    end
+
+    # Determines whether there is some error
+    #
+    # @return [Boolean]
+    def errors?
+      errors.any?
+    end
+
+    # Generates a new result containing the updated config and the full list of errors
+    #
+    # @param other [ReadingResult] Result to merge
+    # @return [ReadingResult]
+    def merge(other)
+      ReadingResult.new(other.config, errors + other.errors)
+    end
+  end
+end

--- a/src/lib/y2network/wicked/config_reader.rb
+++ b/src/lib/y2network/wicked/config_reader.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 require "yast"
 require "cfa/sysctl_config"
+require "y2network/config"
 require "y2network/config_reader"
 require "y2network/interface"
 require "y2network/routing"
@@ -27,6 +28,8 @@ require "y2network/wicked/dns_reader"
 require "y2network/wicked/hostname_reader"
 require "y2network/wicked/interfaces_reader"
 require "y2network/wicked/connection_configs_reader"
+require "y2network/reading_result"
+require "y2network/errors"
 
 Yast.import "NetworkInterfaces"
 Yast.import "Host"
@@ -49,12 +52,12 @@ module Y2Network
 
         initial_config = Config.new(source: :wicked)
 
-        result = SECTIONS.reduce(initial_config) do |current_config, section|
+        network_config = SECTIONS.reduce(initial_config) do |current_config, section|
           send("read_#{section}", current_config)
         end
 
-        log.info "Sysconfig reader result: #{result.inspect}"
-        result
+        log.info "Sysconfig reader result: #{network_config.inspect}"
+        ReadingResult.new(network_config, errors_list)
       end
 
     protected
@@ -134,7 +137,9 @@ module Y2Network
 
       # @return [Y2Network::ConnectionConfigsCollection] Connection configurations collection
       def connection_configs_reader
-        @connection_configs_reader ||= Y2Network::Wicked::ConnectionConfigsReader.new
+        @connection_configs_reader ||= Y2Network::Wicked::ConnectionConfigsReader.new(
+          errors_list
+        )
       end
 
       # Adds missing interfaces from connections
@@ -213,6 +218,10 @@ module Y2Network
         @sysctl_config_file = CFA::SysctlConfig.new
         @sysctl_config_file.load
         @sysctl_config_file
+      end
+
+      def errors_list
+        @errors_list ||= Y2Network::Errors::List.new
       end
     end
   end

--- a/src/lib/y2network/wicked/connection_config_reader.rb
+++ b/src/lib/y2network/wicked/connection_config_reader.rb
@@ -29,16 +29,16 @@ module Y2Network
       #
       # @param name [String] Interface name
       # @param type [InterfaceType, string, nil] Interface type; if the type is unknown,
-      #   `nil` can be used and it will be guessed from the configuration file is possible.
+      #   `nil` can be used and it will be guessed from the configuration file if possible.
       #
       # @return [Y2Network::ConnectionConfig::Base]
-      def read(name, type)
+      def read(name, type, errors_list)
         file = CFA::InterfaceFile.new(name)
         file.load
         handler_class = find_handler_class(type || file.type)
         return nil if handler_class.nil?
 
-        handler_class.new(file).connection_config
+        handler_class.new(file, errors_list).connection_config
       end
 
     private

--- a/src/lib/y2network/wicked/connection_configs_reader.rb
+++ b/src/lib/y2network/wicked/connection_configs_reader.rb
@@ -28,6 +28,13 @@ module Y2Network
     #
     # @see Y2Network::ConnectionConfigsCollection
     class ConnectionConfigsReader
+      attr_reader :errors_list
+
+      # @param errors_list [Errors::List] List to register errors
+      def initialize(errors_list)
+        @errors_list = errors_list
+      end
+
       # Returns the connection configurations from sysconfig
       #
       # It needs the list of known interfaces in order to infer
@@ -41,7 +48,8 @@ module Y2Network
           interface = interfaces.by_name(file.interface)
           connection = ConnectionConfigReader.new.read(
             file.interface,
-            interface ? interface.type : nil
+            interface ? interface.type : nil,
+            errors_list
           )
           conns << connection if connection
         end


### PR DESCRIPTION
This PR contains a proposal to handle errors when reading the network configuration. The solution could be moved to `yast2.rpm` and used in more places.

**It is still a WIP, but feedback is welcome!**

## The Problem

When reading the network configuration, many things can go wrong. And, usually, YaST is [not able to handle those situations](https://bugzilla.suse.com/show_bug.cgi?id=1181296).

## The Proposed Solution

The idea is to provide a mechanism similar to [AutoinstIssues](https://github.com/yast/yast-yast2/blob/master/library/general/src/lib/installation/autoinst_issues.rb) to register and report errors to the user. In this PR, we are handling the case where `BOOTPROTO` contains an invalid name. Additionally, we are falling back to a sensible (not yet) value and asking the user whether we should continue.

<details>
<summary>Screenshot: Invalid network configuration</summary>

![invalid network configuration](https://user-images.githubusercontent.com/15836/114552951-084ba980-9c5d-11eb-98ba-4690ed2675e7.png)
</details>

<details>
<summary>Code Example: Checking Errors</summary>

```ruby
require "yast"
require "y2network/config_reader"

reader = Y2Network::ConfigReader.for(:wicked)
result = reader.config

puts Y2Network::Errors::Presenter.new(result.errors).to_s
```
</details>

<details>
<summary>Code Example: Adding Errors</summary>

```ruby
require "yast"
require "y2network/errors"

errors = Y2Network::Errors::List.new
errors << Y2Network::Errors::InvalidValue.new("boot protocol", "magic")
errors << Y2Network::Errors::InvalidValue.new("start mode", "random", "auto")
puts Y2Network::Errors::Presenter.new(errors).to_s
```
</details>

## To do

- [ ] Idea: bring `AutoinstIssues` and `Errors` together (using a mixin or even 'inheritance').
- [ ] [AutoinstIssues::List](https://github.com/yast/yast-yast2/blob/master/library/general/src/lib/installation/autoinst_issues/list.rb) looks pretty similar to `Errors::List`. Should we merge them? What about the rest?
- [x] Decide about a proper name. *Error* seems related to *exceptions* (*problem*, *issue*, ...)
- [x] Split the `errors.rb` into different files. Move them to `yast2`?
- [ ] Should `MissingValue` and `InvalidValue` be merged into a single class?
- [x] Add a mechanism to identify better the source of the error (the `ifcfg-eth0` file in this case).
- [ ] Do not allow the user to continue when a *fatal* error occurs.
- [ ] Provide a widget to display errors (?)
- [ ] Add tests and documentation.
