### PR TITLE
AutoYaST schema: Added networking route extrapara element

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul  4 11:54:34 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- AY: Added missing route extrapara element to the networking
+  section (bsc#1201129)
+- 4.2.110
+
+-------------------------------------------------------------------
 Wed Nov 10 21:41:54 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixed interfaces table description for s390 Group devices

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.2.109
+Version:        4.2.110
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/networking.rnc
+++ b/src/autoyast-rnc/networking.rnc
@@ -272,11 +272,12 @@ route =
     destination &
     element netmask { text }? &	#overloaded
     element device { text }? &	#overloaded
-    gateway ?
+    gateway ? &
+    extrapara ?
   }
 destination = element destination { text }
 gateway = element gateway { text }
-
+extrapara = element extrapara { text }
 
 #
 # DNS (fqdn + resolver)


### PR DESCRIPTION
## Problem

It seems that the AutoYaST networking documentation contains some errors and verifying that it was found that the extrapara route element is not declared in the schema.

- https://bugzilla.suse.com/show_bug.cgi?id=1201129
- see https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-configuration-installation-options.html#ex-ay-network-config-general

## Solution

Added missing 'extrapara' element
