### PR TITLE
Dropped setting set_default_route

### DIFF
--- a/src/lib/y2network/dialogs/add_interface.rb
+++ b/src/lib/y2network/dialogs/add_interface.rb
@@ -51,24 +51,9 @@ module Y2Network
         )
       end
 
-      # initialize legacy stuff, that should be removed soon
-      def legacy_init
-        # FIXME: This is for backward compatibility only
-        # dhclient needs to set just one dhcp enabled interface to
-        # DHCLIENT_SET_DEFAULT_ROUTE=yes. Otherwise interface is selected more
-        # or less randomly (bnc#868187). However, UI is not ready for such change yet.
-        # As it could easily happen that all interfaces are set to "no" (and
-        # default route is unreachable in such case) this explicit setup was
-        # added.
-        # FIXME: not implemented in network-ng
-        Yast::LanItems.set_default_route = true
-      end
-
       # @return [Y2Network::InterfaceConfigBuilder, nil] returns new builder when type selected
       #   or nil if canceled
       def run
-        legacy_init
-
         ret = super
         log.info "AddInterface result #{ret}"
         ret = :back if ret == :abort


### PR DESCRIPTION
I've decided to remove it completely because:
1) we haven't written this setup since last huge network-ng refactoring
2) we do not have (and never had) support for configuring it via UI
3) no one complained that it haven't worked since last refactoring
4) it worked as "dak magic" anyway (see 2) and was marked as FIXME in the old code
5) this is related to UI only and doesn't affect (auto)installation
6) if it is not explicitly set in ifcfg file then default from /etc/sysconfig/network/dhcp which is provided by wicked is used