### PR TITLE
Fix NetworkManager wireless connection name

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 18 19:49:34 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- CFA NM: replace problematic characters when getting the filename
+  for the given wireless configuration (bsc#1199451).
+- 4.3.82
+
+-------------------------------------------------------------------
 Wed Nov 10 21:41:54 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixed interfaces table description for s390 Group devices

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.81
+Version:        4.3.82
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/cfa/nm_connection.rb
+++ b/src/lib/cfa/nm_connection.rb
@@ -53,15 +53,17 @@ module CFA
 
       SYSTEM_CONNECTIONS_PATH = Pathname.new("/etc/NetworkManager/system-connections").freeze
       FILE_EXT = ".nmconnection".freeze
+      ESCAPE_CHAR = "_".freeze
 
       # Returns the file base name for the given connection
       #
       # @param conn [ConnectionConfig::Base]
       # @return [String]
       def file_basename_for(conn)
-        return conn.essid.to_s if conn.is_a?(Y2Network::ConnectionConfig::Wireless) && conn.essid
+        return conn.name unless conn.is_a?(Y2Network::ConnectionConfig::Wireless) && conn.essid
 
-        conn.name
+        # Convert special characters that could be problematic (bsc#1199451)
+        conn.essid.to_s.gsub(/^\.|\/|~$/, ESCAPE_CHAR)
       end
     end
 

--- a/test/cfa/nm_connection_test.rb
+++ b/test/cfa/nm_connection_test.rb
@@ -54,9 +54,39 @@ describe CFA::NmConnection do
         end
       end
 
-      it "uses the ESSID as path basename" do
-        file = described_class.for(conn)
-        expect(file.file_path.basename.to_s).to eq("MY_WIRELESS.nmconnection")
+      context "and the ESSID is set" do
+        it "uses the ESSID as path basename" do
+          file = described_class.for(conn)
+          expect(file.file_path.basename.to_s).to eq("MY_WIRELESS.nmconnection")
+        end
+
+        context "and the ESSID contains some '/' character" do
+          let(:essid) { "MY/WIRELESS" }
+
+          it "replaces '/' characters with '_'" do
+            file = described_class.for(conn)
+            expect(file.file_path.basename.to_s).to eq("MY_WIRELESS.nmconnection")
+          end
+        end
+
+        context "and the ESSID starts with a dot" do
+          let(:essid) { ".MY_WIRELESS" }
+
+          it "replaces the '.' character with '_'" do
+            file = described_class.for(conn)
+            expect(file.file_path.basename.to_s).to eq("_MY_WIRELESS.nmconnection")
+          end
+        end
+
+        context "and the ESSID ends with '~'" do
+          let(:essid) { ".MY/WIRELESS~" }
+
+          it "replaces the '~' character with '_'" do
+            file = described_class.for(conn)
+            expect(file.file_path.basename.to_s).to eq("_MY_WIRELESS_.nmconnection")
+          end
+        end
+
       end
 
       context "and the ESSID is not set" do


### PR DESCRIPTION
## Problem

YaST crashes when it tries to write a NetworkManager **wireless** configuration containing a **slash** character in the **essid**.

- https://bugzilla.suse.com/show_bug.cgi?id=1199451
- https://trello.com/c/CqOhhhgJ/2957-tw-p5-1199451-cannot-switch-to-networkmanager-internal-error

## Solution

Replace problematic characters when obtaining the filename for a NetworkManager wireless configuration. (see https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/main/src/libnm-core-impl/nm-keyfile.c#L4383)

## Testing

- *Added a new unit test*
