### PR TITLE
Do not setup DHCP in case of firmware configured devices

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,7 +2,7 @@
 Wed Jan 25 13:52:26 UTC 2023 - Knut Alejandro Anderssen González <kanderssen@suse.com>
 
 - During installation, do not configure DHCP if there is some
-  active interface configured by firmware (jsc#PED-3138).
+  active interface configured by firmware (jsc#PED-967).
 - 4.5.15
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 25 13:52:26 UTC 2023 - Knut Alejandro Anderssen González <kanderssen@suse.com>
+
+- During installation, do not configure DHCP if there is some
+  active interface configured by firmware (jsc#PED-3138).
+- 4.5.15
+
+-------------------------------------------------------------------
 Tue Jan 24 09:37:43 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix the return of packages needed by the selected backend when

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.5.14
+Version:        4.5.15
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/network_autoconfiguration.rb
+++ b/src/lib/network/network_autoconfiguration.rb
@@ -51,11 +51,11 @@ module Yast
       config.interfaces.any? do |interface|
         next false unless active_config?(interface.name)
 
-        config.connections.by_name(interface.name) || ibft_interfaces.include?(interface.name)
+        config.connections.by_name(interface.name) || firmware_interfaces.include?(interface.name)
       end
     end
 
-    # Return true if the given interface is connected but it is not configured by iBFT or via an
+    # Return true if the given interface is connected but it is not configured by firmware or via an
     # ifcfg file.
     #
     # Note: (it speeds up the initialization phase of installer - bnc#872319)
@@ -63,7 +63,7 @@ module Yast
     # @return [Boolean]
     def dhcp_candidate?(interface)
       return false if config.connections.by_name(interface.name)
-      return false if ibft_interfaces.include?(interface.name)
+      return false if firmware_interfaces.include?(interface.name)
 
       phy_connected?(interface.name)
     end

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -92,7 +92,7 @@ module Yast
     # @return [Array <String>] array of interface names
     def firmware_interfaces
       output = Yast::Execute.stdout.locally!(WICKED_PATH, "firmware", "interfaces")
-      interfaces = output.gsub(/^(ibft|nbft|redfish)\s+/, "").split(/\s+/)
+      interfaces = output.gsub(/^\w+\s+/, "").split(/\s+/)
       (ibft_interfaces + interfaces).uniq
     end
   end

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -84,7 +84,7 @@ module Yast
     #
     # @return [Array <String>] array of interface names
     def ibft_interfaces
-      Yast::Execute.stdout.locally!(IBFT_CMD, "-l").gsub("\n", " ").split(" ").uniq
+      Yast::Execute.stdout.locally!(IBFT_CMD, "-l").gsub("\n", " ").split(/\s+/).uniq
     end
 
     # Returns an array of interface names which are configured via firmware
@@ -92,7 +92,7 @@ module Yast
     # @return [Array <String>] array of interface names
     def firmware_interfaces
       output = Yast::Execute.stdout.locally!(WICKED_PATH, "firmware", "interfaces")
-      interfaces = output.gsub(/^(ibft|nbft|redfish)/, "").gsub("\n", " ").split(" ")
+      interfaces = output.gsub(/^(ibft|nbft|redfish)\s+/, "").gsub("\n", " ").split(/\s+/)
       (ibft_interfaces + interfaces).uniq
     end
   end

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -84,7 +84,7 @@ module Yast
     #
     # @return [Array <String>] array of interface names
     def ibft_interfaces
-      Yast::Execute.stdout.locally!(IBFT_CMD, "-l").gsub("\n", " ").split(/\s+/).uniq
+      Yast::Execute.stdout.locally!(IBFT_CMD, "-l").split(/\s+/).uniq
     end
 
     # Returns an array of interface names which are configured via firmware
@@ -92,7 +92,7 @@ module Yast
     # @return [Array <String>] array of interface names
     def firmware_interfaces
       output = Yast::Execute.stdout.locally!(WICKED_PATH, "firmware", "interfaces")
-      interfaces = output.gsub(/^(ibft|nbft|redfish)\s+/, "").gsub("\n", " ").split(/\s+/)
+      interfaces = output.gsub(/^(ibft|nbft|redfish)\s+/, "").split(/\s+/)
       (ibft_interfaces + interfaces).uniq
     end
   end

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -92,7 +92,8 @@ module Yast
     # @return [Array <String>] array of interface names
     def firmware_interfaces
       output = Yast::Execute.stdout.locally!(WICKED_PATH, "firmware", "interfaces")
-      output.gsub(/^(ibft|nbft|redfish)/, "").gsub("\n", " ").split(" ").uniq
+      interfaces = output.gsub(/^(ibft|nbft|redfish)/, "").gsub("\n", " ").split(" ")
+      (ibft_interfaces + interfaces).uniq
     end
   end
 end

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -26,6 +26,7 @@ module Yast
     BASH_PATH = Path.new(".target.bash")
     BASH_OUTPUT_PATH = Path.new(".target.bash_output")
     IBFT_CMD = "/etc/wicked/extensions/ibft".freeze
+    WICKED_PATH = "/usr/sbin/wicked".freeze
 
     # Reloads configuration for each device named in devs
     #
@@ -84,6 +85,14 @@ module Yast
     # @return [Array <String>] array of interface names
     def ibft_interfaces
       Yast::Execute.stdout.locally!(IBFT_CMD, "-l").gsub("\n", " ").split(" ").uniq
+    end
+
+    # Returns an array of interface names which are configured via firmware
+    #
+    # @return [Array <String>] array of interface names
+    def firmware_interfaces
+      output = Yast::Execute.stdout.locally!(WICKED_PATH, "firmware", "interfaces")
+      output.gsub(/^(ibft|nbft|redfish)/, "").gsub("\n", " ").split(" ").uniq
     end
   end
 end

--- a/test/network_autoconfiguration_test.rb
+++ b/test/network_autoconfiguration_test.rb
@@ -86,14 +86,14 @@ describe Yast::NetworkAutoconfiguration do
 
   describe "#any_iface_active?" do
     let(:active) { false }
-    let(:ibft_interfaces) { [] }
+    let(:firmware_interfaces) { [] }
     let(:eth1) { Y2Network::Interface.new("eth1") }
     let(:interfaces) { Y2Network::InterfacesCollection.new([eth1, eth0]) }
 
     before do
       allow(instance).to receive(:active_config?).with("eth1").and_return(false)
       allow(instance).to receive(:active_config?).with("eth0").and_return(active)
-      allow(instance).to receive(:ibft_interfaces).and_return(ibft_interfaces)
+      allow(instance).to receive(:firmware_interfaces).and_return(firmware_interfaces)
     end
 
     it "returns false if there is no interface UP" do
@@ -103,8 +103,8 @@ describe Yast::NetworkAutoconfiguration do
     context "when at least one interface is UP" do
       let(:active) { true }
 
-      context "and the interface is configured through iBFT" do
-        let(:ibft_interfaces) { [eth0.name] }
+      context "and the interface is configured through firmware" do
+        let(:firmware_interfaces) { [eth0.name] }
 
         it "returns true" do
           expect(instance.any_iface_active?).to be true
@@ -128,12 +128,12 @@ describe Yast::NetworkAutoconfiguration do
   end
 
   describe "#dhcp_candidate?" do
-    let(:ibft_interfaces) { [] }
+    let(:firmware_interfaces) { [] }
     let(:connected) { true }
     let(:connections) { Y2Network::ConnectionConfigsCollection.new([]) }
 
     before do
-      allow(instance).to receive(:ibft_interfaces).and_return(ibft_interfaces)
+      allow(instance).to receive(:firmware_interfaces).and_return(firmware_interfaces)
       allow(instance).to receive(:phy_connected?).with(eth0.name).and_return(connected)
     end
 
@@ -145,8 +145,8 @@ describe Yast::NetworkAutoconfiguration do
       end
     end
 
-    context "when the given interface is configured by iBFT" do
-      let(:ibft_interfaces) { [eth0.name] }
+    context "when the given interface is configured by firmware" do
+      let(:firmware_interfaces) { [eth0.name] }
 
       it "returns false" do
         expect(instance.dhcp_candidate?(eth0)).to eql(false)

--- a/test/wicked_test.rb
+++ b/test/wicked_test.rb
@@ -80,7 +80,7 @@ describe Yast::Wicked do
 
   describe "#firmware_interfaces" do
     let(:stdout) { instance_double("Yast::Execute") }
-    let(:output) { "ibft    eth1 eth1.10\nibft    eth2 ibft\nnbft    eth3\nredfish usb0 usb0.42" }
+    let(:output) { "ibft    eth1 eth1.10\nibft\teth2 ibft0\nnbft    nbft0\nredfish usb0 usb0.42" }
     let(:ibft_interfaces) { ["eth1", "eth1.10"] }
 
     before do
@@ -91,7 +91,7 @@ describe Yast::Wicked do
 
     it "returns an array of the interfaces configured by firmware" do
       expect(subject.firmware_interfaces)
-        .to eql(["eth1", "eth1.10", "eth2", "ibft", "eth3", "usb0", "usb0.42"])
+        .to eql(["eth1", "eth1.10", "eth2", "ibft0", "nbft0", "usb0", "usb0.42"])
     end
 
     context "when `wicked firmware interfaces` is not present" do

--- a/test/wicked_test.rb
+++ b/test/wicked_test.rb
@@ -80,18 +80,26 @@ describe Yast::Wicked do
 
   describe "#firmware_interfaces" do
     let(:stdout) { instance_double("Yast::Execute") }
+    let(:output) { "ibft    eth1 eth1.10\nibft    eth2 ibft\nnbft    eth3\nredfish usb0 usb0.42" }
+    let(:ibft_interfaces) { ["eth1", "eth1.10"] }
 
     before do
       allow(Yast::Execute).to receive(:stdout).and_return(stdout)
-      allow(stdout).to receive(:locally!).and_return(
-        "ibft    eth1 eth1.10\nibft    eth2 ibft\n" \
-        "nbft    eth3\nredfish usb0 usb0.42"
-      )
+      allow(stdout).to receive(:locally!).and_return(output)
+      allow(subject).to receive(:ibft_interfaces).and_return(ibft_interfaces)
     end
 
     it "returns an array of the interfaces configured by firmware" do
       expect(subject.firmware_interfaces)
         .to eql(["eth1", "eth1.10", "eth2", "ibft", "eth3", "usb0", "usb0.42"])
+    end
+
+    context "when `wicked firmware interfaces` is not present" do
+      let(:output) { "" }
+
+      it "returns the interfaces returned by the ibft extension is available" do
+        expect(subject.firmware_interfaces).to eql(ibft_interfaces)
+      end
     end
   end
 end

--- a/test/wicked_test.rb
+++ b/test/wicked_test.rb
@@ -77,4 +77,21 @@ describe Yast::Wicked do
       expect(subject.ibft_interfaces).to eql(["eth0.42", "eth0", "eth1"])
     end
   end
+
+  describe "#firmware_interfaces" do
+    let(:stdout) { instance_double("Yast::Execute") }
+
+    before do
+      allow(Yast::Execute).to receive(:stdout).and_return(stdout)
+      allow(stdout).to receive(:locally!).and_return(
+        "ibft    eth1 eth1.10\nibft    eth2 ibft\n" \
+        "nbft    eth3\nredfish usb0 usb0.42"
+      )
+    end
+
+    it "returns an array of the interfaces configured by firmware" do
+      expect(subject.firmware_interfaces)
+        .to eql(["eth1", "eth1.10", "eth2", "ibft", "eth3", "usb0", "usb0.42"])
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Similar to #1282 but **YaST** should also skip **DHCP** setup in case that there is some interface configured by firmware **(iBFT, NBFT or Redfish)**.

- https://trello.com/c/eFJXEeep/3274-3-urgent-top-priority-connect-to-nbft-disks
- https://jira.suse.com/browse/PED-967
- https://jira.suse.com/browse/PED-3138

## Solution

When there is some active interface configured by **firmware** **yast2-network** will also skip the **DHCP** setup completely as it was doing when there was some active interface with an ifcfg file.

In case that `wicked firmware` command is not available it will be logged by **Cheetah**, the same happens if the **ibft** extension is not available and for us it will means that there are no firmware configured devices at all.

## Testing

- *Added a new unit test*
- *Tested manually*
