### PR TITLE
Handle invalid values

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 22 10:15:42 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when the BOOTPROTO or STARTMODE ar missing or
+  invalid (bsc#1181295).
+- 4.3.66
+
+-------------------------------------------------------------------
 Mon Apr 12 12:05:02 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not require a MAC address when activating a qeth device

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.65
+Version:        4.3.66
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/wicked/connection_config_readers/base.rb
+++ b/src/lib/y2network/wicked/connection_config_readers/base.rb
@@ -72,20 +72,35 @@ module Y2Network
 
       private
 
+        DEFAULT_BOOTPROTO = BootProtocol::STATIC
+
+        # Finds the boot protocol
+        #
+        # If it is not defined or it has an unknown value, it returns the
+        # fallback value (BootProtocol::STATIC).
+        #
+        # @return [BootProtocol]
         def find_bootproto
           bootproto = BootProtocol.from_name(file.bootproto.to_s)
           return bootproto if bootproto
 
-          fallback = file.ipaddrs.empty? ? BootProtocol::DHCP : BootProtocol::STATIC
-          report_invalid_value("BOOTPROTO", file.bootproto, fallback.name)
-          fallback
+          report_invalid_value("BOOTPROTO", file.bootproto, DEFAULT_BOOTPROTO.name)
+          DEFAULT_BOOTPROTO
         end
 
+        DEFAULT_STARTMODE_NAME = "manual".freeze
+
+        # Finds the start mode
+        #
+        # If it is not defined or it has an unknown value, it returns the
+        # fallback value (manual).
+        #
+        # @return [Startmode]
         def find_startmode
           startmode = Startmode.create(file.startmode) if file.startmode
           return startmode if startmode
 
-          fallback = Startmode.create("manual")
+          fallback = Startmode.create(DEFAULT_STARTMODE_NAME)
           report_invalid_value("STARTMODE", file.startmode, fallback.name)
           fallback
         end

--- a/test/y2network/wicked/connection_config_readers/ethernet_test.rb
+++ b/test/y2network/wicked/connection_config_readers/ethernet_test.rb
@@ -109,36 +109,14 @@ describe Y2Network::Wicked::ConnectionConfigReaders::Ethernet do
         allow(file).to receive(:bootproto).and_return("something")
       end
 
-      context "and there is some defined address" do
-        before do
-          allow(file).to receive(:ipaddrs).and_return([double("IP")])
-        end
-
-        it "falls back to STATIC" do
-          eth = handler.connection_config
-          expect(eth.bootproto).to eq(Y2Network::BootProtocol::STATIC)
-        end
-
-        it "logs the problem" do
-          expect(handler.log).to receive(:warn).with(/Invalid.*BOOTPROTO.*static/)
-          handler.connection_config
-        end
+      it "falls back to STATIC" do
+        eth = handler.connection_config
+        expect(eth.bootproto).to eq(Y2Network::BootProtocol::STATIC)
       end
 
-      context "and there are not defined addresses" do
-        before do
-          allow(file).to receive(:ipaddrs).and_return([])
-        end
-
-        it "falls back to DHCP" do
-          eth = handler.connection_config
-          expect(eth.bootproto).to eq(Y2Network::BootProtocol::DHCP)
-        end
-
-        it "logs the problem" do
-          expect(handler.log).to receive(:warn).with(/Invalid.*BOOTPROTO.*dhcp/)
-          handler.connection_config
-        end
+      it "logs the problem" do
+        expect(handler.log).to receive(:warn).with(/Invalid.*BOOTPROTO.*static/)
+        handler.connection_config
       end
     end
 


### PR DESCRIPTION
Prevent YaST2 from crashing when `BOOTMODE` or `STARTMODE` are invalid. Unlike #1206, it does not use the [Y2Issues mechanism](https://github.com/yast/yast-yast2/pull/1156) because it is not available in `SLE-15-SP3` and backporting all those changes might be risky. So, by now, YaST2 just logs the problem and selects a suitable default value.

Bug: [bsc#1181295](https://bugzilla.suse.com/show_bug.cgi?id=1181295)
Trello: https://trello.com/c/3dJHjgeQ/