### PR TITLE
Read default NTP servers from control file

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep  7 07:41:52 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Add support for reading the default NTP servers from the control
+  file in case of defined (bsc#1180699)
+- 4.4.23
+
+-------------------------------------------------------------------
 Fri Jul 30 08:07:09 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix write of device routes. (bsc#1188908)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.22
+Version:        4.4.23
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/ntp_server.rb
+++ b/src/lib/y2network/ntp_server.rb
@@ -67,7 +67,7 @@ module Y2Network
             "suse"
           end
 
-        log.info "Using ntp product servers (#{host})"
+        log.info "Using the '#{host}' NTP product servers"
 
         (0..DEFAULT_SERVERS - 1).map { |i| "#{i}.#{host}.#{DEFAULT_SUBDOMAIN}" }
       end
@@ -75,7 +75,7 @@ module Y2Network
       def control_servers
         Yast.import "ProductFeatures"
         servers = Yast::ProductFeatures.GetSection("globals")["default_ntp_servers"]
-        log.info "Using the servers defined in the control file: #{servers.inspect}"
+        log.info "Using the servers defined in the control file: #{servers.inspect}" if servers
         servers
       end
     end

--- a/test/y2network/ntp_server_test.rb
+++ b/test/y2network/ntp_server_test.rb
@@ -23,49 +23,72 @@ require "y2network/ntp_server"
 
 describe Y2Network::NtpServer do
   describe ".default_servers" do
+    let(:servers) { nil }
+    let(:globals) { { "default_ntp_servers" => servers } }
+
     before do
-      allow(Yast::Product).to receive(:FindBaseProducts)
-        .and_return(products)
+      allow(Yast::ProductFeatures).to receive(:GetSection).with("globals").and_return(globals)
     end
 
-    context "when running in an openSUSE system" do
-      let(:products) do
-        [{ "name" => "openSUSE" }]
+    context "when defined a list of servers in the control file" do
+      let(:servers) { ["1.suse.pool.ntp.org", "2.suse.pool.ntp.org"] }
+
+      it "returns the list of defined servers" do
+        expect(described_class.default_servers.map(&:hostname)).to eql(servers)
       end
 
-      it "returns a set of opensuse.pool.ntp.org servers" do
-        domain = "opensuse.pool.ntp.org"
-        expect(described_class.default_servers.map(&:hostname)).to eq(
-          ["0.#{domain}", "1.#{domain}", "2.#{domain}", "3.#{domain}"]
-        )
-      end
-    end
-
-    context "when not running in an openSUSE system" do
-      let(:products) do
-        [{ "name" => "SLES" }]
-      end
-
-      it "returns a set of suse.pool.ntp.org servers" do
-        domain = "suse.pool.ntp.org"
-        expect(described_class.default_servers.map(&:hostname)).to eq(
-          ["0.#{domain}", "1.#{domain}", "2.#{domain}", "3.#{domain}"]
-        )
+      context "and the list of servers is empty" do
+        it "returns an empty list" do
+          expect(described_class.default_servers.map(&:hostname)).to eql(servers)
+        end
       end
     end
 
-    context "when a list of base product is given" do
-      let(:products) do
-        [{ "name" => "openSUSE" }]
+    context "when no defined a list of servers in the control file" do
+      before do
+        allow(Yast::Product).to receive(:FindBaseProducts)
+          .and_return(products)
       end
 
-      it "returns the set of servers for that product" do
-        domain = "opensuse.pool.ntp.org"
-        expect(Yast::Product).to_not receive(:FindBaseProducts)
-        servers = described_class.default_servers(products)
-        expect(servers.map(&:hostname)).to eq(
-          ["0.#{domain}", "1.#{domain}", "2.#{domain}", "3.#{domain}"]
-        )
+      context "when running in an openSUSE system" do
+        let(:products) do
+          [{ "name" => "openSUSE" }]
+        end
+
+        it "returns a set of opensuse.pool.ntp.org servers" do
+          domain = "opensuse.pool.ntp.org"
+          expect(described_class.default_servers.map(&:hostname)).to eq(
+            ["0.#{domain}", "1.#{domain}", "2.#{domain}", "3.#{domain}"]
+          )
+        end
+      end
+
+      context "when not running in an openSUSE system" do
+        let(:products) do
+          [{ "name" => "SLES" }]
+        end
+
+        it "returns a set of suse.pool.ntp.org servers" do
+          domain = "suse.pool.ntp.org"
+          expect(described_class.default_servers.map(&:hostname)).to eq(
+            ["0.#{domain}", "1.#{domain}", "2.#{domain}", "3.#{domain}"]
+          )
+        end
+      end
+
+      context "when a list of base product is given" do
+        let(:products) do
+          [{ "name" => "openSUSE" }]
+        end
+
+        it "returns the set of servers for that product" do
+          domain = "opensuse.pool.ntp.org"
+          expect(Yast::Product).to_not receive(:FindBaseProducts)
+          servers = described_class.default_servers(products)
+          expect(servers.map(&:hostname)).to eq(
+            ["0.#{domain}", "1.#{domain}", "2.#{domain}", "3.#{domain}"]
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
## Problem

During the installation, the default **NTP** servers are inferred from the product name. Depending on it the installation will use a list of **openSUSE** or **SUSE** ntp pool servers.

Currently the product detection is broken and **openSUSE** products are using the **SUSE** servers but there is also no option to define the default ones and the list is currently hard coded.

- https://bugzilla.suse.com/show_bug.cgi?id=1180699
- https://trello.com/c/HtBLfvR0/2280-3-ostumbleweed-p5-1180699-microos-defaults-to-using-the-suse-ntp-pool

## Solution

Read the default servers from the control file in case of defined using the hard coded default ones only in case of missed definition. (see related https://github.com/yast/yast-country/pull/282, https://github.com/yast/skelcd-control-openSUSE/pull/223, https://github.com/yast/yast-installation-control/pull/112)

**Note:** An empty list can be used allowing the installation to not pre-fill the list of **NTP** servers, but it does not influence the RPM selection.