### PR TITLE
Display user defined device name in the overview

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 22 08:46:16 UTC 2021 - Michal Filka <mfilka@suse.com>
+
+- bnc#1190645
+  - display user defined device name in the devices overview
+- 4.3.74
+
+-------------------------------------------------------------------
 Tue Jul 20 08:47:30 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when the aliases defined in the AutoYaST profile

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.73
+Version:        4.3.74
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -40,8 +40,6 @@ module Y2Network
 
     # @return [String] Device name ('eth0', 'wlan0', etc.)
     attr_accessor :name
-    # @return [String] Interface description
-    attr_accessor :description
     # @return [InterfaceType] Interface type
     attr_accessor :type
     # @return [HwInfo]
@@ -75,7 +73,6 @@ module Y2Network
     # @param type [InterfaceType] Interface type
     def initialize(name, type: InterfaceType::ETHERNET)
       @name = name.freeze
-      @description = ""
       @type = type
       # TODO: move renaming logic to physical interfaces only
       @renaming_mechanism = :none

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -99,15 +99,17 @@ module Y2Network
         ""
       end
 
+      # Constructs device description for inactive s390 devices
       def device_item(device)
         [device.id, friendly_name(device), _("Not activated"), device.id, ""]
       end
 
+      # Generic device description handler
       def interface_item(interface)
         conn = config.connections.by_name(interface.name)
         [
           interface.name, # first is ID in table
-          friendly_name(interface),
+          conn.description || friendly_name(interface), # if user named the connection explicitly, it will have precendence
           interface_protocol(conn),
           interface.name,
           note(interface, conn)


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1190645

## Problem ##

we simply forgot of it during refactoring to network-ng

## Solution ##

Just use what was read from an ifcfg file(s)