### PR TITLE
Omit networks without an essid

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Wed Apr 28 09:18:27 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
-- Omit hidden networks from the list of wireless network to be
+- Omit hidden networks from the list of wireless networks to be
   selected preventing the dialog to crash (bsc#1185372)
 - 4.3.67
 

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 28 09:18:27 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Omit hidden networks from the list of wireless network to be
+  selected preventing the dialog to crash (bsc#1185372)
+- 4.3.67
+
+-------------------------------------------------------------------
 Thu Apr 22 10:15:42 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when the BOOTPROTO or STARTMODE ar missing or

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.66
+Version:        4.3.67
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/dialogs/wireless_networks.rb
+++ b/src/lib/y2network/dialogs/wireless_networks.rb
@@ -121,7 +121,7 @@ module Y2Network
           _("Scanning for wireless networks..."), headline: _("Scanning network")
         ) do
           found_networks = Y2Network::WirelessNetwork.all(@builder.interface.name, cache: cache)
-          found_networks.delete_if { |n| n.essid.to_s.empty? }
+            .reject { |n| n.essid.to_s.empty? }
           log.info("Found networks: #{found_networks.map(&:essid)}")
         end
 

--- a/src/lib/y2network/dialogs/wireless_networks.rb
+++ b/src/lib/y2network/dialogs/wireless_networks.rb
@@ -121,6 +121,7 @@ module Y2Network
           _("Scanning for wireless networks..."), headline: _("Scanning network")
         ) do
           found_networks = Y2Network::WirelessNetwork.all(@builder.interface.name, cache: cache)
+          found_networks.delete_if { |n| n.essid.to_s.empty? }
           log.info("Found networks: #{found_networks.map(&:essid)}")
         end
 

--- a/test/y2network/dialogs/wireless_networks_test.rb
+++ b/test/y2network/dialogs/wireless_networks_test.rb
@@ -87,6 +87,5 @@ describe Y2Network::Dialogs::WirelessNetworks do
         expect(subject.run).to eq(nil)
       end
     end
-
   end
 end

--- a/test/y2network/dialogs/wireless_networks_test.rb
+++ b/test/y2network/dialogs/wireless_networks_test.rb
@@ -34,6 +34,14 @@ describe Y2Network::Dialogs::WirelessNetworks do
     Y2Network::Widgets::WirelessNetworks.new(builder)
   end
 
+  let(:scanned_networks) do
+    [hidden, selected]
+  end
+
+  let(:hidden) do
+    instance_double(Y2Network::WirelessNetwork, essid: nil)
+  end
+
   let(:selected) do
     instance_double(Y2Network::WirelessNetwork, essid: "TESTING")
   end
@@ -46,7 +54,7 @@ describe Y2Network::Dialogs::WirelessNetworks do
     allow(Y2Network::Widgets::WirelessNetworks).to receive(:new)
       .and_return(networks_table)
     allow(Y2Network::WirelessNetwork).to receive(:all).with("wlo1", cache: true)
-      .and_return([selected])
+      .and_return(scanned_networks)
     allow(networks_table).to receive(:selected).and_return(selected)
     allow(networks_table).to receive(:update)
     allow(Yast2::Feedback).to receive(:show) { |&block| block.call }
@@ -55,13 +63,18 @@ describe Y2Network::Dialogs::WirelessNetworks do
   end
 
   describe "#run" do
+    let(:event) { { "ID" => :ok, "EventReason" => "Activated" } }
+
     before do
       allow(Yast::UI).to receive(:WaitForEvent).and_return(event)
     end
 
-    context "if the user clicks the 'Select' button" do
-      let(:event) { { "ID" => :ok, "EventReason" => "Activated" } }
+    it "does not show networks without and essid in the table selection" do
+      expect(networks_table).to receive(:update).with([selected])
+      subject.run
+    end
 
+    context "if the user clicks the 'Select' button" do
       it "returns the selected network" do
         expect(subject.run).to eq(selected)
       end
@@ -74,5 +87,6 @@ describe Y2Network::Dialogs::WirelessNetworks do
         expect(subject.run).to eq(nil)
       end
     end
+
   end
 end


### PR DESCRIPTION
## Problem

The dialog for selecting a wireless network crashes when there is some hidden network (empty essid).

- https://bugzilla.suse.com/show_bug.cgi?id=1185372

## Solution

Skip networks without an essid from the table list.
