### PR TITLE
Use networkmanager lense

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon May 31 17:50:42 UTC 2021 - Michal Filka <mfilka@suse.com>
+
+- bnc#1185524
+  - do not crash at the end of installation when storing wifi
+    configuration for NetworkManager at the target 
+- 4.4.13
+
+-------------------------------------------------------------------
 Fri May 28 13:51:57 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Allow to modify the network IP forwarding configuration defining

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.12
+Version:        4.4.13
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/cfa/nm_connection.rb
+++ b/src/lib/cfa/nm_connection.rb
@@ -70,9 +70,7 @@ module CFA
     # @param path [String] File path
     # @param file_handler [.read, .write] Object to read/write the file.
     def initialize(path, file_handler: nil)
-      # FIXME: The Networkmanager lense writes the values surrounded by double
-      # quotes which is not valid
-      super(AugeasParser.new("Desktop.lns"), path, file_handler: file_handler)
+      super(AugeasParser.new("NetworkManager.lns"), path, file_handler: file_handler)
     end
 
     # Returns the augeas tree for the given section


### PR DESCRIPTION
See [Trello](https://trello.com/c/un8hpdfr/2469-3-ostumbleweed-p3-1185524-changing-to-networkmanager-via-yast-network-throws-an-internal-error) for details

## Problem ##

Installer reported an internal error at the end of installation when writing NetworkManager's configuration to the target.

## Solution

We used to use ```Desktop.lns``` instead of ```NetworkManager.lns``` because of a bug in the later one. As the bug was fixed [here](https://github.com/hercules-team/augeas/pull/723) we can switch to fixed NetworkManager.lns which solves the issue

## TBD
- ~~reference to augeas' pr~~
- version dependency on augeas lenses package with fixed lenses (?)