### PR TITLE
bsc#1197019: display the configuration summary in AutoYaST

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 11 12:36:29 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Display the network configuration in the AutoYaST user interface
+  (see bsc#1197019).
+- 4.4.45
+
+-------------------------------------------------------------------
 Wed Mar  9 10:10:37 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Write NetworkManager s390 options to the ethernet section instead

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.44
+Version:        4.4.45
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -45,6 +45,9 @@ require "y2issues"
 
 require "shellwords"
 
+Yast.import "HTML"
+Yast.import "Summary"
+
 module Yast
   class LanClass < Module
     include ::UI::TextHelpers
@@ -629,9 +632,11 @@ module Yast
     #   "proposal": for proposal also with resolver an routing summary
     # @return summary of the current configuration
     def Summary(mode)
+      return no_config_message if yast_config.nil?
+
       case mode
       when "summary", "proposal"
-        Y2Network::Presenters::Summary.text_for(yast_config, mode)
+        Y2Network::Presenters::Summary.text_for(yast_config, "proposal")
       else
         Y2Network::Presenters::Summary.text_for(yast_config, "interfaces")
       end
@@ -921,6 +926,10 @@ module Yast
         hash[tmp_mac] ||= addr if tmp_mac
         log.debug("link_status #{hash.inspect}")
       end
+    end
+
+    def no_config_message
+      HTML.Heading(_("Network Configuration")) + Summary.NotConfigured
     end
   end
 


### PR DESCRIPTION
[bsc#1197019](https://bugzilla.suse.com/show_bug.cgi?id=1197019)

* Display the configuration summary in AutoYaST.
* Do not crash when no configuration is read.