### PR TITLE
Do not initialize the connection description

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,7 +2,9 @@
 Mon Sep 27 09:12:23 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when the interfaces table contains a not configured
-  one (bnc#1190645)
+  one (bnc#1190645, bsc#1190915)
+- Fix the shown description using the interface friendly name when
+  it is empty (bsc#1190933)
 - 4.2.105
 
 -------------------------------------------------------------------

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -62,7 +62,7 @@ module Y2Network
       attr_accessor :mtu
       # @return [Startmode]
       attr_accessor :startmode
-      # @return [String] Connection's description (e.g., "Ethernet Card 0")
+      # @return [String, nil] Connection's custom description (e.g., "Ethernet Card 0")
       attr_accessor :description
       # @return [String] Link layer address
       attr_accessor :lladdress

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -90,7 +90,6 @@ module Y2Network
         @bootproto = BootProtocol::STATIC
         @ip = IPConfig.new(IPAddress.from_string("0.0.0.0/32"))
         @startmode = Startmode.create("manual")
-        @description = ""
         @ethtool_options = ""
         @firewall_zone = ""
       end

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -145,7 +145,7 @@ module Y2Network
       # Returns the connection description if given or the interface friendly name if not
       #
       # @param interface [Interface] Network interface
-      # @param conn [ConnectionConfig::Base] Connection configuration
+      # @param conn [ConnectionConfig::Base, nil] Connection configuration
       # @return [String] Connection description if given or the friendly name for the interface (
       #   description or name) if not
       def description_for(interface, conn)

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -110,7 +110,7 @@ module Y2Network
           # first is (item) ID in table
           interface.name,
           # if user named the connection explicitly, it will have precendence
-          conn&.description || friendly_name(interface),
+          conn&.description.to_s.empty? ? friendly_name(conn, interface) : conn.description
           interface_protocol(conn),
           interface.name,
           note(interface, conn)

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -109,8 +109,7 @@ module Y2Network
         [
           # first is (item) ID in table
           interface.name,
-          # if user named the connection explicitly, it will have precendence
-          conn&.description.to_s.empty? ? friendly_name(conn, interface) : conn.description
+          description_for(interface, conn),
           interface_protocol(conn),
           interface.name,
           note(interface, conn)
@@ -143,11 +142,15 @@ module Y2Network
         summary.new(value, config).text
       end
 
-      # Returns a friendly name for a given interface
+      # Returns the connection description if given or the interface friendly name if not
       #
       # @param interface [Interface] Network interface
-      # @return [String] Friendly name for the interface (description or name)
-      def friendly_name(interface)
+      # @param conn [ConnectionConfig::Base] Connection configuration
+      # @return [String] Connection description if given or the friendly name for the interface (
+      #   description or name) if not
+      def description_for(interface, conn)
+        return conn.description unless conn&.description.to_s.empty?
+
         hwinfo = interface.hardware
         (hwinfo&.present?) ? hwinfo.description : interface.name
       end

--- a/test/y2network/widgets/interfaces_table_test.rb
+++ b/test/y2network/widgets/interfaces_table_test.rb
@@ -66,7 +66,6 @@ describe Y2Network::Widgets::InterfacesTable do
     context "when it includes a configured device" do
       it "includes the connection device name" do
         expect(subject.items).to include(a_collection_including(/eth0/))
-        subject.handle
       end
 
       context "and the device is named by user" do
@@ -89,7 +88,6 @@ describe Y2Network::Widgets::InterfacesTable do
       it "shows the hwinfo interface description if present or the interface name if not" do
         expect(subject.items).to include(a_collection_including(/Cool device/, /eth0/),
           a_collection_including(/br0/))
-        subject.items
       end
     end
 


### PR DESCRIPTION
## Problem

By default we initialize the description to nil, that will affects any new connection as we are initializing the description to an empty string (as we can see here - https://openqa.opensuse.org/tests/1940430#step/yast2_lan_device_settings/41) but it is not the case of read configurations.

Related to #1256 #1247 and https://bugzilla.suse.com/show_bug.cgi?id=1190645
![NoDescription](https://user-images.githubusercontent.com/7056681/134906566-542b8ec9-bfd6-4c7b-b868-25cab0e96652.png)


## Solution

Do not initialize the description when a new connection is added.

![EmptyVlanName](https://user-images.githubusercontent.com/7056681/134910014-3f0ae81f-a8fd-4dba-88e1-cf202ccb97b8.png)

## Note

No bump version is introduced as #1255 has not been submitted yet, but could add a changelog if needed