### PR TITLE
InterfaceFile: Write collections in order

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 12 16:46:00 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Write IP addresses in order preventing an alias to set the
+  primary IP address (bsc#1185967)
+- 4.2.99
+
+-------------------------------------------------------------------
 Fri Apr 16 16:27:13 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash during an AutoYaST installation when trying to

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.98
+Version:        4.2.99
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/sysconfig/interface_file.rb
+++ b/src/lib/y2network/sysconfig/interface_file.rb
@@ -605,7 +605,7 @@ module Y2Network
       # @see #clean_collection
       def write_collection(key, values)
         clean_collection(key)
-        values.each do |suffix, value|
+        values.sort_by { |s, _v| (s == :default) ? "" : s.to_s }.each do |suffix, value|
           write_key = (suffix == :default) ? key : "#{key}#{suffix}"
           write_scalar(write_key, value)
         end


### PR DESCRIPTION
## Problem

When a connection has **multiple** IP addresses, the order in which them will be written down to the file is unknown and the primary IP address could be an alias one.

- https://bugzilla.suse.com/show_bug.cgi?id=1185967

## Solution

Ensure that the **InterfaceFile** collection variables are sort when writing them down.

With the fix the collections are written in order:

```
IPADDR='192.168.0.190/24'
IPADDR_1='192.168.1.101/24'
IPADDR_2='192.168.0.181/24'
BOOTPROTO='static'
STARTMODE='auto'
LABEL_1='test'
LABEL_2='te'
```

**Note:** each set is usually written together like:

```
IPADDR='192.168.0.190/24'
BOOTPROTO='static'
STARTMODE='auto'
IPADDR_1='192.168.1.101/24'
LABEL_1='test'
IPADDR_2='192.168.0.181/24'
LABEL_2='te'
```

But for the bug should be enough with this fix.

## Tests

- Tested manually