### PR TITLE
Fix description for s390 Group Device description

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 10 21:41:54 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixed interfaces table description for s390 Group devices
+  (bsc#1192560).
+- 4.2.109
+
+-------------------------------------------------------------------
 Wed Nov 10 16:45:32 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Replace calls to dropped method InterfacesTable#friendly_name

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.108
+Version:        4.2.109
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -100,7 +100,7 @@ module Y2Network
 
       # Constructs device description for inactive s390 devices
       def device_item(device)
-        [device.id, description_for(device.interface), _("Not activated"), device.id, ""]
+        [device.id, description_for(device), _("Not activated"), device.id, ""]
       end
 
       # Generic device description handler
@@ -148,7 +148,7 @@ module Y2Network
       # @param conn [ConnectionConfig::Base, nil] Connection configuration
       # @return [String] Connection description if given or the friendly name for the interface (
       #   description or name) if not
-      def description_for(interface, conn)
+      def description_for(interface, conn = nil)
         return conn.description unless conn&.description.to_s.empty?
 
         hwinfo = interface.hardware

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -142,17 +142,17 @@ module Y2Network
         summary.new(value, config).text
       end
 
-      # Returns the connection description if given or the interface friendly name if not
+      # Returns the connection description if given or the device friendly name if not
       #
-      # @param interface [Interface] Network interface
+      # @param device [Interface, S390GroupDevice] Network device
       # @param conn [ConnectionConfig::Base, nil] Connection configuration
       # @return [String] Connection description if given or the friendly name for the interface (
       #   description or name) if not
-      def description_for(interface, conn = nil)
+      def description_for(device, conn = nil)
         return conn.description unless conn&.description.to_s.empty?
 
-        hwinfo = interface.hardware
-        (hwinfo&.present?) ? hwinfo.description : interface.name
+        hwinfo = device.hardware
+        (hwinfo&.present?) ? hwinfo.description : device.name
       end
 
       def summary_class_name

--- a/test/y2network/widgets/interfaces_table_test.rb
+++ b/test/y2network/widgets/interfaces_table_test.rb
@@ -41,6 +41,7 @@ describe Y2Network::Widgets::InterfacesTable do
     instance_double(Y2Network::Hwinfo, link: link, mac: mac, busid: busid,
       exists?: exists?, present?: true, description: "Cool device", name: "Cool device")
   end
+
   let(:mac) { "01:23:45:67:89:ab" }
   let(:busid) { "0000:04:00.0" }
   let(:link) { false }
@@ -53,9 +54,24 @@ describe Y2Network::Widgets::InterfacesTable do
     Y2Network::ConnectionConfig::Bridge.new.tap { |c| c.name = "br0" }
   end
 
+  let(:qeth_0700) do
+    instance_double(Y2Network::S390GroupDevice, type: "qeth", hardware: hwinfo_0700,
+      id: "0.0.0700:0.0.0701:0.0.0702", online?: false)
+  end
+
+  let(:hwinfo_0700) do
+    instance_double(Y2Network::Hwinfo, present?:    true,
+                                       description: "OSA Express Network card (0.0.0700)")
+  end
+
+  let(:s390_devices) do
+    Y2Network::S390GroupDevicesCollection.new([qeth_0700])
+  end
+
   before do
     allow(Yast::Lan).to receive(:yast_config)
-      .and_return(double(interfaces: interfaces, connections: connections, s390_devices: []))
+      .and_return(double(interfaces: interfaces, connections: connections, s390_devices:
+                  s390_devices))
     allow(Yast::UI).to receive(:QueryWidget).and_return([])
     allow(subject).to receive(:value).and_return("eth0")
   end
@@ -87,10 +103,9 @@ describe Y2Network::Widgets::InterfacesTable do
 
       it "shows the hwinfo interface description if present or the interface name if not" do
         expect(subject.items).to include(a_collection_including(/Cool device/, /eth0/),
-          a_collection_including(/br0/))
+          a_collection_including(/br0/), a_collection_including(/OSA Express Network card/))
       end
     end
-
   end
 
   describe "#handle" do


### PR DESCRIPTION
## Problem

The `description_for` method added by https://github.com/yast/yast-network/pull/1268 expect two parameters and the first one is an `Interface` or a offline `S390 Group Device`.

## Solution

Fixed the issue and also the documentation, already tested in a s390 machine.

## Screenshot

![S390LanOverview](https://user-images.githubusercontent.com/7056681/141197932-590a1cf4-3f14-41a4-bea6-8c1e9bd91786.png)

