### PR TITLE
bsc#1190739: consider <aliases> as case insensitive

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep 23 10:01:21 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Consider aliases sections as case insensitive (bsc#1190739).
+- 4.2.104
+
+-------------------------------------------------------------------
 Wed Sep 22 08:46:16 UTC 2021 - Michal Filka <mfilka@suse.com>
 
 - bnc#1190645

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.103
+Version:        4.2.104
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -99,10 +99,10 @@ module Y2Network
         config.ip = load_ipaddr(interface_section)
 
         # handle aliases
-        interface_section.aliases.values.each_with_index do |alias_h, index|
-          next if alias_h.fetch("IPADDR", "").empty?
+        interface_section.aliases.each_with_index do |section, index|
+          next if section.ipaddr.to_s.empty?
 
-          config.ip_aliases << load_alias(alias_h, id: "_#{index}")
+          config.ip_aliases << load_alias(section, id: "_#{index}")
         end
 
         # startmode
@@ -175,16 +175,16 @@ module Y2Network
 
       # Loads and initializates an IP alias according to given hash with alias details
       #
-      # @param alias_h [Hash] hash of AY profile's alias section as obtained from parser
+      # @param section[AliasSection] hash of AY profile's alias section as obtained from parser
       #
       # @return [ConnectionConfig::IPConfig] alias details
-      def load_alias(alias_h, id: nil)
-        ipaddr = IPAddress.from_string(alias_h["IPADDR"])
+      def load_alias(section, id: nil)
+        ipaddr = IPAddress.from_string(section.ipaddr)
         # Assign first netmask, as prefixlen has precedence so it will overwrite it
-        ipaddr.prefix = prefix_for(alias_h["NETMASK"]) if !alias_h.fetch("NETMASK", "").empty?
-        ipaddr.prefix = prefix_for(alias_h["PREFIXLEN"]) if !alias_h.fetch("PREFIXLEN", "").empty?
+        ipaddr.prefix = prefix_for(section.netmask) unless section.netmask.to_s.empty?
+        ipaddr.prefix = prefix_for(section.prefixlen) unless section.prefixlen.to_s.empty?
 
-        ConnectionConfig::IPConfig.new(ipaddr, id: id, label: alias_h["LABEL"])
+        ConnectionConfig::IPConfig.new(ipaddr, id: id, label: section.label)
       end
 
       def load_wireless(config, interface_section)

--- a/src/lib/y2network/autoinst_profile/alias_section.rb
+++ b/src/lib/y2network/autoinst_profile/alias_section.rb
@@ -1,0 +1,91 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/autoinst_profile/section_with_attributes"
+
+module Y2Network
+  module AutoinstProfile
+    # This class represents an alias specification within the <interface> section.
+    #
+    # <aliases>
+    #   <alias0>
+    #     <IPADDR>192.168.1.100</IPADDR>
+    #     <LABEL>1</LABEL>
+    #     <PREFIXLEN>24</PREFIXLEN>
+    #   </alias0>
+    # </aliases>
+    #
+    # It is case insensitive.
+    #
+    # @see InterfaceSection
+    class AliasSection < SectionWithAttributes
+      def self.attributes
+        [
+          { name: :ipaddr },
+          { name: :label },
+          { name: :prefixlen },
+          { name: :netmask },
+        ]
+      end
+
+      define_attr_accessors
+
+      # @!attribute ipaddr
+      #  @return [String] IP address
+
+      # @!attribute label
+      #  @return [String] alias label
+
+      # @!attribute prefixlen
+      #  @return [String] prefix length
+      #
+      # @!attribute netmask
+      #  @return [String] IP netmask
+
+      # Clones an IP config into an AutoYaST alias section
+      #
+      # @param ip_config [Y2Network::ConnectionConfig::IPConfig] Network connection config
+      # @return [AliasSection]
+      def self.new_from_network(config)
+        result = new
+        result.init_from_config(config)
+        result
+      end
+
+      # Method used by {.new_from_network} to populate the attributes when cloning an IP config
+      #
+      # @param config [Y2Network::ConnectionConfig]
+      # @return [Boolean]
+      def init_from_config(config)
+        @ipaddr = config.address&.address&.to_s
+        @label = config.label
+        @prefixlen = config.address&.prefix&.to_s
+      end
+
+      # Method used by {.new_from_hashes} to populate the attributes using a hash
+      # 
+      # @param config [Hash]
+      # @return [Boolean]
+      def init_from_hashes(config)
+        normalized_config = config.each_with_object({}) { |(k, v), c| c[k.downcase] = v }
+        super(normalized_config)
+      end
+    end
+  end
+end

--- a/test/y2network/autoinst_profile/alias_section_test.rb
+++ b/test/y2network/autoinst_profile/alias_section_test.rb
@@ -1,0 +1,67 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2network/autoinst_profile/alias_section"
+require "y2network/connection_config/ip_config"
+
+describe Y2Network::AutoinstProfile::AliasSection do
+  subject(:section) { described_class.new }
+
+  describe ".new_from_network" do
+    let(:config) do
+      Y2Network::ConnectionConfig::IPConfig.new(
+        Y2Network::IPAddress.from_string("10.100.0.1/24"), label: "test"
+      )
+    end
+
+    it "initializes values properly" do
+      section = described_class.new_from_network(config)
+      expect(section.ipaddr).to eq("10.100.0.1")
+      expect(section.prefixlen).to eq("24")
+      expect(section.label).to eq("test")
+    end
+  end
+
+  describe ".new_from_hashes" do
+    let(:hash) do
+      { "ipaddr" => "10.100.0.1", "prefixlen" => "24", "label" => "test" }
+    end
+
+    it "returns a section with the corresponding values" do
+      section = described_class.new_from_hashes(hash)
+      expect(section.ipaddr).to eq("10.100.0.1")
+      expect(section.prefixlen).to eq("24")
+      expect(section.label).to eq("test")
+    end
+
+    context "when keys use capital letters" do
+      let(:hash) do
+        { "IPADDR" => "10.100.0.1", "PREFIXLEN" => "24", "LABEL" => "test" }
+      end
+
+      it "returns a section with the corresponding values" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.ipaddr).to eq("10.100.0.1")
+        expect(section.prefixlen).to eq("24")
+        expect(section.label).to eq("test")
+      end
+    end
+  end
+end

--- a/test/y2network/autoinst_profile/interface_section_test.rb
+++ b/test/y2network/autoinst_profile/interface_section_test.rb
@@ -39,9 +39,6 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
         c.ip_aliases = [
           Y2Network::ConnectionConfig::IPConfig.new(
             Y2Network::IPAddress.from_string("10.100.0.1/24"), label: "test"
-          ),
-          Y2Network::ConnectionConfig::IPConfig.new(
-            Y2Network::IPAddress.from_string("10.100.0.2/24"), label: "test1"
           )
         ]
       end
@@ -52,10 +49,10 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
       expect(section.bootproto).to eq("static")
       expect(section.ipaddr).to eq("10.100.0.1")
       expect(section.prefixlen).to eq("24")
-      expect(section.aliases).to eq(
-        "alias0" => { "IPADDR" => "10.100.0.1", "PREFIXLEN" => "24", "LABEL" => "test" },
-        "alias1" => { "IPADDR" => "10.100.0.2", "PREFIXLEN" => "24", "LABEL" => "test1" }
-      )
+      alias0 = section.aliases.first
+      expect(alias0.ipaddr).to eq("10.100.0.1")
+      expect(alias0.prefixlen).to eq("24")
+      expect(alias0.label).to eq("test")
     end
   end
 
@@ -109,12 +106,16 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
     subject(:section) do
       described_class.new_from_hashes(
         "device"  => "eth0",
-        "aliases" => { "alias0" => { "IPADDR" => "10.100.0.1", "PREFIXLEN" => "24" } }
+        "aliases" => aliases_hash
       )
     end
 
+    let(:aliases_hash) do
+      { "alias0" => { "ipaddr" => "10.100.0.1", "prefixlen" => "24" } }
+    end
+
     it "exports the aliases key" do
-      expect(section.to_hashes["aliases"]).to eq(section.aliases)
+      expect(section.to_hashes["aliases"]).to eq(aliases_hash)
     end
 
     context "when the list of aliases is empty" do


### PR DESCRIPTION
According to [bsc#1190739](https://bugzilla.suse.com/show_bug.cgi?id=1190739), the `<aliases>` section is case sensitive. I guess it is a reminiscence of exporting the content of the `sysconfig` file.

This PR adds a proper `AliasSection` to handle these sections. From now on, the following examples are equivalent:

```xml
<aliases>
  <alias0>
    <IPADDR>192.168.122.1</IPADDR>
    <PREFIXLEN>24</PREFIXLEN>
  </alias0>
</aliases>

<!-- the same than: -->
<aliases>
  <alias0>
    <ipaddr>192.168.122.1</ipaddr>
    <prefixlen>24</prefixlen>
  </alias0>
</aliases>
```

The XML representation of the aliases list is rather weird: instead of being a list, it is a hash where the keys (`alias0`, `alias1`, etc.) are ignored. Actually, this section is [not validated](https://github.com/yast/yast-network/blob/f1c311fc8d6af163ac4f8c92813a98e6a1693909/src/autoyast-rnc/networking.rnc#L70) at all. In order to simplify things,
`InterfaceSection#aliases` is now an array of `AliasSection` objects instead of a hash. However, the XML representation is still the same, but it is easier to reason about it when dealing with the section objects.