### PR TITLE
Do not crash when checking if a virtual interface is connected

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,7 +2,7 @@
 Wed Nov  3 22:19:45 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when checking if a virtual interface is connected
-  (bsc#1192270).
+  (bsc#1192183, bsc#1192270).
 - 4.2.106
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov  3 22:19:45 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not crash when checking if a virtual interface is connected
+  (bsc#1192270).
+- 4.2.106
+
+-------------------------------------------------------------------
 Mon Sep 27 09:12:23 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when the interfaces table contains a not configured

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.105
+Version:        4.2.106
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -75,7 +75,7 @@ module Y2Network
       @renaming_mechanism = :none
     end
 
-    # Whether the interface is connected or not based con hardware information
+    # Whether the interface is connected or not based on hardware information
     #
     # @see Hwinfo#connected?
     # @return [Boolean]

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -35,7 +35,6 @@ module Y2Network
   # @see Y2Network::PhysicalInterface
   # @see Y2Network::VirtualInterface
   class Interface
-    extend Forwardable
     include Yast::Logger
 
     # @return [String] Device name ('eth0', 'wlan0', etc.)
@@ -50,8 +49,6 @@ module Y2Network
     attr_accessor :renaming_mechanism
     # @return [String,nil]
     attr_reader :old_name
-
-    def_delegators :hardware, :drivers, :connected?
 
     class << self
       # Builds an interface based on a connection
@@ -76,6 +73,22 @@ module Y2Network
       @type = type
       # TODO: move renaming logic to physical interfaces only
       @renaming_mechanism = :none
+    end
+
+    # Whether the interface is connected or not based con hardware information
+    #
+    # @see Hwinfo#connected?
+    # @return [Boolean]
+    def connected?
+      !!hardware&.connected?
+    end
+
+    # Returns the list of kernel modules
+    #
+    # @return [Array<Driver>]
+    # @see Hwinfo#drivers
+    def drivers
+      hardware&.drivers || []
     end
 
     # Determines whether two interfaces are equal

--- a/test/y2network/interface_test.rb
+++ b/test/y2network/interface_test.rb
@@ -92,7 +92,7 @@ describe Y2Network::Interface do
     end
   end
 
-  describe "#modules_names" do
+  describe "#drivers" do
     let(:driver) { instance_double(Y2Network::Driver) }
     let(:hwinfo) { instance_double(Y2Network::Hwinfo, drivers: [driver]) }
 
@@ -102,6 +102,39 @@ describe Y2Network::Interface do
 
     it "returns modules names from hardware information" do
       expect(interface.drivers).to eq([driver])
+    end
+  end
+
+  describe "#connected?" do
+    let(:hwinfo) { instance_double(Y2Network::Hwinfo, connected?: connected) }
+    let(:connected) { true }
+
+    before do
+      allow(interface).to receive(:hardware).and_return(hwinfo)
+    end
+
+    context "when the interface has hardware information" do
+      context "and the interface is connected" do
+        it "returns true" do
+          expect(interface.connected?).to eq(true)
+        end
+      end
+
+      context "and the interface is not connected" do
+        let(:connected) { false }
+
+        it "returns false" do
+          expect(interface.connected?).to eq(false)
+        end
+      end
+    end
+
+    context "when the interface does not have hardware information" do
+      let(:hwinfo) { nil }
+
+      it "returns false" do
+        expect(interface.connected?).to eq(false)
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

When a configured interface does not have hardware information the connected? method crashes miserably.

- https://bugzilla.suse.com/show_bug.cgi?id=1192270