### PR TITLE
Disable backends

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -4,7 +4,7 @@ Thu Sep  1 08:30:47 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 - At the end of the installation, force an enablement of the
   selected network service even when the selected one has not been
   modified and ensure other backends are disabled (bsc#1202479)
-- 4.4.52
+- 4.4.50
 
 -------------------------------------------------------------------
 Thu Jul 21 08:38:40 UTC 2022 - Knut Anderssen <kanderssen@suse.com>

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Sep  1 08:30:47 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- At the end of the installation, force an enablement of the
+  selected network service even when the selected one has not been
+  modified and ensure other backends are disabled (bsc#1202479)
+- 4.4.52
+
+-------------------------------------------------------------------
 Thu Jul 21 08:38:40 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Added a class to generate the configuration needed for a FCoE

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.49
+Version:        4.4.50
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only
@@ -33,8 +33,8 @@ BuildRequires:  yast2-devtools >= 3.1.15
 #for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  yast2-storage-ng
-# Replace PackageSystem with Package
-BuildRequires:  yast2 >= 4.4.38
+# Added force option to NetworkService.EnableDisableNow method
+BuildRequires:  yast2 >= 4.4.52
 
 BuildRequires:  yast2-packager >= 4.0.18
 # Product control need xml agent
@@ -51,8 +51,8 @@ PreReq:         /bin/rm
 Requires:       sysconfig >= 0.80.0
 Requires:       yast2-proxy
 Requires:       yast2-storage-ng
-# Replace PackageSystem with Package
-Requires:       yast2 >= 4.4.38
+# Added force option to NetworkService.EnableDisableNow method
+Requires:       yast2 >= 4.4.52
 # Packages::vnc_packages
 Requires:       yast2-packager >= 4.0.18
 Requires:       augeas-lenses

--- a/test/save_network_test.rb
+++ b/test/save_network_test.rb
@@ -67,6 +67,7 @@ describe Yast::SaveNetworkClient do
       allow(Yast::Lan).to receive(:Write)
       allow(Yast::Arch).to receive(:s390).and_return(s390)
       allow(Yast::NetworkService).to receive(:EnableDisableNow)
+      allow(Yast::NetworkService).to receive(:disable_service)
       allow(Yast::NetworkAutoYast.instance).to receive(:configure_hosts).and_return(nil)
     end
 
@@ -198,6 +199,12 @@ describe Yast::SaveNetworkClient do
         subject.main
       end
 
+      it "disables wicked" do
+        expect(Yast::NetworkService).to receive(:disable_service).with(:wicked)
+
+        subject.main
+      end
+
       context "when running on network manager (e.g., live installation)" do
         let(:system_backend) { Y2Network::Backends::NetworkManager.new }
 
@@ -223,6 +230,12 @@ describe Yast::SaveNetworkClient do
 
     context "when the backend selected is wicked" do
       let(:selected_backend) { :wicked }
+
+      it "disables NetworkManager" do
+        expect(Yast::NetworkService).to receive(:disable_service).with(:network_manager)
+
+        subject.main
+      end
 
       it "selects wicked as the service to be used after installation" do
         expect(Yast::NetworkService).to receive(:use_wicked)


### PR DESCRIPTION
## Problem

During installation, if apparently the selected network service has not been modified (wicked is default backend) the service is not enabled explicitly in the target system which could end with it disabled.

- https://bugzilla.suse.com/show_bug.cgi?id=1202479

## Solution

During installation, force an enablement of the selected network service even when if has not been modified and also ensure not selected backend is disabled in order to prevent more than one end running after the installation. 

It depends on (https://github.com/yast/yast-yast2/pull/1269)

## Testing

Tested manually

