### PR TITLE
Allow to set IP forwarding defaults through the control file (bsc#1186280)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 28 13:51:57 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Allow to modify the network IP forwarding configuration defining
+  the defaults in the control file (bsc#1186280)
+- 4.4.12
+
+-------------------------------------------------------------------
 Mon May 24 10:47:46 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix error when determining the removed interfaces in order to

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.11
+Version:        4.4.12
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/clients/network_proposal.rb
+++ b/src/lib/network/clients/network_proposal.rb
@@ -46,6 +46,7 @@ module Yast
       textdomain "installation"
 
       settings.refresh_packages
+      settings.apply_defaults
     end
 
     def description

--- a/src/lib/network/clients/save_network.rb
+++ b/src/lib/network/clients/save_network.rb
@@ -296,6 +296,7 @@ module Yast
 
       if !Mode.autoinst
         NetworkAutoconfiguration.instance.configure_dns
+        NetworkAutoconfiguration.instance.configure_routing
         configure_network_manager
       end
 

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -147,6 +147,12 @@ module Yast
       Host.Write
     end
 
+    def configure_routing
+      return if config.routing == Lan.system_config.routing
+
+      Lan.write_config(only: [:routing])
+    end
+
   private
 
     # Makes DHCP setup persistent

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -175,7 +175,7 @@ module Yast
     # @param devnames [Array] list of device names
     # @return true when changes were successfully applied
     def activate_changes(devnames)
-      Lan.write_config
+      Lan.write_config(only: [:connections])
 
       reload_config(devnames)
     end

--- a/src/lib/y2network/autoinst_profile/routing_section.rb
+++ b/src/lib/y2network/autoinst_profile/routing_section.rb
@@ -82,8 +82,8 @@ module Y2Network
       def init_from_hashes(hash)
         super
         ip_forward = hash["ip_forward"]
-        @ipv4_forward = hash["ipv4_forward"] || ip_forward
-        @ipv6_forward = hash["ipv6_forward"] || ip_forward
+        @ipv4_forward = hash.fetch("ipv4_forward", ip_forward)
+        @ipv6_forward = hash.fetch("ipv6_forward", ip_forward)
         @routes = routes_from_hash(hash)
       end
 

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -33,11 +33,11 @@ module Y2Network
     # @return [Boolean] network service to be used after the installation
     attr_accessor :selected_backend
     attr_accessor :virt_bridge_proposal
-    attr_accessor :ipv4_forwarding
-    attr_accessor :ipv6_forwarding
+    attr_accessor :ipv4_forward
+    attr_accessor :ipv6_forward
     attr_accessor :defaults_applied
 
-    DEFAULTS = [:ipv4_forwarding, :ipv6_forwarding].freeze
+    DEFAULTS = [:ipv4_forward, :ipv6_forward].freeze
 
     # Constructor
     def initialize
@@ -65,11 +65,11 @@ module Y2Network
     # network configuration if the proposal settings were already applied
     def apply_defaults
       return if defaults_applied
-      return @defaults_applied = true if DEFAULTS.all? { |k, _| public_send(k).nil? }
+      return @defaults_applied = true if DEFAULTS.all? { |o| public_send(o).nil? }
 
       Yast::Lan.read_config(report: false) unless yast_config
-      yast_config.routing.forward_ipv4 = ipv4_forwarding unless ipv4_forwarding.nil?
-      yast_config.routing.forward_ipv6 = ipv6_forwarding unless ipv6_forwarding.nil?
+      yast_config.routing.forward_ipv4 = ipv4_forward unless ipv4_forward.nil?
+      yast_config.routing.forward_ipv6 = ipv6_forward unless ipv6_forward.nil?
       @defaults_applied = true
     end
 

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -55,9 +55,8 @@ module Y2Network
 
     # Modifies the proposal according to the given settings
     #
-    # @param settings [Hash] networking default settings to be loaded
-    def modify_defaults(settings)
-      load_features # Networking section first
+    # @param settings [Hash] network default settings to be loaded
+    def modify_defaults(settings = network_section)
       load_features(settings)
       @defaults_applied = false
     end

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -196,7 +196,7 @@ module Y2Network
     def load_features(source = network_section)
       return unless source.is_a?(Hash)
 
-      source.keys.each { |k| load_feature(k, k, source: source) if respond_to?("#{k}=") }
+      source.keys.each { |k| load_feature(k, k, source: source) }
     end
 
     # Reads a feature from a given hash and assign it to the corresponding object attribute
@@ -205,8 +205,10 @@ module Y2Network
     # @param to [String, Symbol] attribute name where to store the feature value
     # @param source [Hash] from where to read the feature
     def load_feature(feature, to, source: network_section)
+      return unless respond_to?("#{to}=")
+
       value = source[feature.to_s]
-      public_send("#{to}=", value) unless value.nil?
+      public_send("#{to}=", value)
     end
 
     # Convenience method to read the control file network section

--- a/test/save_network_test.rb
+++ b/test/save_network_test.rb
@@ -60,6 +60,7 @@ describe Yast::SaveNetworkClient do
         .and_return(propose_bridge)
       allow(Yast::NetworkAutoconfiguration.instance).to receive(:configure_dns)
       allow(Yast::NetworkAutoconfiguration.instance).to receive(:configure_hosts)
+      allow(Yast::NetworkAutoconfiguration.instance).to receive(:configure_routing)
       allow(Yast::Lan).to receive(:yast_config).and_return(yast_config)
       allow(Yast::Lan).to receive(:system_config).and_return(system_config)
       allow(Yast::Lan).to receive(:write_config)
@@ -170,9 +171,18 @@ describe Yast::SaveNetworkClient do
       context "if the hosts are not configured by AutoYaST" do
         it "configures the /etc/hosts automatically" do
           allow(Yast::NetworkAutoYast.instance).to receive(:configure_hosts).and_return(false)
-          expect(Yast::NetworkAutoconfiguration.instance).to_not receive(:configure_dns)
+          expect(Yast::NetworkAutoconfiguration.instance).to receive(:configure_hosts)
           subject.main
         end
+      end
+    end
+
+    context "in case of not written previously" do
+      it "configures dns, hosts and routing according to the proposal" do
+        expect(Yast::NetworkAutoconfiguration.instance).to receive(:configure_dns)
+        expect(Yast::NetworkAutoconfiguration.instance).to receive(:configure_routing)
+        expect(Yast::NetworkAutoconfiguration.instance).to receive(:configure_hosts)
+        subject.main
       end
     end
 

--- a/test/y2network/proposal_settings_test.rb
+++ b/test/y2network/proposal_settings_test.rb
@@ -428,7 +428,7 @@ describe Y2Network::ProposalSettings do
 
   describe "#modify_defaults" do
     let(:settings) { described_class.create_instance }
-    let(:feature) { { "network" => { "ipv4_forwarding" => true } } }
+    let(:feature) { { "network" => { "ipv4_forward" => true } } }
 
     context "in case of defined IP forwarding features in the control file" do
       context "and no specific section is given" do
@@ -440,14 +440,14 @@ describe Y2Network::ProposalSettings do
 
       it "sets the IPv4 forwarding settings according to the feature value" do
         settings.modify_defaults
-        expect(settings.ipv4_forwarding).to eql(true)
-        expect(settings.ipv6_forwarding).to eql(nil)
+        expect(settings.ipv4_forward).to eql(true)
+        expect(settings.ipv6_forward).to eql(nil)
       end
 
       it "sets the IPv6 forwarding settings according to the feature value" do
-        role_feature = { "network" => { "ipv6_forwarding" => true } }
+        role_feature = { "network" => { "ipv6_forward" => true } }
         settings.modify_defaults(role_feature["network"])
-        expect(settings.ipv6_forwarding).to eql(true)
+        expect(settings.ipv6_forward).to eql(true)
       end
 
       it "sets the modified defaults as not applied" do
@@ -462,7 +462,7 @@ describe Y2Network::ProposalSettings do
     let(:settings) { described_class.create_instance }
     let(:config) { Y2Network::Config.new(source: "test", routing: routing) }
     let(:routing) { Y2Network::Routing.new(forward_ipv4: false, forward_ipv6: false, tables: []) }
-    let(:feature) { { "network" => { "ipv4_forwarding" => true } } }
+    let(:feature) { { "network" => { "ipv4_forward" => true } } }
 
     before do
       allow(Yast::Lan).to receive(:yast_config).and_return(config)


### PR DESCRIPTION
## Problem

During the installation, we read the current network configuration which includes the **sysctl IP forwarding** settings.
Therefore, if the configuration is modified and written, it will include those settings.

In a common case it happens when we call the **dhcp_setup** client which is very early during installation as you can see in the control file below:

- https://github.com/yast/skelcd-control-Kubic/blob/master/control/control.Kubic.xml#L668

We can adapt the **dhcp setup** writing only the connection changes (ifcfg files) which means that the **/etc/sysctl.d/70-yast.conf** will not be written yet and also it will not be copied to the target system if the network configuration is not modified manually.

That could be fine in most of the cases, and specially in Kubic if it is not expected to touch the network at all but the proposal would be showing that the IP forwarding is off. And apparently it needs to have it enabled by default which means this only change is not enough.

![Screenshot_Kubic_2021-05-25_21:54:34](https://user-images.githubusercontent.com/7056681/119633557-c3916180-be09-11eb-88d4-054a941ac938.png)

- https://bugzilla.suse.com/show_bug.cgi?id=1186280

## Solution

- The setup_dhcp client will write only what needed (connections).
- The network proposal settings can read and apply the defaults from the control file being written at the end of the installation in case it is needed.

## Example

```xml
    <!-- Example -->
    <network>
        <ipv4_forward>true</ipv4_forward>
    </network>

    <system_roles config:type="list">
      <system_role>
        <id>kubic_admin_role</id>

        <network>
          <ipv6_forward>true</ipv6_forward>
        </network>

```

![KubicDefaults](https://user-images.githubusercontent.com/7056681/120174537-1baad800-c1fd-11eb-9037-996a4dac2658.png)
