### PR TITLE
Revert last PR skipping DCHP setup completely in case of iBFT configured

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,8 +1,15 @@
 -------------------------------------------------------------------
+Fri Feb 25 11:54:49 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Revert last change going back to skip DHCP setup completely if
+  the network is already configured through iBFT (bsc#1194911)
+- 4.4.42
+
+-------------------------------------------------------------------
 Thu Feb 24 11:56:41 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Related to bsc#1194911:
-  - Skip iBFT interfaces as DHCP candidates but configure DHCP if 
+  - Skip iBFT interfaces as DHCP candidates but configure DHCP if
     there is no active and ifcfg file configured interface
 - 4.4.41
 

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.41
+Version:        4.4.42
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/clients/inst_lan.rb
+++ b/src/lib/network/clients/inst_lan.rb
@@ -94,13 +94,13 @@ module Yast
       ret
     end
 
-    # Convenience method that checks whether there is some interface active and configured by iBFT
-    # or by a ifcfg file.
+    # Convenience method that checks whether there is some connection
+    # configuration present in the system
     #
-    # @return [Boolean] true when there is some interface configured by iBFT or there is some
-    #   connection present in yast config; false otherwise
+    # @return [Boolean] true when there is some connection present in yast
+    #   config; false otherwise
     def connections_configured?
-      NetworkAutoconfiguration.instance.network_configured?
+      NetworkAutoconfiguration.instance.any_iface_active?
     end
 
     # It returns whether the network has been configured or not. It returns

--- a/src/lib/network/clients/inst_lan.rb
+++ b/src/lib/network/clients/inst_lan.rb
@@ -100,7 +100,7 @@ module Yast
     # @return [Boolean] true when there is some interface configured by iBFT or there is some
     #   connection present in yast config; false otherwise
     def connections_configured?
-      NetworkAutoconfiguration.instance.any_iface_active?(ibft_included: true)
+      NetworkAutoconfiguration.instance.network_configured?
     end
 
     # It returns whether the network has been configured or not. It returns

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -43,24 +43,10 @@ module Yast
       Yast.include self, "network/routines.rb" # TODO: needed only for phy_connected
     end
 
-    # Checks if any of available interfaces is active and with a connection file present in the
-    # system
+    # Checks if any of available interfaces is configured and active
     #
     # returns [Boolean] true when at least one interface is active
     def any_iface_active?
-      Yast::Lan.Read(:cache)
-      config.interfaces.any? do |interface|
-        next false unless active_config?(interface.name)
-
-        config.connections.by_name(interface.name)
-      end
-    end
-
-    # Checks if any of available interfaces is active and configured by iBFT or with a connection
-    # file present in the system
-    #
-    # returns [Boolean] true when at least one interface is active and configured
-    def network_configured?
       Yast::Lan.Read(:cache)
       config.interfaces.any? do |interface|
         next false unless active_config?(interface.name)

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -47,14 +47,25 @@ module Yast
     # system
     #
     # returns [Boolean] true when at least one interface is active
-    def any_iface_active?(ibft_included: false)
-      Lan::Read(:cache)
-
+    def any_iface_active?
+      Yast::Lan.Read(:cache)
       config.interfaces.any? do |interface|
         next false unless active_config?(interface.name)
-        return true if ibft_included && ibft_interfaces.include?(interface.name)
 
         config.connections.by_name(interface.name)
+      end
+    end
+
+    # Checks if any of available interfaces is active and configured by iBFT or with a connection
+    # file present in the system
+    #
+    # returns [Boolean] true when at least one interface is active and configured
+    def network_configured?
+      Yast::Lan.Read(:cache)
+      config.interfaces.any? do |interface|
+        next false unless active_config?(interface.name)
+
+        config.connections.by_name(interface.name) || ibft_interfaces.include?(interface.name)
       end
     end
 

--- a/test/inst_lan_test.rb
+++ b/test/inst_lan_test.rb
@@ -96,7 +96,7 @@ describe Yast::InstLanClient do
       context "and there is some active network configuration" do
         it "does not run the network configuration sequence" do
           expect(Yast::NetworkAutoconfiguration.instance)
-            .to receive(:network_configured?).and_return(true)
+            .to receive(:any_iface_active?).and_return(true)
           expect(subject).to_not receive(:LanSequence)
 
           subject.main
@@ -107,7 +107,7 @@ describe Yast::InstLanClient do
       context "and the network is unconfigured" do
         it "runs the network configuration sequence" do
           expect(Yast::NetworkAutoconfiguration.instance)
-            .to receive(:network_configured?).and_return(false)
+            .to receive(:any_iface_active?).and_return(false)
 
           expect(subject).to receive(:LanSequence)
           subject.main

--- a/test/inst_lan_test.rb
+++ b/test/inst_lan_test.rb
@@ -87,7 +87,6 @@ describe Yast::InstLanClient do
     end
 
     context "when the NetworkService is wicked" do
-
       it "reads the current network config" do
         expect(Yast::Lan).to receive(:Read).with(:cache)
 
@@ -97,7 +96,7 @@ describe Yast::InstLanClient do
       context "and there is some active network configuration" do
         it "does not run the network configuration sequence" do
           expect(Yast::NetworkAutoconfiguration.instance)
-            .to receive(:any_iface_active?).with(ibft_included: true).and_return(true)
+            .to receive(:network_configured?).and_return(true)
           expect(subject).to_not receive(:LanSequence)
 
           subject.main
@@ -108,7 +107,7 @@ describe Yast::InstLanClient do
       context "and the network is unconfigured" do
         it "runs the network configuration sequence" do
           expect(Yast::NetworkAutoconfiguration.instance)
-            .to receive(:any_iface_active?).with(ibft_included: true).and_return(false)
+            .to receive(:network_configured?).and_return(false)
 
           expect(subject).to receive(:LanSequence)
           subject.main

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -109,13 +109,46 @@ describe Yast::NetworkAutoconfiguration do
         end
       end
 
-      context "when ibft_included param is true" do
-        context "and the interface is configured through iBFT" do
-          let(:ibft_interfaces) { [eth0.name] }
+      context "but the interface is not configured" do
+        let(:connections) { Y2Network::ConnectionConfigsCollection.new([]) }
 
-          it "returns true" do
-            expect(instance.any_iface_active?(ibft_included: true)).to be true
-          end
+        it "returns false" do
+          expect(instance.any_iface_active?).to be false
+        end
+      end
+    end
+  end
+
+  describe "#network_configured?" do
+    let(:active) { false }
+    let(:ibft_interfaces) { [] }
+    let(:eth1) { Y2Network::Interface.new("eth1") }
+    let(:interfaces) { Y2Network::InterfacesCollection.new([eth1, eth0]) }
+
+    before do
+      allow(instance).to receive(:active_config?).with("eth1").and_return(false)
+      allow(instance).to receive(:active_config?).with("eth0").and_return(active)
+      allow(instance).to receive(:ibft_interfaces).and_return(ibft_interfaces)
+    end
+
+    it "returns false if there is no interface UP" do
+      expect(instance.network_configured?).to be false
+    end
+
+    context "when at least one interface is UP" do
+      let(:active) { true }
+
+      context "and the interface is configured through iBFT" do
+        let(:ibft_interfaces) { [eth0.name] }
+
+        it "returns true" do
+          expect(instance.network_configured?).to be true
+        end
+      end
+
+      context "and the interface has a configuration file" do
+        it "returns true" do
+          expect(instance.network_configured?).to be true
         end
       end
 
@@ -123,7 +156,7 @@ describe Yast::NetworkAutoconfiguration do
         let(:connections) { Y2Network::ConnectionConfigsCollection.new([]) }
 
         it "returns false" do
-          expect(instance.any_iface_active?).to be false
+          expect(instance.network_configured?).to be false
         end
       end
     end

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -103,6 +103,14 @@ describe Yast::NetworkAutoconfiguration do
     context "when at least one interface is UP" do
       let(:active) { true }
 
+      context "and the interface is configured through iBFT" do
+        let(:ibft_interfaces) { [eth0.name] }
+
+        it "returns true" do
+          expect(instance.any_iface_active?).to be true
+        end
+      end
+
       context "and the interface has a configuration file" do
         it "returns true" do
           expect(instance.any_iface_active?).to be true
@@ -114,49 +122,6 @@ describe Yast::NetworkAutoconfiguration do
 
         it "returns false" do
           expect(instance.any_iface_active?).to be false
-        end
-      end
-    end
-  end
-
-  describe "#network_configured?" do
-    let(:active) { false }
-    let(:ibft_interfaces) { [] }
-    let(:eth1) { Y2Network::Interface.new("eth1") }
-    let(:interfaces) { Y2Network::InterfacesCollection.new([eth1, eth0]) }
-
-    before do
-      allow(instance).to receive(:active_config?).with("eth1").and_return(false)
-      allow(instance).to receive(:active_config?).with("eth0").and_return(active)
-      allow(instance).to receive(:ibft_interfaces).and_return(ibft_interfaces)
-    end
-
-    it "returns false if there is no interface UP" do
-      expect(instance.network_configured?).to be false
-    end
-
-    context "when at least one interface is UP" do
-      let(:active) { true }
-
-      context "and the interface is configured through iBFT" do
-        let(:ibft_interfaces) { [eth0.name] }
-
-        it "returns true" do
-          expect(instance.network_configured?).to be true
-        end
-      end
-
-      context "and the interface has a configuration file" do
-        it "returns true" do
-          expect(instance.network_configured?).to be true
-        end
-      end
-
-      context "but the interface is not configured" do
-        let(:connections) { Y2Network::ConnectionConfigsCollection.new([]) }
-
-        it "returns false" do
-          expect(instance.network_configured?).to be false
         end
       end
     end


### PR DESCRIPTION
After some discussions, apparently #1282 was good enough and #1285 was wrong and has been requested to be reverted.

https://bugzilla.suse.com/show_bug.cgi?id=1194911#c49

Basically, if **iBFT** is used it should provide all require settings and configuring another interface with DHCP could be a problem with the reverse path.

Therefore, this PR reverts #1285 .