### PR TITLE
Proxy settings

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  8 08:44:23 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Use the linuxrc proxy settings for the HTTPS and FTP proxies
+  (bsc#1185016)
+- 4.3.70
+
+-------------------------------------------------------------------
 Mon May 24 10:47:46 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix error when determining the removed interfaces in order to

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.69
+Version:        4.3.70
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/install_inf_convertor.rb
+++ b/src/lib/network/install_inf_convertor.rb
@@ -95,6 +95,11 @@ module Yast
       ex["proxy_password"] = proxy.password
       proxy.password = nil
       ex["#{proxyProto}_proxy"] = proxy.to_s
+      # Use the proxy also for https and ftp
+      if proxyProto == "http"
+        ex["https_proxy"] = proxy.to_s
+        ex["ftp_proxy"] = proxy.to_s
+      end
       ex["enabled"] = true
       log.info "Writing proxy settings: #{proxyProto}_proxy = '#{proxy}'"
       log.debug "Writing proxy settings: #{ex}"

--- a/test/install_inf_convertor_test.rb
+++ b/test/install_inf_convertor_test.rb
@@ -138,7 +138,8 @@ describe "InstallInfConvertor" do
       )
       expect(Yast::Proxy).to receive(:Import) do |config|
         # proxy is enabled and the URL is set
-        expect(config).to include("enabled" => true, "http_proxy" => proxy_url)
+        expect(config).to include("enabled" => true, "http_proxy" => proxy_url,
+          "https_proxy" => proxy_url, "ftp_proxy" => proxy_url)
       end
       expect(Yast::Proxy).to receive(:Write).and_return(true)
 
@@ -162,6 +163,7 @@ describe "InstallInfConvertor" do
       expect(Yast::Proxy).to receive(:Import) do |config|
         # proxy is enabled and the URL without credentials is set
         expect(config).to include("enabled" => true, "http_proxy" => proxy_url,
+          "https_proxy" => proxy_url, "ftp_proxy" => proxy_url,
           "proxy_user" => "user", "proxy_password" => "passwd")
       end
       expect(Yast::Proxy).to receive(:Write).and_return(true)


### PR DESCRIPTION
## Problem

See https://github.com/yast/yast-installation/pull/965 description.

## Solution

Use the **linuxrc** proxy settings for the **HTTPS** and **FTP** proxies (settings are written to /etc/sysconfig/proxy at the beginning of the installation)