### PR TITLE
Added a FCoE connections generator (bsc#1199554)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 21 08:38:40 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Added a class to generate the configuration needed for a FCoE
+  device being aware of it during the installation (bsc#1199554)
+- 4.3.85
+
+-------------------------------------------------------------------
 Mon Jul  4 11:54:34 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - AY: Added missing route extrapara element to the networking

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.84
+Version:        4.3.85
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/fcoe_conn_generator.rb
+++ b/src/lib/y2network/fcoe_conn_generator.rb
@@ -1,0 +1,78 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2network/interface_config_builder"
+
+module Y2Network
+  # This class is responsible for creating the connection configuration for a
+  # given FCoE storage only device
+  class FcoeConnGenerator
+    include Yast::Logger
+    # @return [Y2Network::Config]
+    attr_reader :config
+
+    def initialize(config)
+      @config = config
+    end
+
+    # @param card [Hash] a hash with all the information about a network interface
+    def update_connections_for(card)
+      update_parent_connection_for(card)
+      update_vlan_connection_for(card)
+    end
+
+  private
+
+    # Adds or modifies the network configuration for the FCoE VLAN parent device
+    #
+    # @param card [Hash] a hash with all the information about a network interface
+    def update_parent_connection_for(card)
+      name = card.fetch("dev_name", "")
+      conn = config.connections.by_name(name)
+      builder = Y2Network::InterfaceConfigBuilder.for("eth", config: conn)
+      builder.name = name
+      builder.startmode = "nfsroot"
+      if conn.nil?
+        builder.boot_protocol = "static"
+        config = builder.connection_config
+        # FIXME: we should delegate this method to the connection_config
+        config.description = card.fetch("device", "") if config
+      end
+      builder.save
+    end
+
+    # Adds the network configuration for the FCoE VLAN interface
+    #
+    # @param card [Hash] a hash with all the information about a network interface
+    def update_vlan_connection_for(card)
+      dev_name = card.fetch("dev_name", "")
+      vid = card.fetch("vlan_interface", "0").to_i
+      return if vid == 0
+
+      vlan_builder = Y2Network::InterfaceConfigBuilder.for("vlan")
+      vlan_builder.name = card.fetch("fcoe_vlan")
+      vlan_builder.etherdevice = dev_name
+      vlan_builder.boot_protocol = "static"
+      vlan_builder.startmode = "nfsroot"
+      vlan_builder.vlan_id = vid
+      vlan_builder.save
+    end
+  end
+end

--- a/src/lib/y2network/interface_config_builder.rb
+++ b/src/lib/y2network/interface_config_builder.rb
@@ -66,7 +66,7 @@ module Y2Network
     attr_writer :newly_added
 
     def_delegators :@connection_config,
-      :startmode, :ethtool_options, :ethtool_options=
+      :startmode, :ethtool_options, :ethtool_options=, :description, :description=
 
     # Constructor
     #

--- a/test/y2network/fcoe_conn_generator_test.rb
+++ b/test/y2network/fcoe_conn_generator_test.rb
@@ -1,0 +1,131 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2network/fcoe_conn_generator"
+
+describe Y2Network::FcoeConnGenerator do
+  let(:generator) { described_class.new(config) }
+  let(:config) do
+    Y2Network::Config.new(interfaces: interfaces, connections: connections, source: :testing)
+  end
+  before do
+    Yast::Lan.add_config(:yast, config)
+  end
+  let(:connections) { Y2Network::ConnectionConfigsCollection.new([]) }
+  let(:interfaces) { Y2Network::InterfacesCollection.new([]) }
+  let(:netcards) do
+    [
+      {
+        "auto_vlan"      => "yes",
+        "cfg_device"     => "",
+        "dcb_capable"    => "no",
+        "dcb_required"   => "no",
+        "dev_name"       => "eth1",
+        "driver"         => "fcoe",
+        "device"         => "TEST Ethernet Controller",
+        "fcoe_enable"    => "yes",
+        "fcoe_vlan"      => "not configured",
+        "mac_addr"       => "08:00:27:11:64:e4",
+        "vlan_interface" => "300"
+      },
+      {
+        "auto_vlan"      => "no",
+        "cfg_device"     => "eth1.400",
+        "dcb_capable"    => "no",
+        "dcb_required"   => "yes",
+        "driver"         => "fcoe",
+        "dev_name"       => "eth1",
+        "device"         => "TEST Ethernet Controller",
+        "fcoe_enable"    => "yes",
+        "fcoe_vlan"      => "eth1.400",
+        "mac_addr"       => "08:00:27:11:64:e4",
+        "vlan_interface" => "400"
+      },
+      {
+        "auto_vlan"      => "yes",
+        "cfg_device"     => "",
+        "dcb_capable"    => "no",
+        "dcb_required"   => "no",
+        "dev_name"       => "eth2",
+        "driver"         => "bnx2x",
+        "device"         => "Intel PRO/1000 MT Desktop Adapter",
+        "fcoe_enable"    => "yes",
+        "fcoe_vlan"      => "not configured",
+        "mac_addr"       => "08:23:27:99:64:78",
+        "vlan_interface" => "200",
+        "fcoe_flag"      => true,
+        "iscsi_flag"     => false,
+        "storage_only"   => true
+      }
+    ]
+  end
+
+  describe ".update_connections_for" do
+    let(:device) { netcards[1] }
+
+    it "adds or updates the parent device and FCoE VLAN connection for the given device" do
+      expect(config.connections.size).to eql(0)
+      generator.update_connections_for(device)
+      expect(config.connections.size).to eql(2)
+    end
+
+    context "when it adds the new connection for the etherdevice" do
+      let(:conn) { config.connections.by_name(device.fetch("dev_name")) }
+
+      before do
+        generator.update_connections_for(device)
+      end
+
+      it "sets the connection STARTMODE to 'nfsroot'" do
+        expect(conn.startmode.to_s).to eql("nfsroot")
+      end
+
+      it "sets the connection BOOTPROTO to 'static'" do
+        expect(conn.bootproto&.name).to eql("static")
+      end
+    end
+
+    context "when it adds the new connection for FCoE VLAN" do
+      let(:conn) { config.connections.by_name(device.fetch("fcoe_vlan")) }
+
+      before do
+        generator.update_connections_for(device)
+      end
+
+      it "sets the parent device" do
+        expect(conn.parent_device).to eq("eth1")
+      end
+
+      it "sets the VLAN id" do
+        expect(conn.vlan_id).to eq(400)
+      end
+
+      it "sets the connection STARTMODE to 'nfsroot'" do
+        expect(conn.startmode.to_s).to eql("nfsroot")
+      end
+
+      it "sets the connection BOOTPROTO to 'static'" do
+        expect(conn.bootproto&.name).to eql("static")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When installing a server with FCoE on a target LUN it gets stuck in subsequent reboots due to a wrong network configuration.

- https://bugzilla.suse.com/show_bug.cgi?id=1199554
- https://trello.com/c/vA1WOdhV

## Solution

Added a class to generate the needed configuration for a **FCoE** device being aware of it during installation.

## Testing

- *Added a new unit test*
- *Tested manually* (pending due to problems with server)

