### PR TITLE
Fallback to NM if wicked is not installed (bsc#1187423)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 17 15:42:01 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Fallback to NetworkManager if wicked is the backend selected but
+  it is not installed at the end of the installation (bsc#1187423)
+- 4.4.17
+
+-------------------------------------------------------------------
 Tue Jun 15 09:17:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the Comment entry in the desktop file so the tooltip

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.16
+Version:        4.4.17
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -160,13 +160,23 @@ module Y2Network
     # depending on the backend selected during the proposal and the packages
     # installed
     def network_service
-      if current_backend == :network_manager
+      case current_backend
+      when :network_manager
         return :network_manager if network_manager_installed?
 
         log.info("NetworkManager is the selected service but it is not installed")
         log.info("- using wicked")
 
         return :wicked
+      when :wicked
+        return :wicked if wicked_installed?
+
+        return :none unless network_manager_installed?
+
+        log.info("Wicked is the selected service but it is not installed")
+        log.info("- using Network Manager")
+
+        return :network_manager
       end
 
       current_backend
@@ -256,6 +266,13 @@ module Y2Network
     # @return [Boolean] true if NetworkManager is installed; false otherwise
     def network_manager_installed?
       Yast::Package.Installed("NetworkManager")
+    end
+
+    # Convenience method to determine if the NM package is installed or not
+    #
+    # @return [Boolean] true if wickedis installed; false otherwise
+    def wicked_installed?
+      Yast::Package.Installed("wicked")
     end
 
     # Determine whether NetworkManager should be selected by default according

--- a/src/lib/y2network/proposal_settings.rb
+++ b/src/lib/y2network/proposal_settings.rb
@@ -173,8 +173,7 @@ module Y2Network
 
         return :none unless network_manager_installed?
 
-        log.info("Wicked is the selected service but it is not installed")
-        log.info("- using Network Manager")
+        log.info("Wicked is the selected service but it is not installed - using Network Manager")
 
         return :network_manager
       end


### PR DESCRIPTION
## Problem

In an **AutoYaST** installation, when there is **no specific backend declared** in the profile then the default one is selected.

Currently the default backend is **NetworkManager** or **wicked** and it is defined in the product control file which in case of Tumbleweed is not set globally but only per role.

- https://github.com/yast/skelcd-control-openSUSE/blob/master/control/control.openSUSE.xml#L354

Thus, for the reported bug the default backend will be wicked which could be modified in the proposal or confirmation step. 

The problem is that wicked is **no required** anymore by **sysconfig** if there is another package providing the network.service which is the case as **NetworkManager** is required by the GNOME pattern. So, we end with a system with a netwok service installed (NetworkManager) but not enabled.

- https://bugzilla.suse.com/show_bug.cgi?id=1187423






## Solution

At the end of the installation, if the wicked service is selected as the backend to be used but it is not installed then NetworkManager will be used as the fallback network service in case of available.

Relevant AutoYaST sections:

```xml
<?xml version="1.0"?>
<!DOCTYPE profile>
<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
  <general>
    <mode>
      <confirm config:type="boolean">false</confirm>
    </mode>
  <software>
    <install_recommended config:type="boolean">true</install_recommended>
    <patterns config:type="list">
      <pattern>base</pattern>
      <pattern>gnome</pattern>
    </patterns>
  </software>
  <networking>
    <keep_install_network config:type="boolean">true</keep_install_network>
  </networking>
</profile>
```

Linuxrc network config: `ifcfg=enp1s0=192.168.122.50/24,192.168.122.1,192.168.122.1,suse.com`


## To be discussed

With the proposed solution **NetworkManager** is enabled and the network settings are translated correctly. The main question is if we should add the **wicked**' package or not in case it is the backend selected, that is done if the proposal dialog is run but not otherwise.