### PR TITLE
Fix interfaces table with not configured ifaces (fix for #1247)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 27 09:12:23 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not crash when the interfaces table contains a not configured
+  one (bnc#1190645)
+- 4.2.105
+
+-------------------------------------------------------------------
 Thu Sep 23 10:01:21 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Consider aliases sections as case insensitive (bsc#1190739).

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.104
+Version:        4.2.105
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -110,7 +110,7 @@ module Y2Network
           # first is (item) ID in table
           interface.name,
           # if user named the connection explicitly, it will have precendence
-          conn.description || friendly_name(interface),
+          conn&.description || friendly_name(interface),
           interface_protocol(conn),
           interface.name,
           note(interface, conn)

--- a/test/y2network/widgets/interfaces_table_test.rb
+++ b/test/y2network/widgets/interfaces_table_test.rb
@@ -83,7 +83,7 @@ describe Y2Network::Widgets::InterfacesTable do
       end
     end
 
-    context "ant the device is not configured" do
+    context "and the device is not configured" do
       let(:connections) { Y2Network::ConnectionConfigsCollection.new([]) }
 
       it "shows the hwinfo interface description if present or the interface name if not" do


### PR DESCRIPTION
## Problem

When the interfaces table contains a not configured interface it crashes trying to call the related connection interface. (introduced by #1247)

Reported by openQA https://openqa.opensuse.org/tests/1940439#step/yast2_lan/14

## Solution

Just use the safe navigation operator **(&)**  preventing to call `description` over a **Nil** object. 
