### PR TITLE
Fix aliases initialization

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 20 08:47:30 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not crash when the aliases defined in the AutoYaST profile
+  are not defined as a map (bsc#1188344)
+- 4.3.73
+
+-------------------------------------------------------------------
 Wed Jun 16 18:00:44 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Support 'boot' and 'on' as aliases for the 'auto' startmode

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.72
+Version:        4.3.73
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -279,9 +279,9 @@ module Y2Network
       # Overwrite base method to load also nested aliases
       def init_from_hashes(hash)
         hash = rename_key(hash, "bridge_forwarddelay", "bridge_forward_delay")
-        super(hash.reject { |k, _| k == "aliases" })
+        super(hash)
 
-        self.aliases = hash["aliases"] if hash["aliases"].is_a?(Hash)
+        self.aliases = hash["aliases"].is_a?(Hash) ? hash["aliases"] : {}
       end
 
       # Method used by {.new_from_network} to populate the attributes when cloning a network

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -279,9 +279,9 @@ module Y2Network
       # Overwrite base method to load also nested aliases
       def init_from_hashes(hash)
         hash = rename_key(hash, "bridge_forwarddelay", "bridge_forward_delay")
-        super(hash)
+        super(hash.reject { |k, _| k == "aliases" })
 
-        self.aliases = hash["aliases"] if hash["aliases"]
+        self.aliases = hash["aliases"] if hash["aliases"].is_a?(Hash)
       end
 
       # Method used by {.new_from_network} to populate the attributes when cloning a network

--- a/test/y2network/autoinst_profile/interface_section_test.rb
+++ b/test/y2network/autoinst_profile/interface_section_test.rb
@@ -120,6 +120,20 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
         expect(section.bridge_forward_delay).to eq("5")
       end
     end
+
+    context "when the aliases are declared as an string" do
+      let(:hash) do
+        {
+          "device"  => "eth0",
+          "aliases" => ""
+        }
+      end
+
+      it "does not break and initializes the aliases as an empty hash" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.aliases).to eql({})
+      end
+    end
   end
 
   describe "#to_hashes" do


### PR DESCRIPTION
## Problem

When the aliases section does not contain the element type it is treated as an string instead of a hash and the interfaces reader crashes.

- https://bugzilla.suse.com/show_bug.cgi?id=1188344

## Solution

Only set the aliases when it is defined as a map.
