### PR TITLE
Bring back overview help (bsc#1195155)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb  4 15:14:10 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixed interfaces overview help (bsc#1195155)
+- 4.4.37
+
+-------------------------------------------------------------------
 Tue Feb  1 06:28:14 UTC 2022 - Michal Filka <mfilka@suse.com>
 
 - jsc#SLE-22015

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.36
+Version:        4.4.37
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/widgets/add_interface.rb
+++ b/src/lib/y2network/widgets/add_interface.rb
@@ -40,9 +40,10 @@ module Y2Network
       end
 
       def help
+        # TRANSLATORS: Help for 'Add' interface configuration button
         _(
-           "<p><b><big>Adding a Network Card:</big></b><br>\nPress " \
-           "<b>Add</b> to configure a new network card manually.</p>\n"
+          "<p><b><big>Adding a Network Card:</big></b><br>\nPress " \
+          "<b>Add</b> to configure a new network card manually.</p>\n"
         )
       end
     end

--- a/src/lib/y2network/widgets/add_interface.rb
+++ b/src/lib/y2network/widgets/add_interface.rb
@@ -38,6 +38,13 @@ module Y2Network
         Y2Network::Sequences::Interface.new.add
         :redraw
       end
+
+      def help
+        _(
+           "<p><b><big>Adding a Network Card:</big></b><br>\nPress " \
+           "<b>Add</b> to configure a new network card manually.</p>\n"
+        )
+      end
     end
   end
 end

--- a/src/lib/y2network/widgets/delete_interface.rb
+++ b/src/lib/y2network/widgets/delete_interface.rb
@@ -76,6 +76,14 @@ module Y2Network
         :redraw
       end
 
+      def help
+        _(
+          "<p><b><big>Deletingg:</big></b><br>\n" \
+          "Choose a network card to change.\n" \
+         "Then press <b>Delete</b>.</p>\n"
+        )
+      end
+
     private
 
       # @return [Array]

--- a/src/lib/y2network/widgets/delete_interface.rb
+++ b/src/lib/y2network/widgets/delete_interface.rb
@@ -77,9 +77,10 @@ module Y2Network
       end
 
       def help
+        # TRANSLATORS: Help for 'Delete' interface configuration button.
         _(
-          "<p><b><big>Deletingg:</big></b><br>\n" \
-          "Choose a network card to change.\n" \
+          "<p><b><big>Deleting:</big></b><br>\n" \
+          "Choose a network card to remove.\n" \
          "Then press <b>Delete</b>.</p>\n"
         )
       end

--- a/src/lib/y2network/widgets/edit_interface.rb
+++ b/src/lib/y2network/widgets/edit_interface.rb
@@ -68,9 +68,10 @@ module Y2Network
       end
 
       def help
+        # TRANSLATORS: Help for 'Edit' interface configuration button
         _(
           "<p><b><big>Configuring:</big></b><br>\n" \
-          "Choose a network card to remove.\n" \
+          "Choose a network card to change.\n" \
          "Then press <b>Edit</b>.</p>\n"
         )
       end

--- a/src/lib/y2network/widgets/edit_interface.rb
+++ b/src/lib/y2network/widgets/edit_interface.rb
@@ -66,6 +66,14 @@ module Y2Network
       def selected_interface(config)
         config.interfaces.by_name(@table.value) || config.s390_devices.by_id(@table.value)
       end
+
+      def help
+        _(
+          "<p><b><big>Configuring:</big></b><br>\n" \
+          "Choose a network card to remove.\n" \
+         "Then press <b>Edit</b>.</p>\n"
+        )
+      end
     end
   end
 end

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -82,6 +82,14 @@ module Y2Network
         handle
       end
 
+      def help
+        _(
+          "<p><b><big>Network Card Overview</big></b><br>\n" \
+           "Obtain an overview of installed network cards. Additionally,\n" \
+           "edit their configuration.<br></p>\n"
+        )
+      end
+
     private
 
       def note(interface, conn)

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -84,9 +84,8 @@ module Y2Network
 
       def help
         _(
-          "<p><b><big>Network Card Overview</big></b><br>\n" \
-           "Obtain an overview of installed network cards. Additionally,\n" \
-           "edit their configuration.<br></p>\n"
+          "<p><b><big>Overview</big></b><br>\n" \
+           "Obtain an overview of the network interfaces configuration.</p>\n"
         )
       end
 


### PR DESCRIPTION
## Problem

Apparently the help text for the **Overview** tab was removed when network-ng and the new widgets were introduced (see https://github.com/yast/yast-network/commit/9312e52420d993272badb4de41f91ed78cdb33ef)

The removed help was:

![Previous help](https://user-images.githubusercontent.com/7056681/152506258-7db5239e-740d-4336-821c-7c68615596b8.png)

- https://bugzilla.suse.com/show_bug.cgi?id=1195155

## Solution

Added help per widget

![HelpPerWidget](https://user-images.githubusercontent.com/7056681/152558741-60c2f130-8a30-46b0-8285-541cb667483b.png)


