### PR TITLE
Use the interface name as the description

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu Nov  4 15:02:24 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- AutoYaST
+  - When the interface section contains the deprecated device
+    element and also the name element, then use the last one as
+    the interface description. (bsc#1192270)
+  - Add the description element to the interface section
+- 4.2.107
+
+-------------------------------------------------------------------
 Wed Nov  3 22:19:45 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not crash when checking if a virtual interface is connected

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,10 +2,10 @@
 Thu Nov  4 15:02:24 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - AutoYaST
-  - When the interface section contains the deprecated device
-    element and also the name element, then use the last one as
-    the interface description. (bsc#1192270)
-  - Add the description element to the interface section
+  - When the interface section contains the "device" (deprecated)
+    and "name" elements then use the "device" as the "name" and the
+    "name" as the "description". (bsc#1192270)
+  - Add the "description" element to the interface section.
 - 4.2.107
 
 -------------------------------------------------------------------

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.106
+Version:        4.2.107
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -42,6 +42,7 @@ interface =
   element (interface | listentry) {
     element device { text }? &	#overloaded
     element name { text }? &
+    element description { text }? &
 
     bootproto? &
     startmode? &

--- a/src/lib/y2network/autoinst/interfaces_reader.rb
+++ b/src/lib/y2network/autoinst/interfaces_reader.rb
@@ -95,6 +95,8 @@ module Y2Network
         end
 
         config.interface = config.name # in autoyast name and interface is same
+        description = interface_section.description.to_s
+        config.description = interface_section.description if !description.empty?
 
         config.ip = load_ipaddr(interface_section)
 

--- a/src/lib/y2network/autoinst_profile/interface_section.rb
+++ b/src/lib/y2network/autoinst_profile/interface_section.rb
@@ -45,6 +45,7 @@ module Y2Network
           { name: :broadcast },
           { name: :device },
           { name: :name }, # has precedence over device
+          { name: :description },
           { name: :ipaddr },
           { name: :remote_ipaddr },
           { name: :netmask },
@@ -260,9 +261,16 @@ module Y2Network
         hash = rename_key(hash, "bridge_forwarddelay", "bridge_forward_delay")
         super(hash)
 
-        if hash["aliases"]
-          self.aliases = hash["aliases"].values.map { |h| AliasSection.new_from_hashes(h) }
+        # When the name and the device attributes are given then the pre network-ng behavior will be
+        # adopted using the name as the description and the device as the name (bsc#1192270).
+        unless (hash.fetch("name", "").empty? || hash.fetch("device", "").empty?)
+          self.name = hash["device"]
+          self.description = hash["name"]
         end
+
+        return unless hash["aliases"].is_a?(Hash)
+
+        self.aliases = hash["aliases"].values.map { |h| AliasSection.new_from_hashes(h) }
       end
 
       # Method used by {.new_from_network} to populate the attributes when cloning a network

--- a/test/y2network/autoinst/interfaces_reader_test.rb
+++ b/test/y2network/autoinst/interfaces_reader_test.rb
@@ -46,6 +46,7 @@ describe Y2Network::Autoinst::InterfacesReader do
     {
       "bootproto"             => "dhcp",
       "name"                  => "eth0",
+      "description"           => "Ethernet Card 0",
       "startmode"             => "boot",
       "dhclient_set_hostname" => "yes",
       "aliases"               => {
@@ -79,6 +80,7 @@ describe Y2Network::Autoinst::InterfacesReader do
     it "assign properly all values in profile" do
       eth0_config = subject.config.by_name("eth0")
       expect(eth0_config.startmode.name).to eq("auto")
+      expect(eth0_config.description).to eq("Ethernet Card 0")
       expect(eth0_config.startmode.alias_name).to eq("boot")
       expect(eth0_config.bootproto).to eq Y2Network::BootProtocol.from_name("dhcp")
       expect(eth0_config.ip_aliases.size).to eq 3

--- a/test/y2network/autoinst_profile/interface_section_test.rb
+++ b/test/y2network/autoinst_profile/interface_section_test.rb
@@ -85,6 +85,17 @@ describe Y2Network::AutoinstProfile::InterfaceSection do
       end
     end
 
+    context "when the device and name are given" do
+      let(:descr) { "Virtual Interface Card 4" }
+
+      it "sets the device as the name and the name as the description" do
+        hash["name"] = descr
+        section = described_class.new_from_hashes(hash)
+        expect(section.name).to eq("eth0")
+        expect(section.description). to eq(descr)
+      end
+    end
+
     context "when bridge_forwarddelay and bridge_forward_delay are both set" do
       let(:hash) do
         {


### PR DESCRIPTION
## Problem

With network-ng the interface sections' device element was marked as
deprecated and the use of name has precedence over it.

But when both elements are given the profile is probably an old one.

- https://bugzilla.suse.com/show_bug.cgi?id=1192270

## Solution

In that case the name will be used as the description (bsc#1192270).