### PR TITLE
Fix write of device routes (bsc#1188908)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 30 08:07:09 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix write of device routes. (bsc#1188908)
+- 4.4.22
+
+-------------------------------------------------------------------
 Tue Jul 20 08:47:30 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when the aliases defined in the AutoYaST profile

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.21
+Version:        4.4.22
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -83,6 +83,9 @@ module Y2Network
 
     # Determines whether two interfaces are equal
     #
+    # @note although it is preferable to use Yast2::Equatable it uses the class
+    #   hash for comparing objects and it will fail when comparing with
+    #   subclasses objects (bsc#1188908)
     # @param other [Interface] Interface to compare with
     # @return [Boolean]
     def ==(other)

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -20,7 +20,6 @@
 require "yast"
 require "y2network/interface_type"
 require "y2network/udev_rule"
-require "yast2/equatable"
 
 module Y2Network
   # Network interface.
@@ -38,7 +37,6 @@ module Y2Network
   class Interface
     extend Forwardable
     include Yast::Logger
-    include Yast2::Equatable
 
     # @return [String] Device name ('eth0', 'wlan0', etc.)
     attr_accessor :name
@@ -83,7 +81,24 @@ module Y2Network
       @renaming_mechanism = :none
     end
 
-    eql_attr :name
+    # Determines whether two interfaces are equal
+    #
+    # @param other [Interface] Interface to compare with
+    # @return [Boolean]
+    def ==(other)
+      return false unless other.is_a?(Interface)
+
+      name == other.name
+    end
+
+    # eql? (hash key equality) should alias ==, see also
+    # https://ruby-doc.org/core-2.3.3/Object.html#method-i-eql-3F
+    alias_method :eql?, :==
+
+    # Used by Array or Hash in order to compare equality of elements (bsc#1186082)
+    def hash
+      name.hash
+    end
 
     # Complete configuration of the interface
     #

--- a/test/y2network/route_test.rb
+++ b/test/y2network/route_test.rb
@@ -48,7 +48,7 @@ describe Y2Network::Route do
 
   describe "==" do
     let(:other_to) { IPAddr.new("192.168.122.0/24") }
-    let(:other_interface) { Y2Network::Interface.new("eth0") }
+    let(:other_interface) { Y2Network::PhysicalInterface.new("eth0") }
     let(:other_gateway) { nil }
     let(:other_options) { "" }
 


### PR DESCRIPTION
## Problem

It was reported [here](https://lists.opensuse.org/archives/list/yast-devel@lists.opensuse.org/thread/S2AZBYIH2QNNB42BVPM5QWJWL6VYB4WH/) that YaST does not supproted the write of routes per interface but that was already supported. 

The problem is that we broke the selection of routes to be written when we adopted Equatable (https://github.com/yast/yast-network/pull/1228)

It happens when we have read the configuration and the interfaces are detected as phisical or virtual ones, but later we compare it with a Y2NetworkInterface, so the classes are different and the comparison fails.

```ruby
Y2Network::Interface.new("eth0") == Y2Network::PhysicalInterface.new("eth0") ## => false

```

- https://bugzilla.opensuse.org/show_bug.cgi?id=1188908

## Solution

By now we will avoid the use of **Equatable** for **Y2NetworkInterface**.