### PR TITLE
Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 22 14:53:13 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)
+- 4.5.10
+
+-------------------------------------------------------------------
 Mon Oct  3 08:31:33 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not assume wicked will be installed by default anymore and

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.5.9
+Version:        4.5.10
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/test/y2network/driver_test.rb
+++ b/test/y2network/driver_test.rb
@@ -47,8 +47,9 @@ describe Y2Network::Driver do
 
   describe "#write_options" do
     it "writes options to the underlying system" do
+      options = { "debug" => "16" }
       expect(Yast::SCR).to receive(:Write)
-        .with(Yast::Path.new(".modules.options.virtio_net"), "debug" => "16")
+        .with(Yast::Path.new(".modules.options.virtio_net"), options)
       driver.write_options
     end
   end

--- a/test/y2network/network_manager/config_writer_test.rb
+++ b/test/y2network/network_manager/config_writer_test.rb
@@ -112,7 +112,8 @@ describe Y2Network::NetworkManager::ConfigWriter do
     end
 
     it "writes connections configuration" do
-      expect(conn_config_writer).to receive(:write).with(eth0_conn, nil, routes: [], parent: nil)
+      options = { routes: [], parent: nil }
+      expect(conn_config_writer).to receive(:write).with(eth0_conn, nil, options)
       writer.write(config)
     end
 

--- a/test/y2network/udev_rule_test.rb
+++ b/test/y2network/udev_rule_test.rb
@@ -135,8 +135,9 @@ describe Y2Network::UdevRule do
     let(:udev_rule) { described_class.new_driver_assignment("virtio:0000", "virtio_net") }
 
     it "writes changes using the udev_persistent agent" do
+      drivers = { "virtio_net" => udev_rule.parts.map(&:to_s) }
       expect(Yast::SCR).to receive(:Write).with(
-        Yast::Path.new(".udev_persistent.drivers"), "virtio_net" => udev_rule.parts.map(&:to_s)
+        Yast::Path.new(".udev_persistent.drivers"), drivers
       )
       expect(Yast::SCR).to receive(:Write).with(Yast::Path.new(".udev_persistent.nil"), [])
       described_class.write_drivers_rules([udev_rule])


### PR DESCRIPTION
- https://bugzilla.opensuse.org/show_bug.cgi?id=1204871 "- [Staging] rubygem-rspec-* 3.12 breaks various yast modules build"
- see https://github.com/yast/yast-yast2/pull/1279 for details
