### PR TITLE
[WIP] Fix network overview for NetworkManager users

### DIFF
--- a/src/lib/y2network/presenters/interface_summary.rb
+++ b/src/lib/y2network/presenters/interface_summary.rb
@@ -87,7 +87,11 @@ module Y2Network
         end
 
         if hardware.nil? || !hardware.exists?
-          rich << "<b>(" << _("No hardware information") << ")</b><br>"
+          if @config.backend?(:network_manager)
+            rich << "<b>" << _("Network interfaces are managed by Network Manager.") << "</b><br>"
+          else
+            rich << "<b>(" << _("No hardware information") << ")</b><br>"
+          end
         else
           rich << "<b>(" << _("Not connected") << ")</b><br>" if !hardware.link
           rich << "<b>MAC : </b>" << hardware.mac << "<br>" if hardware.mac
@@ -104,9 +108,11 @@ module Y2Network
             rich << Yast::HTML.Bold(dev_name) << "<br>"
           end
 
-          rich << "<p>"
-          rich << _("The device is not configured. Press <b>Edit</b>\nto configure.\n")
-          rich << "</p>"
+          if !@config.backend?(:network_manager)
+            rich << "<p>"
+            rich << _("The device is not configured. Press <b>Edit</b>\nto configure.\n")
+            rich << "</p>"
+          end
         end
         rich
       end

--- a/src/lib/y2network/widgets/add_interface.rb
+++ b/src/lib/y2network/widgets/add_interface.rb
@@ -30,6 +30,10 @@ module Y2Network
         textdomain "network"
       end
 
+      def init
+        disable if Yast::Lan.yast_config&.backend?(:network_manager)
+      end
+
       def label
         Yast::Label.AddButton
       end

--- a/src/lib/y2network/widgets/delete_interface.rb
+++ b/src/lib/y2network/widgets/delete_interface.rb
@@ -41,6 +41,7 @@ module Y2Network
       # @see CWM::AbstractWidget#init
       def init
         disable unless @table.value
+        disable if Yast::Lan.yast_config&.backend?(:network_manager)
       end
 
       def handle

--- a/src/lib/y2network/widgets/edit_interface.rb
+++ b/src/lib/y2network/widgets/edit_interface.rb
@@ -39,6 +39,7 @@ module Y2Network
       # @see CWM::AbstractWidget#init
       def init
         disable unless @table.value
+        disable if Yast::Lan.yast_config&.backend?(:network_manager)
       end
 
       def label

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -67,18 +67,6 @@ module Y2Network
 
       # Workaround for usage in old CWM which also cache content of cwm items
       def init
-        if config.backend?(:network_manager)
-          Yast::Popup.Warning(
-            _(
-              "Network is currently handled by NetworkManager\n" \
-              "or completely disabled. YaST is unable to configure some options."
-            )
-          )
-          # switch to global tab
-          Yast::UI.FakeUserInput("ID" => "global")
-          return
-        end
-
         change_items(items)
         handle
         disable if config.backend?(:network_manager)

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -56,6 +56,7 @@ module Y2Network
 
       def items
         items_list = []
+        return items_list if config.backend?(:network_manager)
         config.interfaces.each { |i| items_list << interface_item(i) }
         config.s390_devices.select(&:offline?).each do |device|
           items_list << device_item(device)
@@ -80,6 +81,7 @@ module Y2Network
 
         change_items(items)
         handle
+        disable if config.backend?(:network_manager)
       end
 
       def help

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -75,7 +75,10 @@ module Y2Network
       def help
         _(
           "<p><b><big>Overview</big></b><br>\n" \
-           "Obtain an overview of the network interfaces configuration.</p>\n"
+           "Obtain an overview of the network interfaces configuration.<br><br>\n" \
+           "YaST cannot be used to configure network interfaces if <b>Network Manager</b><br>\n" \
+           "is selected as network setup method. Choose <b>Wicked</b> if you prefer to<br>\n" \
+           "configure them with YaST.</p>\n"
         )
       end
 


### PR DESCRIPTION
Please allow me to propose a solution to make navigating the network section more flawlessly.

## Problem

The user is displayed a message when entering the tab `Overview` in the `Network Settings` of YaST and by acknowledging that message, forced to switch to tab `Global Options`. Apparently this is done to prevent a user from accessing controls that can't be used. This solution might be acceptable in most cases, although it is not possible to check the list of network interfaces anymore, even without the intention to change anything.

However, in case of the ncurses UI it breaks the option to use a combination of `TAB`, `Arrow Keys`, `Enter` to navigate instead of `Alt+<KEY>` shortcuts. (See bug report.)

https://bugzilla.suse.com/show_bug.cgi?id=1205715

## Solution

This PR would disable the buttons `Add`, `Edit`, `Delete` on the tab `Overview` as well as the interfaces table if NetworkManager is used for configuration.
~It will not force the user to `Global Options` anymore when acknowledging the warning. Instead it will inform about the network setup method option in `Global Options`. As a result, the user is still able to see the properties of the network interfaces on the `Overview` page.~
The popup message is not shown anymore. Instead, in the box which usually displays the interface properties, an information is displayed that Network Manager is managing the interfaces.
In the help of the `Overview` page, an information about fixing this by selecting `Wicked` is given.

### Reason for hiding all interfaces:
It looks that the interfaces displayed might differ from reality if NM is used. C.f. https://bugzilla.suse.com/show_bug.cgi?id=1205715#c7
From my perspective it makes sense to handle this separately if required. As a result, these are hidden as well with the current code.

## Testing

The code was tested manually on openSUSE Tumbleweed.

## Request for comments

1. Please give some comments on the proposed change. 
2. This would be my first contribution to the project - if I missed a side effect, please let me know.
3. I changed the ~warning~ message to only tell that NetworkManager is used. If `:network_manager` as backend means that the network could also be disabled, please let me know as well. To me it appears that we know that the network is not disabled but just NetworkManager is used if that is the value.

## Screenshots


![Screenshot from 2023-01-12 09-52-29](https://user-images.githubusercontent.com/31621613/212022245-b5b2b834-1871-4dcd-9906-0115695cfbe6.png)

![Screenshot from 2023-01-12 09-53-15](https://user-images.githubusercontent.com/31621613/212022285-cd14e370-a527-4257-afdc-db1db591c712.png)

![Screenshot from 2023-01-12 09-55-25](https://user-images.githubusercontent.com/31621613/212022334-2744ed08-767b-4a09-8151-96df79eb878a.png)

![Screenshot from 2023-01-12 09-55-39](https://user-images.githubusercontent.com/31621613/212022371-2faa9fd1-8b6e-4e5e-89de-e189b085c221.png)