### PR TITLE
Search domains: allow 6+ entries (bsc#1200155).

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  7 13:30:22 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Allow more than 6 domains in resolver search list (bsc#1200155).
+- 4.3.83
+
+-------------------------------------------------------------------
 Wed May 18 19:49:34 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - CFA NM: replace problematic characters when getting the filename

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.82
+Version:        4.3.83
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -498,19 +498,6 @@ module Yast
       sl = NonEmpty(Builtins.splitstring(value, " ,\n\t"))
       error = ""
 
-      if Ops.greater_than(Builtins.size(sl), 6)
-        # Popup::Error text
-        error = Builtins.sformat(
-          _("The search list can have at most %1 domains."),
-          6
-        )
-      elsif Ops.greater_than(Builtins.size(Builtins.mergestring(sl, " ")), 256)
-        # Popup::Error text
-        error = Builtins.sformat(
-          _("The search list can have at most %1 characters."),
-          256
-        )
-      end
       Builtins.foreach(sl) do |s|
         if !Hostname.CheckDomain(s)
           # Popup::Error text

--- a/src/include/network/services/dns.rb
+++ b/src/include/network/services/dns.rb
@@ -498,18 +498,13 @@ module Yast
       sl = NonEmpty(Builtins.splitstring(value, " ,\n\t"))
       error = ""
 
-      Builtins.foreach(sl) do |s|
-        if !Hostname.CheckDomain(s)
-          # Popup::Error text
-          error = Ops.add(
-            Ops.add(
-              Builtins.sformat(_("The search domain '%1' is invalid."), s),
-              "\n"
-            ),
-            Hostname.ValidDomain
-          )
-          break
-        end
+      sl.each do |s|
+        next if Hostname.CheckDomain(s)
+
+        # TRANSLATORS: Popup::Error text
+        error = Builtins.sformat(_("The search domain '%1' is invalid."), s) +
+          "\n" + Hostname.ValidDomain
+        break
       end
 
       if error != ""


### PR DESCRIPTION
## Problem

- (**L3**) [bsc#1200155](https://bugzilla.suse.com/show_bug.cgi?id=1200155) 

man resolv.conf: In glibc 2.25 and earlier, the search list is limited to six domains with a total of 256 characters.  Since glibc 2.26 \[upstream release: 2017-08-02], the search list is unlimited.

But YaST did not get the memo and did a too strict input validation.

![seven-search-domains](https://user-images.githubusercontent.com/102056/172396125-11cf4fca-709a-4992-804e-ed058278306e.jpg)

## Solution

- Removed the obsolete validation code.


## Testing

- Wrote unit tests for the validation method

