### PR TITLE
Do not consider iBFT configuration for proposing DHCP setup

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb 24 11:56:41 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Related to bsc#1194911:
+  - Skip iBFT interfaces as DHCP candidates but configure DHCP if 
+    there is no active and ifcfg file configured interface
+- 4.4.41
+
+-------------------------------------------------------------------
 Tue Feb 22 11:34:20 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixed active configuration detection (bsc#1196276, bsc#1194911)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.40
+Version:        4.4.41
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/clients/inst_lan.rb
+++ b/src/lib/network/clients/inst_lan.rb
@@ -94,13 +94,13 @@ module Yast
       ret
     end
 
-    # Convenience method that checks whether there is some connection
-    # configuration present in the system
+    # Convenience method that checks whether there is some interface active and configured by iBFT
+    # or by a ifcfg file.
     #
-    # @return [Boolean] true when there is some connection present in yast
-    #   config; false otherwise
+    # @return [Boolean] true when there is some interface configured by iBFT or there is some
+    #   connection present in yast config; false otherwise
     def connections_configured?
-      NetworkAutoconfiguration.instance.any_iface_active?
+      NetworkAutoconfiguration.instance.network_configured?
     end
 
     # It returns whether the network has been configured or not. It returns

--- a/src/lib/network/clients/inst_lan.rb
+++ b/src/lib/network/clients/inst_lan.rb
@@ -100,7 +100,7 @@ module Yast
     # @return [Boolean] true when there is some interface configured by iBFT or there is some
     #   connection present in yast config; false otherwise
     def connections_configured?
-      NetworkAutoconfiguration.instance.network_configured?
+      NetworkAutoconfiguration.instance.any_iface_active?(ibft_included: true)
     end
 
     # It returns whether the network has been configured or not. It returns

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -47,25 +47,14 @@ module Yast
     # system
     #
     # returns [Boolean] true when at least one interface is active
-    def any_iface_active?
-      Yast::Lan.Read(:cache)
+    def any_iface_active?(ibft_included: false)
+      Lan::Read(:cache)
+
       config.interfaces.any? do |interface|
         next false unless active_config?(interface.name)
+        return true if ibft_included && ibft_interfaces.include?(interface.name)
 
         config.connections.by_name(interface.name)
-      end
-    end
-
-    # Checks if any of available interfaces is active and configured by iBFT or with a connection
-    # file present in the system
-    #
-    # returns [Boolean] true when at least one interface is active and configured
-    def network_configured?
-      Yast::Lan.Read(:cache)
-      config.interfaces.any? do |interface|
-        next false unless active_config?(interface.name)
-
-        config.connections.by_name(interface.name) || ibft_interfaces.include?(interface.name)
       end
     end
 

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -43,10 +43,24 @@ module Yast
       Yast.include self, "network/routines.rb" # TODO: needed only for phy_connected
     end
 
-    # Checks if any of available interfaces is configured and active
+    # Checks if any of available interfaces is active and with a connection file present in the
+    # system
     #
     # returns [Boolean] true when at least one interface is active
     def any_iface_active?
+      Yast::Lan.Read(:cache)
+      config.interfaces.any? do |interface|
+        next false unless active_config?(interface.name)
+
+        config.connections.by_name(interface.name)
+      end
+    end
+
+    # Checks if any of available interfaces is active and configured by iBFT or with a connection
+    # file present in the system
+    #
+    # returns [Boolean] true when at least one interface is active and configured
+    def network_configured?
       Yast::Lan.Read(:cache)
       config.interfaces.any? do |interface|
         next false unless active_config?(interface.name)

--- a/test/inst_lan_test.rb
+++ b/test/inst_lan_test.rb
@@ -96,7 +96,7 @@ describe Yast::InstLanClient do
       context "and there is some active network configuration" do
         it "does not run the network configuration sequence" do
           expect(Yast::NetworkAutoconfiguration.instance)
-            .to receive(:any_iface_active?).and_return(true)
+            .to receive(:network_configured?).and_return(true)
           expect(subject).to_not receive(:LanSequence)
 
           subject.main
@@ -107,7 +107,7 @@ describe Yast::InstLanClient do
       context "and the network is unconfigured" do
         it "runs the network configuration sequence" do
           expect(Yast::NetworkAutoconfiguration.instance)
-            .to receive(:any_iface_active?).and_return(false)
+            .to receive(:network_configured?).and_return(false)
 
           expect(subject).to receive(:LanSequence)
           subject.main

--- a/test/inst_lan_test.rb
+++ b/test/inst_lan_test.rb
@@ -87,6 +87,7 @@ describe Yast::InstLanClient do
     end
 
     context "when the NetworkService is wicked" do
+
       it "reads the current network config" do
         expect(Yast::Lan).to receive(:Read).with(:cache)
 
@@ -96,7 +97,7 @@ describe Yast::InstLanClient do
       context "and there is some active network configuration" do
         it "does not run the network configuration sequence" do
           expect(Yast::NetworkAutoconfiguration.instance)
-            .to receive(:network_configured?).and_return(true)
+            .to receive(:any_iface_active?).with(ibft_included: true).and_return(true)
           expect(subject).to_not receive(:LanSequence)
 
           subject.main
@@ -107,7 +108,7 @@ describe Yast::InstLanClient do
       context "and the network is unconfigured" do
         it "runs the network configuration sequence" do
           expect(Yast::NetworkAutoconfiguration.instance)
-            .to receive(:network_configured?).and_return(false)
+            .to receive(:any_iface_active?).with(ibft_included: true).and_return(false)
 
           expect(subject).to receive(:LanSequence)
           subject.main

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -103,14 +103,6 @@ describe Yast::NetworkAutoconfiguration do
     context "when at least one interface is UP" do
       let(:active) { true }
 
-      context "and the interface is configured through iBFT" do
-        let(:ibft_interfaces) { [eth0.name] }
-
-        it "returns true" do
-          expect(instance.any_iface_active?).to be true
-        end
-      end
-
       context "and the interface has a configuration file" do
         it "returns true" do
           expect(instance.any_iface_active?).to be true
@@ -122,6 +114,49 @@ describe Yast::NetworkAutoconfiguration do
 
         it "returns false" do
           expect(instance.any_iface_active?).to be false
+        end
+      end
+    end
+  end
+
+  describe "#network_configured?" do
+    let(:active) { false }
+    let(:ibft_interfaces) { [] }
+    let(:eth1) { Y2Network::Interface.new("eth1") }
+    let(:interfaces) { Y2Network::InterfacesCollection.new([eth1, eth0]) }
+
+    before do
+      allow(instance).to receive(:active_config?).with("eth1").and_return(false)
+      allow(instance).to receive(:active_config?).with("eth0").and_return(active)
+      allow(instance).to receive(:ibft_interfaces).and_return(ibft_interfaces)
+    end
+
+    it "returns false if there is no interface UP" do
+      expect(instance.network_configured?).to be false
+    end
+
+    context "when at least one interface is UP" do
+      let(:active) { true }
+
+      context "and the interface is configured through iBFT" do
+        let(:ibft_interfaces) { [eth0.name] }
+
+        it "returns true" do
+          expect(instance.network_configured?).to be true
+        end
+      end
+
+      context "and the interface has a configuration file" do
+        it "returns true" do
+          expect(instance.network_configured?).to be true
+        end
+      end
+
+      context "but the interface is not configured" do
+        let(:connections) { Y2Network::ConnectionConfigsCollection.new([]) }
+
+        it "returns false" do
+          expect(instance.network_configured?).to be false
         end
       end
     end

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -109,54 +109,21 @@ describe Yast::NetworkAutoconfiguration do
         end
       end
 
+      context "when ibft_included param is true" do
+        context "and the interface is configured through iBFT" do
+          let(:ibft_interfaces) { [eth0.name] }
+
+          it "returns true" do
+            expect(instance.any_iface_active?(ibft_included: true)).to be true
+          end
+        end
+      end
+
       context "but the interface is not configured" do
         let(:connections) { Y2Network::ConnectionConfigsCollection.new([]) }
 
         it "returns false" do
           expect(instance.any_iface_active?).to be false
-        end
-      end
-    end
-  end
-
-  describe "#network_configured?" do
-    let(:active) { false }
-    let(:ibft_interfaces) { [] }
-    let(:eth1) { Y2Network::Interface.new("eth1") }
-    let(:interfaces) { Y2Network::InterfacesCollection.new([eth1, eth0]) }
-
-    before do
-      allow(instance).to receive(:active_config?).with("eth1").and_return(false)
-      allow(instance).to receive(:active_config?).with("eth0").and_return(active)
-      allow(instance).to receive(:ibft_interfaces).and_return(ibft_interfaces)
-    end
-
-    it "returns false if there is no interface UP" do
-      expect(instance.network_configured?).to be false
-    end
-
-    context "when at least one interface is UP" do
-      let(:active) { true }
-
-      context "and the interface is configured through iBFT" do
-        let(:ibft_interfaces) { [eth0.name] }
-
-        it "returns true" do
-          expect(instance.network_configured?).to be true
-        end
-      end
-
-      context "and the interface has a configuration file" do
-        it "returns true" do
-          expect(instance.network_configured?).to be true
-        end
-      end
-
-      context "but the interface is not configured" do
-        let(:connections) { Y2Network::ConnectionConfigsCollection.new([]) }
-
-        it "returns false" do
-          expect(instance.network_configured?).to be false
         end
       end
     end


### PR DESCRIPTION
## Problem

1. In #1282 we skipped **DHCP setup** completely when there was some active interface configured by **iBFT**. 
 
    This change is probably too much at this moment and we should skip only the **iBFT** interfaces as candidates to **setup DHCP** but continue configuring any not configured interface in case there is no **connection config (ifcfg-file)** present in the system.

2. In #1283 we applied also the **same logic** when deciding if the **network settings** dialog needs to be run or not. 

    This behavior should be maintained as for example in case that all the interfaces present in the system are **iBFT** configured then the dialog will be run when it is not needed. (Like in https://bugzilla.suse.com/show_bug.cgi?id=1194711)

- https://bugzilla.suse.com/show_bug.cgi?id=1194911#1284 


## Solution

1. **DHCP Setup Client**
    - It is skipped if there is some network interface **UP** and configured through a **ifcfg file**.
    - If it is not skipped then try to setup with **DHCP** not configured interfaces **(iBFT configured interfaces are considered as configured).**
2. The **network settings** dialog is only shown if there is no active and configured interface (including iBFT configured interfaces).

## Tests

Tested manually and added unit tests.

## Screenshots

**Scenario with 1 interface configured with iBFT**

| Description | Screenshot |
| --------------- | --------------- |
| iPXE eth0 configured | ![Screenshot_testing_2022-02-24_12:57:13](https://user-images.githubusercontent.com/7056681/155529957-9fe192cb-0ad4-4824-937d-060fe5fe60e9.png) |
| First screen after language selection | ![Screenshot_testing_2022-02-24_12:54:45](https://user-images.githubusercontent.com/7056681/155529969-b098bbfc-b831-467a-b778-aa62030f064b.png) |
| Clicking on Network Configuration | ![Screenshot_testing_2022-02-24_12:55:00](https://user-images.githubusercontent.com/7056681/155529964-538c9b45-05e5-4115-8e20-6a2ae873908e.png) |

**Scenario with 1 interface configured with iBFT and 1 not configured**

| Description | Screenshot |
| --------------- | --------------- |
| iPXE eth0 configured | ![Screenshot_testing_2022-02-24_12:57:13](https://user-images.githubusercontent.com/7056681/155529957-9fe192cb-0ad4-4824-937d-060fe5fe60e9.png) |
| Before yast.ssh is called | ![Screenshot_testing_2022-02-24_13:05:47](https://user-images.githubusercontent.com/7056681/155530468-7149f2b4-6e03-495c-a90e-1b0d9f93c445.png) |
| After yast.ssh is called | ![Screenshot_testing_2022-02-24_13:07:35](https://user-images.githubusercontent.com/7056681/155530467-a8c1ffce-8e80-4772-9305-883c7101c612.png) |
| First screen after language selection | ![Screenshot_testing_2022-02-24_12:54:45](https://user-images.githubusercontent.com/7056681/155529969-b098bbfc-b831-467a-b778-aa62030f064b.png) |
| Clicking on Network Configuration | ![Screenshot_testing_2022-02-24_13:07:44](https://user-images.githubusercontent.com/7056681/155530465-36cffc12-4453-4121-84d0-45a3ddefe2da.png) |

