### PR TITLE
Fix no route gw nm

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep 29 09:15:47 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Fixed issue when writing the NetworkManager config without a
+  gateway (bsc#1203866)
+- 4.3.86
+
+-------------------------------------------------------------------
 Thu Jul 21 08:38:40 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Added a class to generate the configuration needed for a FCoE

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.85
+Version:        4.3.86
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/network_manager/connection_config_writers/base.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/base.rb
@@ -64,7 +64,7 @@ module Y2Network
         #
         # @param routes [<Array<Y2Network::Route>] routes associated with the connection
         def configure_routes(routes)
-          routes.select(&:default?).each { |r| configure_gateway(r) }
+          routes.select(&:default?).each { |r| configure_gateway(r) if r.gateway }
         end
 
         # @param route [Y2Network::Route] route to be written


### PR DESCRIPTION
## Problem

When no route gateway is defined the NetworkManager routing writer crashes.

- [bsc#1203866](https://bugzilla.suse.com/show_activity.cgi?id=1203866)

## Solution

When writing the NetworkManager configuration ignore a route when there is no route gateway.
