### PR TITLE
User NetworkManager lense in SLE-15-SP3 (backported #1230)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Oct  5 09:50:42 UTC 2021 - Michal Filka <mfilka@suse.com>
+
+- bnc#1185524, bsc#1187512
+  - do not crash at the end of installation when storing wifi
+    configuration for NetworkManager at the target
+- 4.3.77
+
+-------------------------------------------------------------------
 Mon Sep 27 09:12:23 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when the interfaces table contains a not configured

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.76
+Version:        4.3.77
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/cfa/nm_connection.rb
+++ b/src/lib/cfa/nm_connection.rb
@@ -70,9 +70,7 @@ module CFA
     # @param path [String] File path
     # @param file_handler [.read, .write] Object to read/write the file.
     def initialize(path, file_handler: nil)
-      # FIXME: The Networkmanager lense writes the values surrounded by double
-      # quotes which is not valid
-      super(AugeasParser.new("Desktop.lns"), path, file_handler: file_handler)
+      super(AugeasParser.new("NetworkManager.lns"), path, file_handler: file_handler)
     end
 
     # Returns the augeas tree for the given section


### PR DESCRIPTION
## Problem

The use of NetworkManager lense was skip because of an error in the lense but as @mchf already provided a fix we should use it in **SLE-15-SP3** instead of the Desktop one as it has other problems. (Already fixed in TW by #1230)

- https://trello.com/c/N782sR6m/2617-osdistribution-p5-1187512-yast-fails-to-convert-wi-fi-connections-to-ones-that-works-in-networkmanager
- https://bugzilla.suse.com/show_bug.cgi?id=1187512

## Solution

Backport #1230 once the SR with the patch for augeas has been already created (https://build.suse.de/request/show/255648)