### PR TITLE
Recognize 'boot' and 'on' startmodes as 'auto' aliases.

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun 16 18:00:44 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Support 'boot' and 'on' as aliases for the 'auto' startmode
+  (bsc#1186910)
+- 4.2.102
+
+-------------------------------------------------------------------
 Tue Jun 15 09:17:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the Comment entry in the desktop file so the tooltip

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.101
+Version:        4.2.102
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/startmode.rb
+++ b/src/lib/y2network/startmode.rb
@@ -27,6 +27,14 @@ module Y2Network
   class Startmode
     include Yast::Logger
 
+    # To be backward compliant 'boot', 'on' and 'onboot' are aliases
+    # for 'auto' (bsc#1186910)
+    ALIASES = {
+      "boot"   => "auto",
+      "onboot" => "auto",
+      "on"     => "auto"
+    }.freeze
+
     attr_reader :name
     alias_method :to_s, :name
 
@@ -35,8 +43,8 @@ module Y2Network
     end
 
     # gets new instance of startmode for given type and its params
-    def self.create(name)
-      name = "auto" if name == "onboot" # onboot is alias for auto
+    def self.create(mode)
+      name = ALIASES[mode] || mode
       # avoid circular dependencies
       require "y2network/startmodes"
       Startmodes.const_get(name.capitalize).new

--- a/src/lib/y2network/startmode.rb
+++ b/src/lib/y2network/startmode.rb
@@ -36,18 +36,24 @@ module Y2Network
     }.freeze
 
     attr_reader :name
+    attr_reader :alias_name
+
     alias_method :to_s, :name
 
-    def initialize(name)
+    def initialize(name, alias_name: nil)
       @name = name
+      @alias_name = alias_name
     end
 
     # gets new instance of startmode for given type and its params
     def self.create(mode)
       name = ALIASES[mode] || mode
+      alias_name = ALIASES[mode] ? mode : nil
+
       # avoid circular dependencies
       require "y2network/startmodes"
-      Startmodes.const_get(name.capitalize).new
+      const = Startmodes.const_get(name.capitalize)
+      alias_name ? const.new(alias_name: alias_name) : const.new
     rescue NameError => e
       log.error "Invalid startmode #{e.inspect}"
       nil

--- a/src/lib/y2network/startmodes/auto.rb
+++ b/src/lib/y2network/startmodes/auto.rb
@@ -31,10 +31,10 @@ module Y2Network
     class Auto < Startmode
       include Yast::I18n
 
-      def initialize
+      def initialize(alias_name: nil)
         textdomain "network"
 
-        super("auto")
+        super("auto", alias_name: alias_name)
       end
 
       def to_human_string

--- a/src/lib/y2network/sysconfig/connection_config_writers/base.rb
+++ b/src/lib/y2network/sysconfig/connection_config_writers/base.rb
@@ -43,7 +43,7 @@ module Y2Network
           file.bootproto = conn.bootproto&.name
           file.name = conn.description
           file.lladdr = conn.lladdress
-          file.startmode = conn.startmode.to_s
+          file.startmode = startmode_for(conn)
           file.dhclient_set_hostname = dhclient_set_hostname(conn)
           file.ifplugd_priority = conn.startmode.priority if conn.startmode&.name == "ifplugd"
           if conn.ethtool_options && !conn.ethtool_options.empty?
@@ -103,6 +103,16 @@ module Y2Network
           return unless conn.hostname && conn.ip
 
           Yast::Host.Update("", conn.hostname, conn.ip.address.address.to_s)
+        end
+
+        # Obtains the startmode to be used for the connection given
+        #
+        # @param conn [Y2Network::ConnectionConfig::Base] Connection to take settings from
+        # @return [String] startmode be written
+        def startmode_for(conn)
+          return "" unless conn.startmode
+
+          conn.startmode.alias_name || conn.startmode.name
         end
       end
     end

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -46,7 +46,7 @@ describe Y2Network::Autoinst::InterfacesReader do
     {
       "bootproto"             => "dhcp",
       "name"                  => "eth0",
-      "startmode"             => "auto",
+      "startmode"             => "boot",
       "dhclient_set_hostname" => "yes",
       "aliases"               => {
         "alias0" => {
@@ -78,7 +78,8 @@ describe Y2Network::Autoinst::InterfacesReader do
 
     it "assign properly all values in profile" do
       eth0_config = subject.config.by_name("eth0")
-      expect(eth0_config.startmode).to eq Y2Network::Startmode.create("auto")
+      expect(eth0_config.startmode.name).to eq("auto")
+      expect(eth0_config.startmode.alias_name).to eq("boot")
       expect(eth0_config.bootproto).to eq Y2Network::BootProtocol.from_name("dhcp")
       expect(eth0_config.ip_aliases.size).to eq 3
       expect(eth0_config.dhclient_set_hostname).to eq true

--- a/test/y2network/sysconfig/connection_config_writers/bridge_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/bridge_test.rb
@@ -33,7 +33,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Bridge do
       c.name = "br1"
       c.interface = "br1"
       c.description = ""
-      c.startmode = Y2Network::Startmode.create("auto")
+      c.startmode = Y2Network::Startmode.create("on")
       c.bootproto = Y2Network::BootProtocol::DHCP
       c.ports = ["eth0", "eth1"]
       c.stp = false
@@ -48,7 +48,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Bridge do
       handler.write(conn)
       expect(file).to have_attributes(
         name:      conn.description,
-        startmode: "auto",
+        startmode: "on",
         bootproto: "dhcp"
       )
     end

--- a/test/y2network/sysconfig/connection_config_writers/ethernet_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/ethernet_test.rb
@@ -64,7 +64,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Ethernet do
       c.bootproto = Y2Network::BootProtocol::STATIC
       c.ip = ip
       c.ip_aliases = [ip_alias]
-      c.startmode = Y2Network::Startmode.create("auto")
+      c.startmode = Y2Network::Startmode.create("boot")
       c.hostname = "foo"
       c.dhclient_set_hostname = true
     end
@@ -78,7 +78,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Ethernet do
       expect(file).to have_attributes(
         name:                  conn.description,
         bootproto:             "static",
-        startmode:             "auto",
+        startmode:             "boot",
         dhclient_set_hostname: "yes"
       )
     end

--- a/test/y2network/sysconfig/connection_config_writers/wireless_test.rb
+++ b/test/y2network/sysconfig/connection_config_writers/wireless_test.rb
@@ -33,7 +33,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Wireless do
     Y2Network::ConnectionConfig::Wireless.new.tap do |c|
       c.interface = "wlan0"
       c.description = "Wireless Card 0"
-      c.startmode = Y2Network::Startmode.create("auto")
+      c.startmode = Y2Network::Startmode.create("onboot")
       c.bootproto = Y2Network::BootProtocol::STATIC
       c.ip = ip
       c.ip_aliases = [ip_alias]
@@ -62,7 +62,7 @@ describe Y2Network::Sysconfig::ConnectionConfigWriters::Wireless do
   it "sets relevant attributes" do
     handler.write(conn)
     expect(file).to have_attributes(
-      startmode:            "auto",
+      startmode:            "onboot",
       bootproto:            "static",
       wireless_mode:        conn.mode,
       wireless_essid:       conn.essid,


### PR DESCRIPTION
## Problem

According to the manual page, **onboot**, **on** and **boot** are aliases for auto start mode. However, YaST network considers **on** and **boot** values as invalid only handling **onboot** correctly.

## Solution

Recognize all the 'auto' aliases and respect the one selected in case that the network configuration is written.

## Test

- Added unit test.
- Tested manually in a normal installation and also in Autoinstallation (**in TW**).