### PR TITLE
Remove call to #friendly_name

### DIFF
--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2019-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -100,7 +100,7 @@ module Y2Network
 
       # Constructs device description for inactive s390 devices
       def device_item(device)
-        [device.id, friendly_name(device), _("Not activated"), device.id, ""]
+        [device.id, description_for(device.interface), _("Not activated"), device.id, ""]
       end
 
       # Generic device description handler


### PR DESCRIPTION
## Problem

Method `InterfacesTable#friendly_name` was removed in favor of `#description_for`, but the old method is still called.

* https://bugzilla.suse.com/show_bug.cgi?id=1192560
* https://github.com/yast/yast-network/pull/1256/files#diff-5908fa6c7d694beecc1ac5e615492f40d209498c812b41d5b844376d7e473f44L150

## Solution

Call to new method `InstancesTable#description_for`.
