### PR TITLE
Ay needed packages

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Oct  3 08:31:33 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not assume wicked will be installed by default anymore and
+  return the needed packages by the selected backend when them
+  are not installed (bsc#1201235, bsc#1201435)
+- 4.4.53
+
+-------------------------------------------------------------------
 Thu Sep 29 09:15:47 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixed issue when writing the NetworkManager config without a

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.4.52
+Version:        4.4.53
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/backend.rb
+++ b/src/lib/y2network/backend.rb
@@ -27,8 +27,6 @@ module Y2Network
     include Yast::I18n
     include Yast2::Equatable
 
-    PACKAGES = [].freeze
-
     # @return [Symbol] backend id
     attr_reader :id
 
@@ -90,8 +88,11 @@ module Y2Network
       Yast::NetworkService.is_backend_available(id)
     end
 
+    # Return a list of the required packages for this backend
+    #
+    # @return [Array<String>] list of packages required by the backend
     def packages
-      self.class.const_get(:PACKAGES)
+      []
     end
   end
 end

--- a/src/lib/y2network/backend.rb
+++ b/src/lib/y2network/backend.rb
@@ -27,6 +27,8 @@ module Y2Network
     include Yast::I18n
     include Yast2::Equatable
 
+    PACKAGES = [].freeze
+
     # @return [Symbol] backend id
     attr_reader :id
 
@@ -86,6 +88,10 @@ module Y2Network
     # @return [Boolean]
     def available?
       Yast::NetworkService.is_backend_available(id)
+    end
+
+    def packages
+      self.class.const_get(:PACKAGES)
     end
   end
 end

--- a/src/lib/y2network/backends/netconfig.rb
+++ b/src/lib/y2network/backends/netconfig.rb
@@ -23,6 +23,8 @@ module Y2Network
   module Backends
     # This class represents the Netconfig backend
     class Netconfig < Backend
+      PACKAGES = ["sysconfig-netconfig"].freeze
+
       def initialize
         textdomain "network"
         super(:netconfig)

--- a/src/lib/y2network/backends/netconfig.rb
+++ b/src/lib/y2network/backends/netconfig.rb
@@ -23,8 +23,6 @@ module Y2Network
   module Backends
     # This class represents the Netconfig backend
     class Netconfig < Backend
-      PACKAGES = ["sysconfig-netconfig"].freeze
-
       def initialize
         textdomain "network"
         super(:netconfig)
@@ -32,6 +30,10 @@ module Y2Network
 
       def label
         _("Traditional ifup")
+      end
+
+      def packages
+        ["sysconfig-netconfig"]
       end
     end
   end

--- a/src/lib/y2network/backends/network_manager.rb
+++ b/src/lib/y2network/backends/network_manager.rb
@@ -23,8 +23,6 @@ module Y2Network
   module Backends
     # This class represents the NetworkManager backend
     class NetworkManager < Backend
-      PACKAGES = ["NetworkManager"].freeze
-
       def initialize
         textdomain "network"
         super(:network_manager)
@@ -32,6 +30,10 @@ module Y2Network
 
       def label
         _("Network Manager")
+      end
+
+      def packages
+        ["NetworkManager"]
       end
     end
   end

--- a/src/lib/y2network/backends/network_manager.rb
+++ b/src/lib/y2network/backends/network_manager.rb
@@ -23,6 +23,8 @@ module Y2Network
   module Backends
     # This class represents the NetworkManager backend
     class NetworkManager < Backend
+      PACKAGES = ["NetworkManager"].freeze
+
       def initialize
         textdomain "network"
         super(:network_manager)

--- a/src/lib/y2network/backends/wicked.rb
+++ b/src/lib/y2network/backends/wicked.rb
@@ -23,8 +23,6 @@ module Y2Network
   module Backends
     # This class represents the wicked backend
     class Wicked < Backend
-      PACKAGES = ["wicked"].freeze
-
       def initialize
         textdomain "network"
         super(:wicked)
@@ -32,6 +30,10 @@ module Y2Network
 
       def label
         _("Wicked Service")
+      end
+
+      def packages
+        ["wicked"]
       end
     end
   end

--- a/src/lib/y2network/backends/wicked.rb
+++ b/src/lib/y2network/backends/wicked.rb
@@ -23,6 +23,8 @@ module Y2Network
   module Backends
     # This class represents the wicked backend
     class Wicked < Backend
+      PACKAGES = ["wicked"].freeze
+
       def initialize
         textdomain "network"
         super(:wicked)

--- a/src/modules/Lan.rb
+++ b/src/modules/Lan.rb
@@ -652,10 +652,13 @@ module Yast
     # @return [Array] of packages needed when writing the config
     def Packages
       pkgs = []
+      backend = yast_config&.backend
 
-      if yast_config&.backend?(:network_manager)
-        pkgs << "NetworkManager" if !Package.Installed("NetworkManager")
-      elsif !Package.Installed("wpa_supplicant")
+      return pkgs unless backend
+
+      backend.packages.each { |p| pkgs << p if !Package.Installed(p) }
+
+      if (backend.id == :wicked) && !Package.Installed("wpa_supplicant")
         # we have to add wpa_supplicant when wlan is in game, wicked relies on it
         wlan_present = yast_config.interfaces.any? do |iface|
           iface.type == Y2Network::InterfaceType::WIRELESS


### PR DESCRIPTION
## Problem

We are only checking needed packages for the selected backend when it is NetworkManager but not in case of wicked or netconfig which in case of AutoYaST now could be needed as otherwise no package will be installed since sysconfig-netconfig is not required anymore.

- [bsc#1201435](https://bugzilla.suse.com/show_bug.cgi?id=1201435)
- 
## Solution

Return needed packages for the selected backend in case them are not installed.

## Testing

- *Added a new unit test*
- *Tested manually*

