### PR TITLE
None slaves work in cli animore

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb  1 06:28:14 UTC 2022 - Michal Filka <mfilka@suse.com>
+
+- jsc#SLE-22015
+  - renamed CLI options to conform inclusive naming
+  - the change is backward incompatible
+- 4.4.36
+
+-------------------------------------------------------------------
 Wed Jan 26 08:59:57 UTC 2022 - Michal Filka <mfilka@suse.com>
 
 - jsc#SLE-22015

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,7 +2,8 @@
 Tue Feb  1 06:28:14 UTC 2022 - Michal Filka <mfilka@suse.com>
 
 - jsc#SLE-22015
-  - renamed CLI options to conform inclusive naming
+  - renamed slaves CLI option to conform to inclusive naming:
+    yast lan add name=bond0 bond_ports=eth0 eth1 bootproto=dhcp
   - the change is backward incompatible
 - 4.4.36
 

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -4,7 +4,7 @@ Tue Feb  1 06:28:14 UTC 2022 - Michal Filka <mfilka@suse.com>
 - jsc#SLE-22015
   - renamed slaves CLI option to conform to inclusive naming:
     yast lan add name=bond0 bond_ports=eth0 eth1 bootproto=dhcp
-  - the change is backward incompatible
+  - the "slaves=" option stays for backward compatibility
 - 4.4.36
 
 -------------------------------------------------------------------

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.35
+Version:        4.4.36
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/clients/lan.rb
+++ b/src/clients/lan.rb
@@ -90,7 +90,7 @@ module Yast
             "example" => [
               "yast lan add name=vlan50 ethdevice=eth0 bootproto=dhcp",
               "yast lan add name=br0 bridge_ports=eth0 eth1 bootproot=dhcp",
-              "yast lan add name=bond0 slaves=eth0 eth1 bootproto=dhcp",
+              "yast lan add name=bond0 bond_ports=eth0 eth1 bootproto=dhcp",
               "yast lan add name=dummy0 type=dummy ip=10.0.0.100"
             ]
           },
@@ -155,7 +155,7 @@ module Yast
             "help" => _("Prefix length"),
             "type" => "string"
           },
-          "slaves"       => {
+          "bond_ports"   => {
             # Commandline option help
             "help" => _("Bond Ports"),
             "type" => "string"
@@ -185,7 +185,7 @@ module Yast
             "ip",
             "netmask",
             "prefix",
-            "slaves",
+            "bond_ports",
             "type",
             "ethdevice",
             "bridge_ports"

--- a/src/clients/lan.rb
+++ b/src/clients/lan.rb
@@ -160,6 +160,11 @@ module Yast
             "help" => _("Bond Ports"),
             "type" => "string"
           },
+          "slaves"   => {
+            # Commandline option help
+            "help" => _("Bond Ports (obsolete, use bond_ports instead)"),
+            "type" => "string"
+          },
           "ethdevice"    => {
             # Commandline option help
             "help" => _("Ethernet Device for VLAN"),
@@ -186,6 +191,7 @@ module Yast
             "netmask",
             "prefix",
             "bond_ports",
+            "slaves",
             "type",
             "ethdevice",
             "bridge_ports"

--- a/src/clients/lan.rb
+++ b/src/clients/lan.rb
@@ -162,6 +162,9 @@ module Yast
           },
           "slaves"       => {
             # Commandline option help
+            # TRANSLATORS: slaves is old option for configuring bond ports. User
+            # should be notified that the option is obsolete and bond_ports should
+            # be used instead
             "help" => _("Bond Ports (obsolete, use bond_ports instead)"),
             "type" => "string"
           },

--- a/src/clients/lan.rb
+++ b/src/clients/lan.rb
@@ -160,7 +160,7 @@ module Yast
             "help" => _("Bond Ports"),
             "type" => "string"
           },
-          "slaves"   => {
+          "slaves"       => {
             # Commandline option help
             "help" => _("Bond Ports (obsolete, use bond_ports instead)"),
             "type" => "string"

--- a/src/include/network/lan/cmdline.rb
+++ b/src/include/network/lan/cmdline.rb
@@ -172,7 +172,7 @@ module Yast
     # @param options [Hash{String => String}] action options
     # @return [String] infered device type; an empty string if not infered
     def infered_type(options)
-      return "bond" if options.include? "slaves"
+      return "bond" if options.include? "bond_ports"
       return "vlan" if options.include? "ethdevice"
       return "br"   if options.include? "bridge_ports"
 
@@ -206,7 +206,7 @@ module Yast
       case builder.type.short_name
       when "bond"
         # change only if user specify it
-        builder.ports = options["slaves"].split(" ") if options["slaves"]
+        builder.ports = options["bond_ports"].split(" ") if options["bond_ports"]
       when "vlan"
         # change only if user specify it
         builder.etherdevice = options["ethdevice"] if options["ethdevice"]

--- a/src/include/network/lan/cmdline.rb
+++ b/src/include/network/lan/cmdline.rb
@@ -107,6 +107,12 @@ module Yast
     # Handler for action "add"
     # @param [Hash{String => String}] options action options
     def AddHandler(options)
+      # slaves option is marked as obsolete, bond_ports should be used instead.
+      # If both options are present, new one (bond_ports) wins.
+      if !options.key?("bond_ports") && options.key?("slaves")
+        options["bond_ports"] = options.delete("slaves")
+      end
+
       type = options.fetch("type", infered_type(options))
       if type.empty?
         Report.Error(_("The device type is mandatory."))

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -316,7 +316,7 @@ describe Yast::NetworkAutoconfiguration do
       end
 
       context "and the routing config was modified" do
-        it "moves the routes from the enslaved interface to the bridge" do
+        it "moves the routes from the bridge port to the bridge" do
           expect { instance.configure_virtuals }.to change { route.interface }.from(eth5).to(br0)
         end
 

--- a/test/y2network/widgets/bridge_ports_test.rb
+++ b/test/y2network/widgets/bridge_ports_test.rb
@@ -41,7 +41,7 @@ describe Y2Network::Widgets::BridgePorts do
       end
     end
 
-    context "when some of the enslaved interfaces are configured" do
+    context "when some of the bridged interfaces are configured" do
       it "warns the user and request confirmation to continue" do
         allow(builder).to receive(:require_adaptation?).and_return(true)
 


### PR DESCRIPTION
Follow up of https://github.com/yast/yast-network/pull/1277

## Problem ##

CLI used naming according to old standards for bonding.

## Solution ##

- options were renamed in a same way like in GUI
- the change is backward incompatible. CLI is not much used (according to fact that some bugs were present in CLI for years), so investing into backward compatibility sounds useless. (Other option is coexistence of bond_ports and slaves options and marking the later as "deprecated" which is going to be removed ... if someone remembers it in the future ;-))