### PR TITLE
Add qeth and hsi connection writers (bsc#1196582)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  3 10:01:24 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Added connection config writers for Qeth and Hipersocket
+  devices (bsc#1196582)
+- 4.4.43
+
+-------------------------------------------------------------------
 Fri Feb 25 11:54:49 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Revert last change going back to skip DHCP setup completely if

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.42
+Version:        4.4.43
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/network_manager/connection_config_writers/hsi.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/hsi.rb
@@ -1,0 +1,31 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/network_manager/connection_config_writers/qeth"
+
+module Y2Network
+  module NetworkManager
+    module ConnectionConfigWriters
+      # This class is responsible for writing the information from a ConnectionConfig::Hsi
+      # object to the underlying system.
+      class Hsi < Qeth
+      end
+    end
+  end
+end

--- a/src/lib/y2network/network_manager/connection_config_writers/qeth.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/qeth.rb
@@ -1,0 +1,48 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2network/network_manager/connection_config_writers/ethernet"
+
+module Y2Network
+  module NetworkManager
+    module ConnectionConfigWriters
+      # This class is responsible for writing the information from a ConnectionConfig::Qeth
+      # object to the underlying system.
+      class Qeth < Ethernet
+        # @see Y2Network::ConnectionConfigWriters::Ethernet#update_file
+        # @param conn [Y2Network::ConnectionConfig::Qeth] Configuration to write
+        def update_file(conn)
+          super
+          file.connection["s390-nettype"] = "qeth"
+          file.connection["s390-options"] = options_for(conn)
+          file.connection["s390-subchannels"] = conn.device_id.gsub(":", ",") if conn.device_id
+        end
+
+      private
+
+        # Convenience method to obtain QETH specific options
+        #
+        # @param conn [Y2Network::ConnectionConfig::Qeth] Configuration to write
+        def options_for(conn)
+          "layer2=#{conn.layer2 ? 1 : 0},portno=#{conn.port_number.to_i}"
+        end
+      end
+    end
+  end
+end

--- a/test/y2network/network_manager/connection_config_writers/hsi_test.rb
+++ b/test/y2network/network_manager/connection_config_writers/hsi_test.rb
@@ -1,0 +1,52 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "y2network/network_manager/connection_config_writers/hsi"
+require "cfa/nm_connection"
+require "y2network/boot_protocol"
+require "y2network/startmode"
+require "y2network/connection_config/bonding"
+
+describe Y2Network::NetworkManager::ConnectionConfigWriters::Hsi do
+  subject(:handler) { described_class.new(file) }
+  let(:file) { CFA::NmConnection.new("hsi0.nm_connection") }
+
+  let(:conn) do
+    Y2Network::ConnectionConfig::Qeth.new.tap do |c|
+      c.interface = "hsi0"
+      c.description = "Hipersocket connection 0"
+      c.startmode = Y2Network::Startmode.create("auto")
+      c.bootproto = Y2Network::BootProtocol::STATIC
+      c.device_id = "0.0.0800:0.0.0801:0.0.0802"
+      c.layer2 = true
+      c.port_number = 0
+    end
+  end
+
+  describe "#write" do
+    it "sets device and IP relevant attributes" do
+      handler.write(conn)
+      expect(file.connection["type"]).to eql("ethernet")
+      expect(file.connection["s390-nettype"]).to eql("qeth")
+      expect(file.connection["s390-options"]).to eql("layer2=1,portno=0")
+      expect(file.connection["s390-subchannels"]).to eql("0.0.0800,0.0.0801,0.0.0802")
+    end
+  end
+end

--- a/test/y2network/network_manager/connection_config_writers/qeth_test.rb
+++ b/test/y2network/network_manager/connection_config_writers/qeth_test.rb
@@ -1,0 +1,52 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "y2network/network_manager/connection_config_writers/qeth"
+require "cfa/nm_connection"
+require "y2network/boot_protocol"
+require "y2network/startmode"
+require "y2network/connection_config/bonding"
+
+describe Y2Network::NetworkManager::ConnectionConfigWriters::Qeth do
+  subject(:handler) { described_class.new(file) }
+  let(:file) { CFA::NmConnection.new("eth0.nm_connection") }
+
+  let(:conn) do
+    Y2Network::ConnectionConfig::Qeth.new.tap do |c|
+      c.interface = "eth0"
+      c.description = "Qeth 0"
+      c.startmode = Y2Network::Startmode.create("auto")
+      c.bootproto = Y2Network::BootProtocol::STATIC
+      c.device_id = "0.0.0800:0.0.0801:0.0.0802"
+      c.layer2 = true
+      c.port_number = 0
+    end
+  end
+
+  describe "#write" do
+    it "sets device and IP relevant attributes" do
+      handler.write(conn)
+      expect(file.connection["type"]).to eql("ethernet")
+      expect(file.connection["s390-nettype"]).to eql("qeth")
+      expect(file.connection["s390-options"]).to eql("layer2=1,portno=0")
+      expect(file.connection["s390-subchannels"]).to eql("0.0.0800,0.0.0801,0.0.0802")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When yast2-network **NetworkManager** writers were [added](https://github.com/yast/yast-network/pull/1149) we omitted s390 devices like **qeth**, **lcs**, **ctc** and **hsi** which are supported by **wicked** writers.

This lack of support has been reported by:

- https://bugzilla.suse.com/show_bug.cgi?id=1196582

## Solution

Added **qeth** and **hsi** connection writers which are currently the most important ones for s390 according to the bug report.

