### PR TITLE
Handling reading errors (BOOTPROTO and STARTMODE)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Apr 22 12:48:27 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Do not crash when the BOOTPROTO or STARTMODE ar missing or
+- Do not crash when the BOOTPROTO or STARTMODE are missing or
   invalid (bsc#1181295).
 - 4.4.6
 

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 22 12:48:27 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when the BOOTPROTO or STARTMODE ar missing or
+  invalid (bsc#1181295).
+- 4.4.6
+
+-------------------------------------------------------------------
 Thu Apr 22 12:22:47 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - bsc#1185106

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -33,8 +33,8 @@ BuildRequires:  yast2-devtools >= 3.1.15
 #for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  yast2-storage-ng
-# AutoYaST ElementPath class
-BuildRequires:  yast2 >= 4.3.20
+# Y2Issues
+BuildRequires:  yast2 >= 4.4.1
 
 BuildRequires:  yast2-packager >= 4.0.18
 # Product control need xml agent
@@ -49,8 +49,8 @@ PreReq:         /bin/rm
 Requires:       sysconfig >= 0.80.0
 Requires:       yast2-proxy
 Requires:       yast2-storage-ng
-# AutoYaST ElementPath class
-Requires:       yast2 >= 4.3.20
+# Y2Issues
+Requires:       yast2 >= 4.4.1
 # Packages::vnc_packages
 Requires:       yast2-packager >= 4.0.18
 Requires:       rubygem(%rb_default_ruby_abi:cfa) >= 0.6.4

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -93,7 +93,7 @@ module Yast
 
       # Force a read of the configuration just for reading the transient
       # hostname as it could be modified through dhcp since previous read.
-      Lan.read_config
+      Lan.read_config(report: false)
     end
 
     # Decides if a proposal for virtualization host machine is required.
@@ -120,7 +120,7 @@ module Yast
 
       log.info("NetworkAutoconfiguration: proposing virtual devices")
 
-      Lan.ProposeVirtualized
+      return unless Lan.ProposeVirtualized
 
       # avoid restarting network (installation can run via ssh, vnc, ...)
       # Moreover virtual devices are not needed during first stage. So, it can

--- a/src/lib/y2network/autoinst/config_reader.rb
+++ b/src/lib/y2network/autoinst/config_reader.rb
@@ -27,6 +27,7 @@ require "y2network/autoinst/interfaces_reader"
 require "y2network/autoinst/udev_rules_reader"
 require "y2network/autoinst_profile/networking_section"
 require "y2network/wicked/interfaces_reader"
+require "y2network/reading_result"
 
 Yast.import "Stage"
 
@@ -46,8 +47,8 @@ module Y2Network
         @original_config = original_config
       end
 
-      # @return [Y2Network::Config] Network configuration
-      def config
+      # @return [ReadingResult] Network configuration
+      def read
         config = Y2Network::Config.new(source: :autoinst)
         # We need the current interfaces in order to rewrite the config
         # properly but the rest should be imported from the profile
@@ -75,7 +76,7 @@ module Y2Network
         # config should be written to the inst-sys (:wicked).
         config.backend = (!Yast::Stage.initial && section.managed) ? :network_manager : :wicked
 
-        config
+        Y2Network::ReadingResult.new(config)
       end
 
     private

--- a/src/lib/y2network/config.rb
+++ b/src/lib/y2network/config.rb
@@ -68,9 +68,10 @@ module Y2Network
       # @param source [Symbol] Source to read the configuration from
       # @param opts   [Array<Object>] Reader options. Check readers documentation to find out
       #   supported options.
+      # @return [ReadingResult] Result of reading the network configuration
       def from(source, *opts)
         reader = ConfigReader.for(source, *opts)
-        reader.config
+        reader.read
       end
 
       # Adds the configuration to the register

--- a/src/lib/y2network/config_reader.rb
+++ b/src/lib/y2network/config_reader.rb
@@ -22,7 +22,7 @@ require "yast"
 module Y2Network
   # This class is responsible for reading the configuration from the system
   #
-  # It implements a {#config} method which returns a configuration object
+  # It implements a {#read} method which returns a configuration object
   # containing the information from the corresponding backend.
   #
   # It is expect that a configuration reader exists for each supported backend

--- a/src/lib/y2network/config_reader.rb
+++ b/src/lib/y2network/config_reader.rb
@@ -50,7 +50,7 @@ module Y2Network
     #
     # @return [Y2Network::ReadingResult] Network configuration
     # @raise NotImplementedError
-    def config
+    def read
       raise NotImplementedError
     end
   end

--- a/src/lib/y2network/config_reader.rb
+++ b/src/lib/y2network/config_reader.rb
@@ -48,9 +48,10 @@ module Y2Network
 
     # Returns the configuration from the given backend
     #
-    # @return [Y2Network::Config] Network configuration
+    # @return [Y2Network::ReadingResult] Network configuration
+    # @raise NotImplementedError
     def config
-      Y2Network::Config.new
+      raise NotImplementedError
     end
   end
 end

--- a/src/lib/y2network/reading_result.rb
+++ b/src/lib/y2network/reading_result.rb
@@ -41,13 +41,5 @@ module Y2Network
     def issues?
       issues.any?
     end
-
-    # Generates a new result containing the updated config and the full list of issues
-    #
-    # @param other [ReadingResult] Result to merge
-    # @return [ReadingResult]
-    def merge(other)
-      ReadingResult.new(other.config, issues + other.issues)
-    end
   end
 end

--- a/src/lib/y2network/reading_result.rb
+++ b/src/lib/y2network/reading_result.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # Copyright (c) [2021] SUSE LLC
 #
 # All Rights Reserved.

--- a/src/lib/y2network/reading_result.rb
+++ b/src/lib/y2network/reading_result.rb
@@ -1,0 +1,55 @@
+# encoding: utf-8
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2issues"
+
+module Y2Network
+  class ReadingResult
+    attr_reader :config, :issues
+
+    # Represents a reading operation result
+    #
+    # @fixme does it make sense when writing changes?
+    #
+    # @param config [Config] Read configuration
+    # @param issues [Errors::List] Errors list
+    def initialize(config, issues = Y2Issues::List.new)
+      @config = config
+      @issues = issues
+    end
+
+    # Determines whether there is some error
+    #
+    # @return [Boolean]
+    def issues?
+      issues.any?
+    end
+
+    # Generates a new result containing the updated config and the full list of issues
+    #
+    # @param other [ReadingResult] Result to merge
+    # @return [ReadingResult]
+    def merge(other)
+      ReadingResult.new(other.config, issues + other.issues)
+    end
+  end
+end

--- a/src/lib/y2network/reading_result.rb
+++ b/src/lib/y2network/reading_result.rb
@@ -26,8 +26,6 @@ module Y2Network
 
     # Represents a reading operation result
     #
-    # @fixme does it make sense when writing changes?
-    #
     # @param config [Config] Read configuration
     # @param issues [Errors::List] Errors list
     def initialize(config, issues = Y2Issues::List.new)

--- a/src/lib/y2network/wicked/config_reader.rb
+++ b/src/lib/y2network/wicked/config_reader.rb
@@ -51,9 +51,10 @@ module Y2Network
         Yast::Host.Read
 
         initial_config = Config.new(source: :wicked)
+        issues_list = Y2Issues::List.new
 
         network_config = SECTIONS.reduce(initial_config) do |current_config, section|
-          send("read_#{section}", current_config)
+          send("read_#{section}", current_config, issues_list)
         end
 
         log.info "Sysconfig reader result: #{network_config.inspect}"
@@ -65,8 +66,9 @@ module Y2Network
       # Reads the network interfaces
       #
       # @param config [Y2Network::Config] Initial configuration object
+      # @param _issues_list [Y2Issues::List] Issues list
       # @return [Y2Network::Config] A new configuration object including the interfaces
-      def read_interfaces(config)
+      def read_interfaces(config, _issues_list)
         config.update(
           interfaces:   interfaces_reader.interfaces,
           s390_devices: interfaces_reader.s390_devices
@@ -76,8 +78,10 @@ module Y2Network
       # Reads the connections
       #
       # @param config [Y2Network::Config] Initial configuration object
+      # @param issues_list [Y2Issues::List] Issues list
       # @return [Y2Network::Config] A new configuration object including the connections
-      def read_connections(config)
+      def read_connections(config, issues_list)
+        connection_configs_reader = ConnectionConfigsReader.new(issues_list)
         connections = connection_configs_reader.connections(config.interfaces)
         missing_interfaces = find_missing_interfaces(
           connections, config.interfaces
@@ -91,16 +95,18 @@ module Y2Network
       # Reads the drivers
       #
       # @param config [Y2Network::Config] Initial configuration object
+      # @param _issues_list [Y2Issues::List] Issues list
       # @return [Y2Network::Config] A new configuration object including the connections
-      def read_drivers(config)
+      def read_drivers(config, _issues_list)
         config.update(drivers: interfaces_reader.drivers)
       end
 
       # Reads the routing information
       #
       # @param config [Y2Network::Config] Initial configuration object
+      # @param _issues_list [Y2Issues::List] Issues list
       # @return [Y2Network::Config] A new configuration object including the routing information
-      def read_routing(config)
+      def read_routing(config, _issues_list)
         routing_tables = find_routing_tables(config.interfaces)
         routing = Routing.new(
           tables:       routing_tables,
@@ -113,16 +119,18 @@ module Y2Network
       # Reads the DNS information
       #
       # @param config [Y2Network::Config] Initial configuration object
+      # @param _issues_list [Y2Issues::List] Issues list
       # @return [Y2Network::Config] A new configuration object including the DNS configuration
-      def read_dns(config)
+      def read_dns(config, _issues_list)
         config.update(dns: Y2Network::Wicked::DNSReader.new.config)
       end
 
       # Returns the Hostname configuration
       #
       # @param config [Y2Network::Config] Initial configuration object
+      # @param _issues_list [Y2Issues::List] Issues list
       # @return [Y2Network::Config] A new configuration object including the hostname information
-      def read_hostname(config)
+      def read_hostname(config, _issues_list)
         config.update(hostname: Y2Network::Wicked::HostnameReader.new.config)
       end
 
@@ -133,13 +141,6 @@ module Y2Network
       # @return [InterfacesReader] Interfaces reader
       def interfaces_reader
         @interfaces_reader ||= Y2Network::Wicked::InterfacesReader.new
-      end
-
-      # @return [Y2Network::ConnectionConfigsCollection] Connection configurations collection
-      def connection_configs_reader
-        @connection_configs_reader ||= Y2Network::Wicked::ConnectionConfigsReader.new(
-          issues_list
-        )
       end
 
       # Adds missing interfaces from connections
@@ -218,10 +219,6 @@ module Y2Network
         @sysctl_config_file = CFA::SysctlConfig.new
         @sysctl_config_file.load
         @sysctl_config_file
-      end
-
-      def issues_list
-        @issues_list ||= Y2Issues::List.new
       end
     end
   end

--- a/src/lib/y2network/wicked/config_reader.rb
+++ b/src/lib/y2network/wicked/config_reader.rb
@@ -44,8 +44,8 @@ module Y2Network
         :interfaces, :connections, :drivers, :routing, :dns, :hostname
       ].freeze
 
-      # @return [Y2Network::Config] Network configuration
-      def config
+      # @return [ReadingResult] Network configuration
+      def read
         # NOTE: This code might be moved outside of the Sysconfig namespace, as it is generic.
         # NOTE: /etc/hosts cache - nothing to do with /etc/hostname
         Yast::Host.Read

--- a/src/lib/y2network/wicked/config_reader.rb
+++ b/src/lib/y2network/wicked/config_reader.rb
@@ -66,7 +66,7 @@ module Y2Network
       # Reads the network interfaces
       #
       # @param config [Y2Network::Config] Initial configuration object
-      # @param _issues_list [Y2Issues::List] Issues list
+      # @param _issues_list [Y2Issues::List] Issues list. Used to register issues when reading.
       # @return [Y2Network::Config] A new configuration object including the interfaces
       def read_interfaces(config, _issues_list)
         config.update(
@@ -78,7 +78,7 @@ module Y2Network
       # Reads the connections
       #
       # @param config [Y2Network::Config] Initial configuration object
-      # @param issues_list [Y2Issues::List] Issues list
+      # @param issues_list [Y2Issues::List] Issues list. Used to register issues when reading.
       # @return [Y2Network::Config] A new configuration object including the connections
       def read_connections(config, issues_list)
         connection_configs_reader = ConnectionConfigsReader.new(issues_list)
@@ -95,7 +95,7 @@ module Y2Network
       # Reads the drivers
       #
       # @param config [Y2Network::Config] Initial configuration object
-      # @param _issues_list [Y2Issues::List] Issues list
+      # @param _issues_list [Y2Issues::List] Issues list. Used to register issues when reading.
       # @return [Y2Network::Config] A new configuration object including the connections
       def read_drivers(config, _issues_list)
         config.update(drivers: interfaces_reader.drivers)
@@ -104,7 +104,7 @@ module Y2Network
       # Reads the routing information
       #
       # @param config [Y2Network::Config] Initial configuration object
-      # @param _issues_list [Y2Issues::List] Issues list
+      # @param _issues_list [Y2Issues::List] Issues list. Used to register issues when reading.
       # @return [Y2Network::Config] A new configuration object including the routing information
       def read_routing(config, _issues_list)
         routing_tables = find_routing_tables(config.interfaces)
@@ -119,7 +119,7 @@ module Y2Network
       # Reads the DNS information
       #
       # @param config [Y2Network::Config] Initial configuration object
-      # @param _issues_list [Y2Issues::List] Issues list
+      # @param _issues_list [Y2Issues::List] Issues list. Used to register issues when reading.
       # @return [Y2Network::Config] A new configuration object including the DNS configuration
       def read_dns(config, _issues_list)
         config.update(dns: Y2Network::Wicked::DNSReader.new.config)
@@ -128,7 +128,7 @@ module Y2Network
       # Returns the Hostname configuration
       #
       # @param config [Y2Network::Config] Initial configuration object
-      # @param _issues_list [Y2Issues::List] Issues list
+      # @param _issues_list [Y2Issues::List] Issues list. Used to register issues when reading.
       # @return [Y2Network::Config] A new configuration object including the hostname information
       def read_hostname(config, _issues_list)
         config.update(hostname: Y2Network::Wicked::HostnameReader.new.config)

--- a/src/lib/y2network/wicked/connection_config_reader.rb
+++ b/src/lib/y2network/wicked/connection_config_reader.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "cfa/interface_file"
+require "y2issues"
 
 module Y2Network
   module Wicked

--- a/src/lib/y2network/wicked/connection_config_reader.rb
+++ b/src/lib/y2network/wicked/connection_config_reader.rb
@@ -29,16 +29,16 @@ module Y2Network
       #
       # @param name [String] Interface name
       # @param type [InterfaceType, string, nil] Interface type; if the type is unknown,
-      #   `nil` can be used and it will be guessed from the configuration file is possible.
+      #   `nil` can be used and it will be guessed from the configuration file if possible.
       #
       # @return [Y2Network::ConnectionConfig::Base]
-      def read(name, type)
+      def read(name, type, issues_list)
         file = CFA::InterfaceFile.new(name)
         file.load
         handler_class = find_handler_class(type || file.type)
         return nil if handler_class.nil?
 
-        handler_class.new(file).connection_config
+        handler_class.new(file, issues_list).connection_config
       end
 
     private

--- a/src/lib/y2network/wicked/connection_config_readers/base.rb
+++ b/src/lib/y2network/wicked/connection_config_readers/base.rb
@@ -21,7 +21,6 @@ require "y2network/connection_config/ip_config"
 require "y2network/ip_address"
 require "y2network/boot_protocol"
 require "y2network/startmode"
-require "y2issues"
 
 Yast.import "Host"
 

--- a/src/lib/y2network/wicked/connection_config_readers/base.rb
+++ b/src/lib/y2network/wicked/connection_config_readers/base.rb
@@ -73,26 +73,41 @@ module Y2Network
 
       private
 
+        DEFAULT_BOOTPROTO = BootProtocol::STATIC
+
+        # Finds the boot protocol
+        #
+        # If it is not defined or it has an unknown value, it returns the
+        # fallback value (BootProtocol::STATIC).
+        #
+        # @return [BootProtocol]
         def find_bootproto
           bootproto = BootProtocol.from_name(file.bootproto.to_s)
           return bootproto if bootproto
 
-          fallback = file.ipaddrs.empty? ? BootProtocol::DHCP : BootProtocol::STATIC
           issue_location = "file:#{file.path}:BOOTPROTO"
           issue = Y2Issues::InvalidValue.new(
-            file.bootproto, fallback: fallback, location: issue_location
+            file.bootproto, fallback: BootProtocol::STATIC, location: issue_location
           )
           issues_list << issue
 
-          fallback
+          BootProtocol::STATIC
         end
 
+        DEFAULT_STARTMODE_NAME = "manual".freeze
+
+        # Finds the start mode
+        #
+        # If it is not defined or it has an unknown value, it returns the
+        # fallback value (manual).
+        #
+        # @return [Startmode]
         def find_startmode
           startmode = Startmode.create(file.startmode) if file.startmode
           return startmode if startmode
 
           issue_location = "file:#{file.path}:STARTMODE"
-          fallback = Startmode.create("manual")
+          fallback = Startmode.create(DEFAULT_STARTMODE_NAME)
           issue = Y2Issues::InvalidValue.new(
             file.startmode, fallback: fallback, location: issue_location
           )

--- a/src/lib/y2network/wicked/connection_config_readers/base.rb
+++ b/src/lib/y2network/wicked/connection_config_readers/base.rb
@@ -85,7 +85,7 @@ module Y2Network
           )
           issues_list << issue
 
-          return fallback
+          fallback
         end
 
         def find_startmode

--- a/src/lib/y2network/wicked/connection_config_readers/base.rb
+++ b/src/lib/y2network/wicked/connection_config_readers/base.rb
@@ -35,11 +35,10 @@ module Y2Network
         # @return [CFA::InterfaceFile] Interface's configuration file
         attr_reader :file
 
-        attr_reader :issues_list
-
         # Constructor
         #
         # @param file [CFA::InterfaceFile] Interface's configuration file
+        # @param issues_list [Y2Issues::List] List to register issues
         def initialize(file, issues_list)
           @file = file
           @issues_list = issues_list
@@ -72,6 +71,9 @@ module Y2Network
         end
 
       private
+
+        # @return [Y2Issues::List] List to register issues
+        attr_reader :issues_list
 
         DEFAULT_BOOTPROTO = BootProtocol::STATIC
 

--- a/src/lib/y2network/wicked/connection_config_readers/base.rb
+++ b/src/lib/y2network/wicked/connection_config_readers/base.rb
@@ -78,7 +78,6 @@ module Y2Network
           bootproto = BootProtocol.from_name(file.bootproto.to_s)
           return bootproto if bootproto
 
-          # TODO: improve boot protocol guessing
           fallback = file.ipaddrs.empty? ? BootProtocol::DHCP : BootProtocol::STATIC
           issue_location = "file:#{file.path}:BOOTPROTO"
           issue = Y2Issues::InvalidValue.new(

--- a/src/lib/y2network/wicked/connection_configs_reader.rb
+++ b/src/lib/y2network/wicked/connection_configs_reader.rb
@@ -28,6 +28,13 @@ module Y2Network
     #
     # @see Y2Network::ConnectionConfigsCollection
     class ConnectionConfigsReader
+      attr_reader :issues_list
+
+      # @param issues_list [Errors::List] List to register errors
+      def initialize(issues_list)
+        @issues_list = issues_list
+      end
+
       # Returns the connection configurations from sysconfig
       #
       # It needs the list of known interfaces in order to infer
@@ -41,7 +48,8 @@ module Y2Network
           interface = interfaces.by_name(file.interface)
           connection = ConnectionConfigReader.new.read(
             file.interface,
-            interface ? interface.type : nil
+            interface ? interface.type : nil,
+            issues_list
           )
           conns << connection if connection
         end

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -718,18 +718,21 @@ module Yast
 
     # Reads system configuration
     #
-    # It resets already read configuration.
+    # It resets the already read configuration. If some issue is detected
+    # while reading the configuration, it is reported to the user.
     #
     # @return [Boolean] Returns whether the configuration was read.
     def read_config
       result = Y2Network::Config.from(:wicked)
+      if result.issues?
+        return false unless Y2Issues.report(result.issues) == :yes
+      end
+
       system_config = result.config
       system_config.backend = NetworkService.cached_name
       Yast::Lan.add_config(:system, system_config)
       Yast::Lan.add_config(:yast, system_config.copy)
-      return true unless result.issues?
-
-      Y2Issues.report(result.issues) == :yes
+      true
     end
 
     # Writes current yast config and replaces the system config with it

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -57,7 +57,6 @@ module Yast
       Yast.import "NetHwDetection"
       Yast.import "Host"
       Yast.import "IP"
-      Yast.import "HTML"
       Yast.import "Map"
       Yast.import "Mode"
       Yast.import "NetworkConfig"

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -720,10 +720,11 @@ module Yast
     # It resets the already read configuration. If some issue is detected
     # while reading the configuration, it is reported to the user.
     #
+    # @param report [Boolean] Report any found issue if set to true
     # @return [Boolean] Returns whether the configuration was read.
-    def read_config
+    def read_config(report: true)
       result = Y2Network::Config.from(:wicked)
-      if result.issues?
+      if result.issues? && report
         return false unless Y2Issues.report(result.issues) == :yes
       end
 

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -40,6 +40,7 @@ require "y2network/virtualization_config"
 require "y2network/interface_config_builder"
 require "y2network/presenters/summary"
 require "y2network/interface_type"
+require "y2issues"
 
 require "shellwords"
 
@@ -56,6 +57,7 @@ module Yast
       Yast.import "NetHwDetection"
       Yast.import "Host"
       Yast.import "IP"
+      Yast.import "HTML"
       Yast.import "Map"
       Yast.import "Mode"
       Yast.import "NetworkConfig"
@@ -271,7 +273,7 @@ module Yast
         return false if Abort()
 
         ProgressNextStage(_("Reading device configuration...")) if @gui
-        read_config
+        return false unless read_config
 
         Builtins.sleep(sl)
 
@@ -569,8 +571,8 @@ module Yast
 
       Read(:cache)
       profile = Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(settings)
-      config = Y2Network::Config.from(:autoinst, profile, system_config)
-      add_config(:yast, config)
+      result = Y2Network::Config.from(:autoinst, profile, system_config)
+      add_config(:yast, result.config)
       @autoinst = autoinst_config(profile)
       if Arch.s390
         NetworkAutoYast.instance.activate_s390_devices(settings.fetch("s390-devices", {}))
@@ -717,11 +719,17 @@ module Yast
     # Reads system configuration
     #
     # It resets already read configuration.
+    #
+    # @return [Boolean] Returns whether the configuration was read.
     def read_config
-      system_config = Y2Network::Config.from(:wicked)
+      result = Y2Network::Config.from(:wicked)
+      system_config = result.config
       system_config.backend = NetworkService.cached_name
       Yast::Lan.add_config(:system, system_config)
       Yast::Lan.add_config(:yast, system_config.copy)
+      return true unless result.issues?
+
+      Y2Issues.report(result.issues) == :yes
     end
 
     # Writes current yast config and replaces the system config with it

--- a/test/y2network/autoinst/config_reader_test.rb
+++ b/test/y2network/autoinst/config_reader_test.rb
@@ -63,7 +63,7 @@ describe Y2Network::Autoinst::ConfigReader do
     }
   end
 
-  describe "#config" do
+  describe "#read" do
     let(:first_stage) { true }
 
     before do
@@ -71,12 +71,13 @@ describe Y2Network::Autoinst::ConfigReader do
     end
 
     it "builds a new Y2Network::Config from a Y2Networking::Section" do
-      expect(subject.config).to be_a Y2Network::Config
-      expect(subject.config.routing).to be_a Y2Network::Routing
-      expect(subject.config.dns).to be_a Y2Network::DNS
-      expect(subject.config.hostname.dhcp_hostname).to eq(:any)
-      expect(subject.config.hostname.installer).to eq("host")
-      expect(subject.config.backend.id).to eq(:wicked)
+      config = subject.read.config
+      expect(config).to be_a Y2Network::Config
+      expect(config.routing).to be_a Y2Network::Routing
+      expect(config.dns).to be_a Y2Network::DNS
+      expect(config.hostname.dhcp_hostname).to eq(:any)
+      expect(config.hostname.installer).to eq("host")
+      expect(config.backend.id).to eq(:wicked)
     end
 
     context "when the networking section sets it to be managed" do
@@ -86,7 +87,8 @@ describe Y2Network::Autoinst::ConfigReader do
 
       context "and run in the first stage of the installation" do
         it "selects :wicked as the backend to be used" do
-          expect(subject.config.backend.id).to eq(:wicked)
+          config = subject.read.config
+          expect(config.backend.id).to eq(:wicked)
         end
       end
 
@@ -94,7 +96,8 @@ describe Y2Network::Autoinst::ConfigReader do
         let(:first_stage) { false }
 
         it "selects :network_manager as the backend to be used" do
-          expect(subject.config.backend.id).to eq(:network_manager)
+          config = subject.read.config
+          expect(config.backend.id).to eq(:network_manager)
         end
       end
     end

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -65,7 +65,9 @@ describe Y2Network::Config do
 
   describe ".from" do
     let(:reader) do
-      instance_double(Y2Network::Wicked::ConfigReader, config: config)
+      instance_double(
+        Y2Network::Wicked::ConfigReader, read: Y2Network::ReadingResult.new(config)
+      )
     end
 
     before do
@@ -74,7 +76,8 @@ describe Y2Network::Config do
     end
 
     it "returns the configuration from the given reader" do
-      expect(described_class.from(:wicked)).to eq(config)
+      result = described_class.from(:wicked)
+      expect(result.config).to eq(config)
     end
   end
 

--- a/test/y2network/wicked/config_reader_test.rb
+++ b/test/y2network/wicked/config_reader_test.rb
@@ -79,12 +79,12 @@ describe Y2Network::Wicked::ConfigReader do
     end
 
     it "returns a configuration including network devices" do
-      config = reader.config
+      config = reader.read.config
       expect(config.interfaces.map(&:name)).to eq(["eth0", "wlan0"])
     end
 
     it "returns a configuration including connection configurations" do
-      config = reader.config
+      config = reader.read.config
       expect(config.connections.to_a).to eq([eth0_conn])
     end
 
@@ -103,7 +103,7 @@ describe Y2Network::Wicked::ConfigReader do
         end
 
         it "creates a virtual interface" do
-          config = reader.config
+          config = reader.read.config
           bridge = config.interfaces.by_name("br0")
           expect(bridge).to be_a Y2Network::VirtualInterface
         end
@@ -118,7 +118,7 @@ describe Y2Network::Wicked::ConfigReader do
         end
 
         it "creates a not present physical interface" do
-          config = reader.config
+          config = reader.read.config
           eth1 = config.interfaces.by_name("eth1")
           expect(eth1).to be_a Y2Network::PhysicalInterface
           expect(eth1).to_not be_present
@@ -127,29 +127,29 @@ describe Y2Network::Wicked::ConfigReader do
     end
 
     it "links routes with detected network devices" do
-      config = reader.config
+      config = reader.read.config
       route = config.routing.routes.find(&:interface)
       iface = config.interfaces.by_name(route.interface.name)
       expect(route.interface).to be(iface)
     end
 
     it "returns a configuration which includes routes" do
-      config = reader.config
+      config = reader.read.config
       expect(config.routing.routes.size).to eq(4)
     end
 
     it "returns a configuration which includes DNS settings" do
-      config = reader.config
+      config = reader.read.config
       expect(config.dns).to eq(dns)
     end
 
     it "returns a configuration which includes available drivers" do
-      config = reader.config
+      config = reader.read.config
       expect(config.drivers).to eq(drivers)
     end
 
     it "sets the config source to :wicked" do
-      config = reader.config
+      config = reader.read.config
       expect(config.source).to eq(:wicked)
     end
   end
@@ -168,7 +168,7 @@ describe Y2Network::Wicked::ConfigReader do
       let(:forward_ipv4) { true }
 
       it "returns true" do
-        expect(reader.config.routing.forward_ipv4).to be true
+        expect(reader.read.config.routing.forward_ipv4).to be true
       end
     end
 
@@ -176,7 +176,7 @@ describe Y2Network::Wicked::ConfigReader do
       let(:forward_ipv4) { false }
 
       it "returns false" do
-        expect(reader.config.routing.forward_ipv4).to be false
+        expect(reader.read.config.routing.forward_ipv4).to be false
       end
     end
   end
@@ -195,7 +195,7 @@ describe Y2Network::Wicked::ConfigReader do
       let(:forward_ipv6) { true }
 
       it "returns true" do
-        expect(reader.config.routing.forward_ipv6).to be true
+        expect(reader.read.config.routing.forward_ipv6).to be true
       end
     end
 
@@ -203,7 +203,7 @@ describe Y2Network::Wicked::ConfigReader do
       let(:forward_ipv6) { false }
 
       it "returns false" do
-        expect(reader.config.routing.forward_ipv6).to be false
+        expect(reader.read.config.routing.forward_ipv6).to be false
       end
     end
   end

--- a/test/y2network/wicked/connection_config_reader_test.rb
+++ b/test/y2network/wicked/connection_config_reader_test.rb
@@ -22,9 +22,11 @@ require_relative "../../test_helper"
 require "y2network/wicked/connection_config_reader"
 require "y2network/wicked/connection_config_readers/wireless"
 require "y2network/physical_interface"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReader do
   subject(:reader) { described_class.new }
+  let(:issues_list) { Y2Issues::List.new }
 
   describe "#read" do
     let(:interface) { instance_double(Y2Network::PhysicalInterface, name: "wlan0", type: "wlan") }
@@ -50,13 +52,13 @@ describe Y2Network::Wicked::ConnectionConfigReader do
     it "uses the appropiate handler" do
       expect(reader).to receive(:require)
         .with("y2network/wicked/connection_config_readers/wireless")
-      conn = reader.read(interface, "wlan")
+      conn = reader.read(interface, "wlan", issues_list)
       expect(conn).to be(connection_config)
     end
 
     context "when the interface type is not given" do
       it "infers the type from the interface's sysconfig file" do
-        expect(reader.read(interface, nil)).to be(connection_config)
+        expect(reader.read(interface, nil, issues_list)).to be(connection_config)
       end
     end
 
@@ -66,7 +68,7 @@ describe Y2Network::Wicked::ConnectionConfigReader do
       end
 
       it "raise exception" do
-        expect { reader.read(interface, :null) }.to raise_error(RuntimeError)
+        expect { reader.read(interface, :null, issues_list) }.to raise_error(RuntimeError)
       end
     end
   end

--- a/test/y2network/wicked/connection_config_readers/bonding_test.rb
+++ b/test/y2network/wicked/connection_config_readers/bonding_test.rb
@@ -20,10 +20,12 @@
 require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/bonding"
 require "cfa/interface_file"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Bonding do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/bridge_test.rb
+++ b/test/y2network/wicked/connection_config_readers/bridge_test.rb
@@ -20,10 +20,12 @@
 require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/bridge"
 require "cfa/interface_file"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Bridge do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/ctc_test.rb
+++ b/test/y2network/wicked/connection_config_readers/ctc_test.rb
@@ -21,10 +21,12 @@ require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/ctc"
 require "cfa/interface_file"
 require "y2network/boot_protocol"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Ctc do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/dummy_test.rb
+++ b/test/y2network/wicked/connection_config_readers/dummy_test.rb
@@ -20,10 +20,12 @@
 require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/dummy"
 require "cfa/interface_file"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Dummy do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/ethernet_test.rb
+++ b/test/y2network/wicked/connection_config_readers/ethernet_test.rb
@@ -111,6 +111,7 @@ describe Y2Network::Wicked::ConnectionConfigReaders::Ethernet do
       end
 
       context "and there is some defined address" do
+
         before do
           allow(file).to receive(:ipaddrs).and_return([double("IP")])
         end
@@ -170,6 +171,5 @@ describe Y2Network::Wicked::ConnectionConfigReaders::Ethernet do
         expect(issue.message).to include("Invalid value 'automatic'")
       end
     end
-
   end
 end

--- a/test/y2network/wicked/connection_config_readers/ethernet_test.rb
+++ b/test/y2network/wicked/connection_config_readers/ethernet_test.rb
@@ -21,12 +21,13 @@ require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/ethernet"
 require "cfa/interface_file"
 require "y2network/boot_protocol"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Ethernet do
   subject(:handler) { described_class.new(file, issues_list) }
 
-  let(:scr_root) { File.join(DATA_PATH, "scr_read") }
   let(:issues_list) { Y2Issues::List.new }
+  let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   before do
     allow(Yast::Host).to receive(:load_hosts).and_call_original

--- a/test/y2network/wicked/connection_config_readers/ethernet_test.rb
+++ b/test/y2network/wicked/connection_config_readers/ethernet_test.rb
@@ -111,45 +111,18 @@ describe Y2Network::Wicked::ConnectionConfigReaders::Ethernet do
         allow(file).to receive(:bootproto).and_return("something")
       end
 
-      context "and there is some defined address" do
-
-        before do
-          allow(file).to receive(:ipaddrs).and_return([double("IP")])
-        end
-
-        it "falls back to STATIC" do
-          eth = handler.connection_config
-          expect(eth.bootproto).to eq(Y2Network::BootProtocol::STATIC)
-        end
-
-        it "registers an issue" do
-          handler.connection_config
-          issue = issues_list.first
-          expect(issue.location.to_s).to eq(
-            "file:/etc/sysconfig/network/ifcfg-eth0:BOOTPROTO"
-          )
-          expect(issue.message).to include("Invalid value 'something'")
-        end
+      it "falls back to STATIC" do
+        eth = handler.connection_config
+        expect(eth.bootproto).to eq(Y2Network::BootProtocol::STATIC)
       end
 
-      context "and there are not defined addresses" do
-        before do
-          allow(file).to receive(:ipaddrs).and_return([])
-        end
-
-        it "falls back to DHCP" do
-          eth = handler.connection_config
-          expect(eth.bootproto).to eq(Y2Network::BootProtocol::DHCP)
-        end
-
-        it "registers an issue" do
-          handler.connection_config
-          issue = issues_list.first
-          expect(issue.location.to_s).to eq(
-            "file:/etc/sysconfig/network/ifcfg-eth0:BOOTPROTO"
-          )
-          expect(issue.message).to include("Invalid value 'something'")
-        end
+      it "registers an issue" do
+        handler.connection_config
+        issue = issues_list.first
+        expect(issue.location.to_s).to eq(
+          "file:/etc/sysconfig/network/ifcfg-eth0:BOOTPROTO"
+        )
+        expect(issue.message).to include("Invalid value 'something'")
       end
     end
 

--- a/test/y2network/wicked/connection_config_readers/ethernet_test.rb
+++ b/test/y2network/wicked/connection_config_readers/ethernet_test.rb
@@ -23,9 +23,10 @@ require "cfa/interface_file"
 require "y2network/boot_protocol"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Ethernet do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
+  let(:issues_list) { Y2Issues::List.new }
 
   before do
     allow(Yast::Host).to receive(:load_hosts).and_call_original
@@ -103,5 +104,72 @@ describe Y2Network::Wicked::ConnectionConfigReaders::Ethernet do
     it "reads dhclient set hostname value as boolean" do
       expect(handler.connection_config.dhclient_set_hostname).to eq true
     end
+
+    context "when the BOOTPROTO is not valid" do
+      before do
+        allow(file).to receive(:bootproto).and_return("something")
+      end
+
+      context "and there is some defined address" do
+        before do
+          allow(file).to receive(:ipaddrs).and_return([double("IP")])
+        end
+
+        it "falls back to STATIC" do
+          eth = handler.connection_config
+          expect(eth.bootproto).to eq(Y2Network::BootProtocol::STATIC)
+        end
+
+        it "registers an issue" do
+          handler.connection_config
+          issue = issues_list.first
+          expect(issue.location.to_s).to eq(
+            "file:/etc/sysconfig/network/ifcfg-eth0:BOOTPROTO"
+          )
+          expect(issue.message).to include("Invalid value 'something'")
+        end
+      end
+
+      context "and there are not defined addresses" do
+        before do
+          allow(file).to receive(:ipaddrs).and_return([])
+        end
+
+        it "falls back to DHCP" do
+          eth = handler.connection_config
+          expect(eth.bootproto).to eq(Y2Network::BootProtocol::DHCP)
+        end
+
+        it "registers an issue" do
+          handler.connection_config
+          issue = issues_list.first
+          expect(issue.location.to_s).to eq(
+            "file:/etc/sysconfig/network/ifcfg-eth0:BOOTPROTO"
+          )
+          expect(issue.message).to include("Invalid value 'something'")
+        end
+      end
+    end
+
+    context "when the STARTMODE is not valid" do
+      before do
+        allow(file).to receive(:startmode).and_return("automatic")
+      end
+
+      it "falls back to MANUAL" do
+        eth = handler.connection_config
+        expect(eth.startmode.to_s).to eq("manual")
+      end
+
+      it "registers an issue" do
+        handler.connection_config
+        issue = issues_list.first
+        expect(issue.location.to_s).to eq(
+          "file:/etc/sysconfig/network/ifcfg-eth0:STARTMODE"
+        )
+        expect(issue.message).to include("Invalid value 'automatic'")
+      end
+    end
+
   end
 end

--- a/test/y2network/wicked/connection_config_readers/hsi_test.rb
+++ b/test/y2network/wicked/connection_config_readers/hsi_test.rb
@@ -21,10 +21,12 @@ require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/hsi"
 require "cfa/interface_file"
 require "y2network/boot_protocol"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Hsi do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/infiniband_test.rb
+++ b/test/y2network/wicked/connection_config_readers/infiniband_test.rb
@@ -20,10 +20,12 @@
 require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/infiniband"
 require "cfa/interface_file"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Infiniband do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/lcs_test.rb
+++ b/test/y2network/wicked/connection_config_readers/lcs_test.rb
@@ -21,10 +21,12 @@ require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/lcs"
 require "cfa/interface_file"
 require "y2network/boot_protocol"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Lcs do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/qeth_test.rb
+++ b/test/y2network/wicked/connection_config_readers/qeth_test.rb
@@ -21,10 +21,12 @@ require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/qeth"
 require "cfa/interface_file"
 require "y2network/boot_protocol"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Qeth do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/tap_test.rb
+++ b/test/y2network/wicked/connection_config_readers/tap_test.rb
@@ -21,10 +21,12 @@ require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/tap"
 require "cfa/interface_file"
 require "y2network/interface_type"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Tap do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/tun_test.rb
+++ b/test/y2network/wicked/connection_config_readers/tun_test.rb
@@ -21,10 +21,12 @@ require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/tun"
 require "cfa/interface_file"
 require "y2network/interface_type"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Tun do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/usb_test.rb
+++ b/test/y2network/wicked/connection_config_readers/usb_test.rb
@@ -21,10 +21,12 @@ require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/usb"
 require "cfa/interface_file"
 require "y2network/boot_protocol"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Usb do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/vlan_test.rb
+++ b/test/y2network/wicked/connection_config_readers/vlan_test.rb
@@ -20,10 +20,12 @@
 require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/vlan"
 require "cfa/interface_file"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Vlan do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
+  let(:issues_list) { Y2Issues::List.new }
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
 
   around do |example|

--- a/test/y2network/wicked/connection_config_readers/wireless_test.rb
+++ b/test/y2network/wicked/connection_config_readers/wireless_test.rb
@@ -20,13 +20,14 @@
 require_relative "../../../test_helper"
 require "y2network/wicked/connection_config_readers/wireless"
 require "cfa/interface_file"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigReaders::Wireless do
-  subject(:handler) { described_class.new(file) }
+  subject(:handler) { described_class.new(file, issues_list) }
 
   let(:interface_name) { "wlan0" }
-
   let(:scr_root) { File.join(DATA_PATH, "scr_read") }
+  let(:issues_list) { Y2Issues::List.new }
 
   around do |example|
     change_scr_root(scr_root, &example)

--- a/test/y2network/wicked/connection_configs_reader_test.rb
+++ b/test/y2network/wicked/connection_configs_reader_test.rb
@@ -22,9 +22,10 @@ require "y2network/wicked/connection_configs_reader"
 require "y2network/physical_interface"
 require "y2network/interfaces_collection"
 require "y2network/connection_config"
+require "y2issues"
 
 describe Y2Network::Wicked::ConnectionConfigsReader do
-  subject(:reader) { described_class.new }
+  subject(:reader) { described_class.new(issues_list) }
 
   let(:eth0) do
     Y2Network::PhysicalInterface.new("eth0")
@@ -52,6 +53,7 @@ describe Y2Network::Wicked::ConnectionConfigsReader do
   end
   let(:conn_eth0) { instance_double(Y2Network::ConnectionConfig) }
   let(:conn_br0) { instance_double(Y2Network::ConnectionConfig) }
+  let(:issues_list) { Y2Issues::List.new }
 
   describe "#connections" do
     before do
@@ -62,10 +64,10 @@ describe Y2Network::Wicked::ConnectionConfigsReader do
 
     it "returns a connection for each file" do
       expect(connection_config_reader).to receive(:read)
-        .with("eth0", Y2Network::InterfaceType::ETHERNET)
+        .with("eth0", Y2Network::InterfaceType::ETHERNET, issues_list)
         .and_return(conn_eth0)
       expect(connection_config_reader).to receive(:read)
-        .with("br0", nil)
+        .with("br0", nil, issues_list)
         .and_return(conn_br0)
 
       connections = reader.connections(interfaces)


### PR DESCRIPTION
Reports problems with `BOOTMODE` and `STARTMODE` to the user using the new [error reporting mechanism](https://github.com/yast/yast-yast2/pull/1156).

Supersedes #1204.

<details>
<summary>Warn about invalid BOOTPROTO</summary>

![network-bootproto-issue](https://user-images.githubusercontent.com/15836/115688457-18494480-a353-11eb-9d05-ec097e7f66d1.png)
</details>

Bug: [bsc#1181295](https://bugzilla.suse.com/show_bug.cgi?id=1181295)
Trello: https://trello.com/c/3dJHjgeQ/

## Pending

- [x] Adapt the `autoinst` reader
- [x] Adapt unit tests
- [x] Check all calls to read_config