### PR TITLE
Fix hotplug check when there is no hardware info

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,7 +2,7 @@
 Thu Apr 22 09:12:38 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when modifying a virtual interface and checking if
-  if it is hotplug (bsc#1184623, bsc#1185106)
+  it is hotplug (bsc#1184623, bsc#1185106)
 - 4.4.5
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 22 09:12:38 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not crash when modifying a virtual interface and checking if
+  if it is hotplug (bsc#1184623, bsc#1185106)
+- 4.4.5
+
+-------------------------------------------------------------------
 Wed Apr 14 11:05:02 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not require a MAC address when activating a qeth device

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.4
+Version:        4.4.5
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -135,6 +135,8 @@ module Y2Network
 
     # @return [Boolean] true if the interface is hotplug
     def hotplug?
+      return false unless hardware
+
       ["usb", "pcmcia"].include?(hardware.hotplug)
     end
   end

--- a/test/y2network/interface_test.rb
+++ b/test/y2network/interface_test.rb
@@ -155,4 +155,53 @@ describe Y2Network::Interface do
       end
     end
   end
+
+  describe "#hotplug?" do
+    context "when the interface does not contain hardware information" do
+      subject(:interface) { Y2Network::PhysicalInterface.new("br0") }
+
+      it "returns false" do
+        expect(interface.hotplug?).to eql(false)
+      end
+    end
+
+    context "when the interface contains hardware information" do
+      let(:hardware) do
+        Y2Network::Hwinfo.new(name: "Ethernet Connection I217-LM",
+          dev_name: "enp0s25", mac: "01:23:45:67:89:ab")
+      end
+
+      subject(:interface) do
+        Y2Network::PhysicalInterface.new("eth0", hardware: hardware)
+      end
+
+      context "and it is not a hotplug interface" do
+        it "returns false" do
+          expect(interface.hotplug?).to eql(false)
+        end
+      end
+
+      context "and it is an usb hotplug interface" do
+        let(:hardware) do
+          Y2Network::Hwinfo.new(name: "100Mbps Network Card Adapter",
+            dev_name: "enp0s20u5c2", mac: "01:23:45:67:89:ab", hotplug: "usb")
+        end
+
+        it "returns true" do
+          expect(interface.hotplug?).to eql(true)
+        end
+      end
+
+      context "and it is a pcmcia hotplug interface" do
+        let(:hardware) do
+          Y2Network::Hwinfo.new(name: "100Mbps Network Card Adapter",
+            dev_name: "enp0s20u5c2", mac: "01:23:45:67:89:ab", hotplug: "pcmcia")
+        end
+
+        it "returns true" do
+          expect(interface.hotplug?).to eql(true)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

When a virtual interface is edited it does not contain hardware information and the hotplug? check crashes miserably.

- https://bugzilla.suse.com/show_bug.cgi?id=1185106

## Solution

Do not crash when there is no hardware information

## Tests

Added unit test for the hotplug? interface method.