### PR TITLE
Activate s390 devices before anything else (bsc#1199746)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Sep 16 08:23:21 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Activate s390 devices before importing and reading the network
+  configuration or otherwise the related linux devices will not be 
+  present and could be ignored (bsc#1199746)
+- 4.4.51
+
+-------------------------------------------------------------------
 Thu Sep  1 08:30:47 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - At the end of the installation, force an enablement of the

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.50
+Version:        4.4.51
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -590,15 +590,15 @@ module Yast
     # @return true on success
     def Import(settings)
       settings = {} if settings.nil?
+      if Arch.s390
+        NetworkAutoYast.instance.activate_s390_devices(settings.fetch("s390-devices", {}))
+      end
 
       Read(:cache)
       profile = Y2Network::AutoinstProfile::NetworkingSection.new_from_hashes(settings)
       result = Y2Network::Config.from(:autoinst, profile, system_config)
       add_config(:yast, result.config)
       @autoinst = autoinst_config(profile)
-      if Arch.s390
-        NetworkAutoYast.instance.activate_s390_devices(settings.fetch("s390-devices", {}))
-      end
 
       NetworkConfig.Import(settings["config"] || {})
       # Ensure that the /etc/hosts has been read to no blank out it in case of


### PR DESCRIPTION
## Problem

In **AutoYaST** it is not possible to write udev rules for more than one s390 interface.

- https://bugzilla.suse.com/show_bug.cgi?id=1199746


## Solution

In order to write custom udev rules for s390 devices then the devices should be activated before the configuration is read or otherwise them will be ignored.

## Testing

- *Tested manually*
