### PR TITLE
Fixed active device detection (bsc#1196276)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 22 11:34:20 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixed active configuration detection (bsc#1196276, bsc#1194911)
+- 4.4.40
+
+-------------------------------------------------------------------
 Thu Feb 10 18:01:05 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Related to (bsc#1194911)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.39
+Version:        4.4.40
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -49,7 +49,7 @@ module Yast
     def any_iface_active?
       Yast::Lan.Read(:cache)
       config.interfaces.any? do |interface|
-        return false unless active_config?(interface.name)
+        next false unless active_config?(interface.name)
 
         config.connections.by_name(interface.name) || ibft_interfaces.include?(interface.name)
       end

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -87,17 +87,20 @@ describe Yast::NetworkAutoconfiguration do
   describe "#any_iface_active?" do
     let(:active) { false }
     let(:ibft_interfaces) { [] }
+    let(:eth1) { Y2Network::Interface.new("eth1") }
+    let(:interfaces) { Y2Network::InterfacesCollection.new([eth1, eth0]) }
 
     before do
+      allow(instance).to receive(:active_config?).with("eth1").and_return(false)
       allow(instance).to receive(:active_config?).with("eth0").and_return(active)
       allow(instance).to receive(:ibft_interfaces).and_return(ibft_interfaces)
     end
 
-    it "returns false if the interface state is not UP" do
+    it "returns false if there is no interface UP" do
       expect(instance.any_iface_active?).to be false
     end
 
-    context "when the interface state is UP" do
+    context "when at least one interface is UP" do
       let(:active) { true }
 
       context "and the interface is configured through iBFT" do


### PR DESCRIPTION
The problem was introduced by https://github.com/yast/yast-network/pull/1282/files#diff-5316412e8bda05f275f2710e425296ad554b326f59d3d320da81b3bdbbdbd56cR52

- https://bugzilla.suse.com/show_bug.cgi?id=1196276

Fixed loop for active device detection which should go next instead of return false.
