### PR TITLE
Fix interfaces collection array operations (bsc#1186082)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 24 10:47:46 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix error when determining the removed interfaces in order to
+  remove their associated routes too (bsc#1186082)
+- 4.2.100
+
+-------------------------------------------------------------------
 Wed May 12 16:46:00 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Write IP addresses in order preventing an alias to set the

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.99
+Version:        4.2.100
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -95,6 +95,11 @@ module Y2Network
     # https://ruby-doc.org/core-2.3.3/Object.html#method-i-eql-3F
     alias_method :eql?, :==
 
+    # Used by Array or Hash in order to compare equality of elements (bsc#1186082)
+    def hash
+      name.hash
+    end
+
     # Complete configuration of the interface
     #
     # @return [Hash<String, String>] option, value hash map

--- a/src/lib/y2network/interfaces_collection.rb
+++ b/src/lib/y2network/interfaces_collection.rb
@@ -86,6 +86,7 @@ module Y2Network
     # @param type [InterfaceType] device type
     # @return [InterfacesCollection] list of found interfaces
     def by_type(type)
+      type = InterfaceType.from_short_name(type.to_s) unless type.is_a?(InterfaceType)
       InterfacesCollection.new(interfaces.select { |i| i.type == type })
     end
 
@@ -123,6 +124,22 @@ module Y2Network
     end
 
     alias_method :eql?, :==
+
+    # Returns a new collection including elements from both collections
+    #
+    # @param other [InterfacesCollection] Other interfaces collection
+    # @return [InterfacesCollection] New interfaces collection
+    def +(other)
+      self.class.new(to_a + other.to_a)
+    end
+
+    # Returns a new collection including only the elements that are not in the given collection
+    #
+    # @param other [InterfacesCollection] Other interfaces collection
+    # @return [InterfacesCollection] New interfaces collection
+    def -(other)
+      self.class.new(to_a - other.to_a)
+    end
 
     # Returns the interfaces that are enslaved in the given bridge
     #

--- a/src/lib/y2network/sysconfig/config_writer.rb
+++ b/src/lib/y2network/sysconfig/config_writer.rb
@@ -104,7 +104,7 @@ module Y2Network
         end
 
         # Actions needed for removed interfaces
-        removed_ifaces = old_config ? old_config.interfaces.to_a - config.interfaces.to_a : []
+        removed_ifaces = old_config ? old_config.interfaces - config.interfaces : []
         removed_ifaces.each do |iface|
           file = routes_file_for(iface)
           file.remove


### PR DESCRIPTION
## Problem

We have overridden the **eql?** method in many places but not the **hash** method which is a problem in some Arrays operation where it could give unexpected values depending on the comparison method used.

- https://bugzilla.suse.com/show_bug.cgi?id=1186082

## Solution

- Override the **hash** method in accordance to the **eql?** logic.
- Add / fix some interfaces collection operators.

This will fix the reported error but we should override the **hash** method in other places where we have also made the **eql?** method an alias of the **==** method.