### PR TITLE
No run the lan client if there is any active configuration

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,8 +2,8 @@
 Thu Feb 10 18:01:05 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Related to (bsc#1194911)
-- During installation, skip to run the network configuration dialog
-  also when the network configuration is done through iBFT.
+  - During installation skip the network configuration dialog when
+    network is configured with iBFT.
 4.4.39
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb 10 18:01:05 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Related to (bsc#1194911)
+- During installation, skip to run the network configuration dialog
+  also when the network configuration is done through iBFT.
+4.4.39
+
+-------------------------------------------------------------------
 Wed Feb  9 12:14:50 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - During installation, do not configure DHCP if there is some

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.38
+Version:        4.4.39
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/clients/inst_lan.rb
+++ b/src/lib/network/clients/inst_lan.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "network/network_autoconfiguration"
 
 Yast.import "UI"
 Yast.import "Lan"
@@ -99,9 +100,7 @@ module Yast
     # @return [Boolean] true when there is some connection present in yast
     #   config; false otherwise
     def connections_configured?
-      # Ensure we read the current network config
-      Lan.Read(:cache)
-      !(Lan.yast_config&.connections || []).empty?
+      NetworkAutoconfiguration.instance.any_iface_active?
     end
 
     # It returns whether the network has been configured or not. It returns


### PR DESCRIPTION
## Problem 

With the fix introduced in #1282 **YaST** does not create any configuration in case there are already configured by iBFT but then the **lan** client is run because there is no ifcfg file present in the system something that in case of **iBFT** configuration should be skipped too.

![LanDialogNoConfig](https://user-images.githubusercontent.com/7056681/153469353-90fa1875-4186-4d3a-a2b7-da018ac1740c.png)

- https://trello.com/c/aEoGu9LX/2825-1-sles15-sp4-p1-1194911-yast2-must-not-create-configurations-for-ibft-interfaces
- https://bugzilla.suse.com/show_bug.cgi?id=1194911


## Solution

Use the same way of detecting any configuration for the setup_dhcp and inst_lan client.