### PR TITLE
Small fixes

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Apr 22 12:22:47 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- bsc#1185106
+  - Initialize correctly the netmask when using the static bootproto
+    without an IP address defined.
+  - Fix MTU write when using wicked.
+
+-------------------------------------------------------------------
 Thu Apr 22 09:12:38 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when modifying a virtual interface and checking if

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -397,7 +397,7 @@ module Y2Network
     def ip_config_default
       return @connection_config.ip if @connection_config.ip
 
-      @connection_config.ip = ConnectionConfig::IPConfig.new(IPAddress.new("0.0.0.0"))
+      @connection_config.ip = ConnectionConfig::IPConfig.new(IPAddress.from_string("0.0.0.0/32"))
     end
 
     # Returns the connection config class for a given type

--- a/src/lib/y2network/wicked/connection_config_writers/base.rb
+++ b/src/lib/y2network/wicked/connection_config_writers/base.rb
@@ -51,7 +51,7 @@ module Y2Network
           file.ifplugd_priority = conn.startmode.priority if conn.startmode.to_s == "ifplugd"
           file.ethtool_options = value_as_string(conn.ethtool_options)
           file.zone = value_as_string(conn.firewall_zone)
-          file.mtu = value_as_string(conn.mtu)
+          file.mtu = conn.mtu
           add_ips(conn)
 
           update_file(conn)

--- a/src/lib/y2network/wicked/connection_config_writers/base.rb
+++ b/src/lib/y2network/wicked/connection_config_writers/base.rb
@@ -51,7 +51,7 @@ module Y2Network
           file.ifplugd_priority = conn.startmode.priority if conn.startmode.to_s == "ifplugd"
           file.ethtool_options = value_as_string(conn.ethtool_options)
           file.zone = value_as_string(conn.firewall_zone)
-          file.mtu = conn.mtu
+          file.mtu = conn.mtu unless conn.mtu.to_i.zero?
           add_ips(conn)
 
           update_file(conn)

--- a/test/y2network/wicked/connection_config_writers/bonding_test.rb
+++ b/test/y2network/wicked/connection_config_writers/bonding_test.rb
@@ -36,6 +36,7 @@ describe Y2Network::Wicked::ConnectionConfigWriters::Bonding do
       c.bootproto = Y2Network::BootProtocol::DHCP
       c.slaves = ["eth0", "eth1"]
       c.options = "mode=active-backup miimon=100"
+      c.mtu     = 9000
     end
   end
 
@@ -46,7 +47,8 @@ describe Y2Network::Wicked::ConnectionConfigWriters::Bonding do
       handler.write(conn)
       expect(file).to have_attributes(
         startmode: "auto",
-        bootproto: "dhcp"
+        bootproto: "dhcp",
+        mtu:       9000
       )
     end
 

--- a/test/y2network/wicked/connection_config_writers/ethernet_test.rb
+++ b/test/y2network/wicked/connection_config_writers/ethernet_test.rb
@@ -66,6 +66,7 @@ describe Y2Network::Wicked::ConnectionConfigWriters::Ethernet do
       c.ip_aliases = [ip_alias]
       c.startmode = Y2Network::Startmode.create("auto")
       c.hostname = "foo"
+      c.mtu = 1518
       c.dhclient_set_hostname = true
     end
   end
@@ -79,7 +80,8 @@ describe Y2Network::Wicked::ConnectionConfigWriters::Ethernet do
         name:                  conn.description,
         bootproto:             "static",
         startmode:             "auto",
-        dhclient_set_hostname: "yes"
+        dhclient_set_hostname: "yes",
+        mtu:                   1518
       )
     end
 

--- a/test/y2network/wicked/connection_config_writers/ethernet_test.rb
+++ b/test/y2network/wicked/connection_config_writers/ethernet_test.rb
@@ -66,7 +66,6 @@ describe Y2Network::Wicked::ConnectionConfigWriters::Ethernet do
       c.ip_aliases = [ip_alias]
       c.startmode = Y2Network::Startmode.create("auto")
       c.hostname = "foo"
-      c.mtu = 1518
       c.dhclient_set_hostname = true
     end
   end
@@ -81,7 +80,7 @@ describe Y2Network::Wicked::ConnectionConfigWriters::Ethernet do
         bootproto:             "static",
         startmode:             "auto",
         dhclient_set_hostname: "yes",
-        mtu:                   1518
+        mtu:                   nil
       )
     end
 


### PR DESCRIPTION
## Problem

- When there is no **IP address** configured but the **bootproto** is static the builder initializes the IPAdress without prefix. 
- The MTU is an integer field and we treat it as a string in the wicked writer

https://bugzilla.suse.com/show_bug.cgi?id=1185106

## Solution

- Initialize the builder default IP using also the netmask
- Set the MTU only when it is not nil or 0.