### PR TITLE
bsc#1187270: fix control center tooltip (SLE-15-SP2)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 15 09:17:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the Comment entry in the desktop file so the tooltip
+  in the control center is properly translated (bsc#1187270).
+- 4.2.101
+
+-------------------------------------------------------------------
 Mon May 24 10:47:46 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix error when determining the removed interfaces in order to

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.100
+Version:        4.2.101
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/desktop/org.opensuse.yast.LAN.desktop
+++ b/src/desktop/org.opensuse.yast.LAN.desktop
@@ -22,6 +22,6 @@ Exec=xdg-su -c "/sbin/yast2 lan"
 
 Name=YaST Network
 GenericName=Network Settings
-Comment=Configure network cards, hostname and routing
+Comment="Configure network cards, hostname and routing"
 StartupNotify=true
 X-SuSE-YaST-Keywords=network,lan,dns,routing


### PR DESCRIPTION
Related to [bsc#1187270](https://bugzilla.opensuse.org/show_bug.cgi?id=1187270).

See [the original issue](https://github.com/yast/yast-users/pull/303) in the yast2-users module.