### PR TITLE
Fixed hosts update when there is no IP address defined

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Apr 16 16:27:13 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not crash during an AutoYaST installation when trying to
+  update the /etc/hosts using a connection without an IP address
+  defined (bsc#1184883)
+- 4.2.98
+
+-------------------------------------------------------------------
 Wed Mar 17 18:26:34 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Always provide the layer2 argument when activating a qeth device

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.97
+Version:        4.2.98
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/clients/auto.rb
+++ b/src/lib/y2network/clients/auto.rb
@@ -122,10 +122,12 @@ module Y2Network
       # Whatever is needed in /etc/hosts during AY installation
       def update_etc_hosts
         config = Yast::Lan.find_config(:yast)
-        return if !config
+        return if [nil, ""].include? config&.hostname&.static
 
-        static_connections = config.connections.select(&:static?)
+        static_connections = config.connections.select { |c| c.static? && c.ip&.address }
         static_connections.each do |connection|
+          next unless connection.hostname.to_s.empty?
+
           log.info("Updating /etc/hosts with" \
                    " #{connection.ip.address.address} #{config.hostname.static}")
           connection.hostname = config.hostname.static

--- a/src/lib/y2network/clients/auto.rb
+++ b/src/lib/y2network/clients/auto.rb
@@ -124,12 +124,11 @@ module Y2Network
         config = Yast::Lan.yast_config
         return if [nil, ""].include?(config&.hostname&.static)
 
-        static_connections = config.connections.select { |c| c.static? && c.ip&.address }
+        static_connections = config.connections.select { |c| c.static? && c.ip }
         static_connections.each do |connection|
           next unless connection.hostname.to_s.empty?
 
-          log.info("Updating /etc/hosts with" \
-                   " #{connection.ip.address.address} #{config.hostname.static}")
+          log.info("Setting connection #{connection.name} hostname to #{config.hostname.static}")
           connection.hostname = config.hostname.static
         end
 

--- a/src/lib/y2network/clients/auto.rb
+++ b/src/lib/y2network/clients/auto.rb
@@ -121,8 +121,8 @@ module Y2Network
 
       # Whatever is needed in /etc/hosts during AY installation
       def update_etc_hosts
-        config = Yast::Lan.find_config(:yast)
-        return if [nil, ""].include? config&.hostname&.static
+        config = Yast::Lan.yast_config
+        return if [nil, ""].include?(config&.hostname&.static)
 
         static_connections = config.connections.select { |c| c.static? && c.ip&.address }
         static_connections.each do |connection|


### PR DESCRIPTION
## Problem

During an AutoYaST installation yast2-network crashes when there is a connection configured with a **static** bootproto but without an **IP** address defined.

- https://bugzilla.suse.com/show_bug.cgi?id=1184883

## Solution

Do not crash in this case and try to return earlier when it does not make sense to apply changes.

## Test

- Adapted unit tested.
- Tested manually