### PR TITLE
Firmware configured interface (bsc#1209589)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,7 +2,7 @@
 Thu May  4 11:21:13 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Display information about firmware configured interfaces and
-  prevent the forbid to edit them (bsc#1209589)
+  forbid editing them (bsc#1209589)
 - 4.5.18
 
 -------------------------------------------------------------------

--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  4 11:21:13 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Display information about firmware configured interfaces and
+  prevent the forbid to edit them (bsc#1209589)
+- 4.5.18
+
+-------------------------------------------------------------------
 Wed Mar  1 14:52:46 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixed a random build failure (introduced by the previous fix for

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.5.17
+Version:        4.5.18
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -146,11 +146,19 @@ module Yast
     end
 
     def edit_interface
-      @edit_interface ||= Y2Network::Widgets::EditInterface.new(interfaces_table)
+      return @edit_interface if @edit_interface
+
+      @edit_interface = Y2Network::Widgets::EditInterface.new(interfaces_table)
+      interfaces_table.add_handler(@edit_interface)
+      @edit_interface
     end
 
     def delete_interface
-      @delete_interface ||= Y2Network::Widgets::DeleteInterface.new(interfaces_table)
+      return @delete_interface if @delete_interface
+
+      @delete_interface = Y2Network::Widgets::DeleteInterface.new(interfaces_table)
+      interfaces_table.add_handler(@delete_interface)
+      @delete_interface
     end
 
     # Commit changes to internal structures

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -112,7 +112,7 @@ module Yast
     #
     # @return [String, nil] Firmware extension used for configuring the interface or nil
     def firmware_configured_by?(interface)
-      firmware_interfaces_by_extension.find { |k, v| v.include?(interface)}&.first
+      firmware_interfaces_by_extension.find { |_, v| v.include?(interface) }&.first
     end
   end
 end

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -84,7 +84,7 @@ module Yast
     #
     # @return [Array <String>] array of interface names
     def ibft_interfaces
-      Yast::Execute.stdout.locally!(IBFT_CMD, "-l").split(/\s+/).uniq
+      @ibft_interfaces ||= Yast::Execute.stdout.locally!(IBFT_CMD, "-l").split(/\s+/).uniq
     end
 
     # Returns an array of interface names which are configured via firmware
@@ -100,17 +100,19 @@ module Yast
     #
     # @return [Hash] configured by firmware interfaces indexed by the firmware extension
     def firmware_interfaces_by_extension
+      return @firmware_interfaces_by_extension if @firmware_interfaces_by_extension
+
       output = Yast::Execute.stdout.locally!(WICKED_PATH, "firmware", "interfaces")
-      output.split("\n").each_with_object({}) do |line, result|
+      @firmware_interfaces_by_extension = output.split("\n").each_with_object({}) do |line, result|
         firmware, *interfaces = line.split(/\s+/)
-        result[firmware] = result.fetch(firmware, []) + interfaces if firmware
+        result[firmware.to_sym] = result.fetch(firmware.to_sym, []) + interfaces if firmware
       end
     end
 
     # Returns the firmware extension used for configuring the given interface or nil when it is not
     # configured by firmware
     #
-    # @return [String, nil] Firmware extension used for configuring the interface or nil
+    # @return [Symbol, nil] Firmware extension used for configuring the interface or nil
     def firmware_configured_by?(interface)
       firmware_interfaces_by_extension.find { |_, v| v.include?(interface) }&.first
     end

--- a/src/lib/network/wicked.rb
+++ b/src/lib/network/wicked.rb
@@ -96,7 +96,10 @@ module Yast
     end
 
     # Returns a hash with each firmware extension as the key and the specific extension
-    # configured interfaces as the value
+    # configured interfaces as an array value
+    #
+    # @example
+    #   Yast::Lan.firmware_interfaces_by_extension => { ibft: ["ibft0"], nbft: ["nbft0"] }
     #
     # @return [Hash] configured by firmware interfaces indexed by the firmware extension
     def firmware_interfaces_by_extension

--- a/src/lib/y2network/interface.rb
+++ b/src/lib/y2network/interface.rb
@@ -49,6 +49,8 @@ module Y2Network
     attr_accessor :renaming_mechanism
     # @return [String,nil]
     attr_reader :old_name
+    # @return [Symbol,nil]
+    attr_accessor :firmware_configured_by
 
     class << self
       # Builds an interface based on a connection
@@ -156,6 +158,11 @@ module Y2Network
       return false unless hardware
 
       ["usb", "pcmcia"].include?(hardware.hotplug)
+    end
+
+    # @return [Boolean] whether the interface is firmware configured or not
+    def firmware_configured?
+      !!firmware_configured_by
     end
   end
 end

--- a/src/lib/y2network/presenters/interface_summary.rb
+++ b/src/lib/y2network/presenters/interface_summary.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "y2network/presenters/interface_status"
+require "network/wicked"
 
 Yast.import "Summary"
 Yast.import "HTML"
@@ -30,6 +31,7 @@ module Y2Network
     class InterfaceSummary
       include Yast::I18n
       include InterfaceStatus
+      include Yast::Wicked
 
       # @return [String]
       attr_reader :name
@@ -102,11 +104,17 @@ module Y2Network
           if hardware&.name && !hardware.name.empty?
             dev_name = _("Device Name: %s") % hardware.name
             rich << Yast::HTML.Bold(dev_name) << "<br>"
-          end
 
-          rich << "<p>"
-          rich << _("The device is not configured. Press <b>Edit</b>\nto configure.\n")
-          rich << "</p>"
+          end
+          extension = firmware_configured_by?(hardware&.name)
+
+          if extension
+            rich << "<p><b>" << _("The device is configured by: ") << "</b>" << extension << "</p>"
+          else
+            rich << "<p>"
+            rich << _("The device is not configured. Press <b>Edit</b>\nto configure.\n")
+            rich << "</p>"
+          end
         end
         rich
       end

--- a/src/lib/y2network/presenters/interface_summary.rb
+++ b/src/lib/y2network/presenters/interface_summary.rb
@@ -19,7 +19,6 @@
 
 require "yast"
 require "y2network/presenters/interface_status"
-require "network/wicked"
 
 Yast.import "Summary"
 Yast.import "HTML"
@@ -31,7 +30,6 @@ module Y2Network
     class InterfaceSummary
       include Yast::I18n
       include InterfaceStatus
-      include Yast::Wicked
 
       # @return [String]
       attr_reader :name
@@ -106,10 +104,10 @@ module Y2Network
             rich << Yast::HTML.Bold(dev_name) << "<br>"
 
           end
-          extension = firmware_configured_by?(hardware&.name)
 
-          if extension
-            rich << "<p><b>" << _("The device is configured by: ") << "</b>" << extension << "</p>"
+          if interface.firmware_configured?
+            rich << "<p><b>" << _("The device is configured by: ") << "</b>"
+            rich << interface.firmware_configured_by.to_s << "</p>"
           else
             rich << "<p>"
             rich << _("The device is not configured. Press <b>Edit</b>\nto configure.\n")

--- a/src/lib/y2network/presenters/interface_summary.rb
+++ b/src/lib/y2network/presenters/interface_summary.rb
@@ -102,18 +102,20 @@ module Y2Network
           if hardware&.name && !hardware.name.empty?
             dev_name = _("Device Name: %s") % hardware.name
             rich << Yast::HTML.Bold(dev_name) << "<br>"
-
           end
 
-          if interface.firmware_configured?
-            rich << "<p><b>" << _("The device is configured by: ") << "</b>"
-            rich << interface.firmware_configured_by.to_s << "</p>"
-          else
+          unless interface.firmware_configured?
             rich << "<p>"
             rich << _("The device is not configured. Press <b>Edit</b>\nto configure.\n")
             rich << "</p>"
           end
         end
+
+        if interface.firmware_configured?
+          rich << "<p><b>" << _("The device is configured by: ") << "</b>"
+          rich << interface.firmware_configured_by.to_s << "</p>"
+        end
+
         rich
       end
 

--- a/src/lib/y2network/wicked/interfaces_reader.rb
+++ b/src/lib/y2network/wicked/interfaces_reader.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "network/wicked"
 require "y2network/interface"
 require "y2network/interface_type"
 require "y2network/virtual_interface"
@@ -40,6 +41,7 @@ module Y2Network
     #
     # @see Y2Network::InterfacesCollection
     class InterfacesReader
+      include Yast::Wicked
       # Returns the collection of s390 group devices
       #
       # @return [Array<Y2Network::ConnectionConfig::Base>] Array of connection
@@ -97,6 +99,7 @@ module Y2Network
           iface.custom_driver = custom_driver_for(iface)
           iface.type = InterfaceType.from_short_name(hwinfo.type) ||
             TypeDetector.type_of(iface.name) || InterfaceType::UNKNOWN
+          iface.firmware_configured_by = firmware_configured_by?(iface.name)
         end
       end
 

--- a/src/lib/y2network/widgets/boot_protocol.rb
+++ b/src/lib/y2network/widgets/boot_protocol.rb
@@ -51,11 +51,6 @@ module Y2Network
                   Opt(:notify),
                   _("No Link and IP Setup (Bond Ports)")
                 ),
-                HSpacing(1),
-                ReplacePoint(
-                  Id(:bootproto_rp),
-                  CheckBox(Id(:bootproto_ibft), Opt(:notify), _("Use iBFT Values"))
-                )
               )
             ),
             Left(
@@ -106,19 +101,7 @@ module Y2Network
         )
       end
 
-      def ibft_available?
-        # IBFT only for eth, is it correct?
-        @settings.type.ethernet?
-      end
-
       def init
-        if !ibft_available?
-          Yast::UI.ReplaceWidget(
-            :bootproto_rp,
-            Empty()
-          )
-        end
-
         case @settings.boot_protocol
         when Y2Network::BootProtocol::STATIC
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_static)
@@ -159,7 +142,6 @@ module Y2Network
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_none)
         when Y2Network::BootProtocol::IBFT
           Yast::UI.ChangeWidget(Id(:bootproto), :CurrentButton, :bootproto_none)
-          Yast::UI.ChangeWidget(Id(:bootproto_ibft), :Value, true)
         end
 
         handle
@@ -170,7 +152,6 @@ module Y2Network
         when :bootproto_static
           static_enabled(true)
           dynamic_enabled(false)
-          none_enabled(false)
           one_ip = Yast::UI.QueryWidget(Id(:bootproto_ipaddr), :Value)
           if one_ip.empty?
             current_hostname = Yast::Hostname.MergeFQ(Yast::DNS.hostname, Yast::DNS.domain)
@@ -182,11 +163,9 @@ module Y2Network
         when :bootproto_dynamic
           static_enabled(false)
           dynamic_enabled(true)
-          none_enabled(false)
         when :bootproto_none
           static_enabled(false)
           dynamic_enabled(false)
-          none_enabled(true)
         else
           raise "Unexpected value for boot protocol #{value.inspect}"
         end
@@ -201,9 +180,6 @@ module Y2Network
         case value
         when :bootproto_none
           bootproto = "none"
-          if ibft_available?
-            bootproto = Yast::UI.QueryWidget(Id(:bootproto_ibft), :Value) ? "ibft" : "none"
-          end
           @settings.boot_protocol = bootproto
         when :bootproto_static
           @settings.boot_protocol = "static"
@@ -297,13 +273,6 @@ module Y2Network
             "to assign an IP address to this device.\n" \
             "This is particularly useful for bonding ethernet devices.</p>\n"
         ) +
-          # FIXME: old CWM does not allow this, but for future this should be dynamic and
-          # printed only if iBFT is available
-          # and future means when type cannot be changed and when cwm object tabs are used,
-          # as it has limited lifetime of cwm definition
-          _(
-            "<p>Check <b>iBFT</b> if you want to keep the network configured in your BIOS.</p>\n"
-          ) +
           # Address dialog help 2/8
           _(
             "<p>Select <b>Dynamic Address</b> if you do not have a static IP address \n" \
@@ -345,10 +314,6 @@ module Y2Network
         else
           Yast::UI.ChangeWidget(Id(:bootproto_dhcp_mode), :Enabled, value)
         end
-      end
-
-      def none_enabled(value)
-        Yast::UI.ChangeWidget(Id(:bootproto_ibft), :Enabled, value) if ibft_available?
       end
 
       def static_enabled(value)

--- a/src/lib/y2network/widgets/boot_protocol.rb
+++ b/src/lib/y2network/widgets/boot_protocol.rb
@@ -50,7 +50,7 @@ module Y2Network
                   Id(:bootproto_none),
                   Opt(:notify),
                   _("No Link and IP Setup (Bond Ports)")
-                ),
+                )
               )
             ),
             Left(

--- a/src/lib/y2network/widgets/delete_interface.rb
+++ b/src/lib/y2network/widgets/delete_interface.rb
@@ -17,35 +17,19 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "yast"
-require "cwm/common_widgets"
+require "y2network/widgets/interface_button"
 require "yast2/popup"
 
-Yast.import "Label"
-Yast.import "Lan"
 Yast.import "Popup"
 
 module Y2Network
   module Widgets
-    class DeleteInterface < CWM::PushButton
-      # @param table [InterfacesTable]
-      def initialize(table)
-        textdomain "network"
-        @table = table
-      end
-
+    class DeleteInterface < InterfaceButton
       def label
         Yast::Label.DeleteButton
       end
 
-      # @see CWM::AbstractWidget#init
-      def init
-        disable unless @table.value
-      end
-
       def handle
-        config = Yast::Lan.yast_config
-        connection_config = config.connections.by_name(@table.value)
         return nil unless connection_config # unconfigured physical device. Delete do nothing
 
         if connection_config.startmode.name == "nfsroot"

--- a/src/lib/y2network/widgets/delete_interface.rb
+++ b/src/lib/y2network/widgets/delete_interface.rb
@@ -25,6 +25,14 @@ Yast.import "Popup"
 module Y2Network
   module Widgets
     class DeleteInterface < InterfaceButton
+      # Constructor
+      #
+      # @param table [InterfacesTable]
+      def initialize(table)
+        textdomain "network"
+        super(table)
+      end
+
       def label
         Yast::Label.DeleteButton
       end

--- a/src/lib/y2network/widgets/delete_interface.rb
+++ b/src/lib/y2network/widgets/delete_interface.rb
@@ -68,6 +68,13 @@ module Y2Network
         :redraw
       end
 
+      def disable?
+        return true unless @table.value
+        return true unless connection_config
+
+        false
+      end
+
       def help
         # TRANSLATORS: Help for 'Delete' interface configuration button.
         _(

--- a/src/lib/y2network/widgets/edit_interface.rb
+++ b/src/lib/y2network/widgets/edit_interface.rb
@@ -50,17 +50,9 @@ module Y2Network
 
       def disable?
         return true unless @table.value
+        return true if config.interfaces.by_name(@table.value)&.firmware_configured?
 
-        configured_by_firmware?
-      end
-
-      def configured_by_firmware?
-        return false if connection_config
-        return false unless config.backend?(:wicked)
-
-        require "network/wicked"
-        singleton_class.include Yast::Wicked
-        firmware_interfaces.include?(@table.value)
+        false
       end
 
       def help

--- a/src/lib/y2network/widgets/edit_interface.rb
+++ b/src/lib/y2network/widgets/edit_interface.rb
@@ -22,6 +22,14 @@ require "y2network/widgets/interface_button"
 module Y2Network
   module Widgets
     class EditInterface < InterfaceButton
+      # Constructor
+      #
+      # @param table [InterfacesTable]
+      def initialize(table)
+        textdomain "network"
+        super(table)
+      end
+
       def label
         Yast::Label.EditButton
       end

--- a/src/lib/y2network/widgets/interface_button.rb
+++ b/src/lib/y2network/widgets/interface_button.rb
@@ -1,0 +1,71 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+require "abstract_method"
+require "y2network/sequences/interface"
+require "y2network/s390_group_device"
+require "y2network/dialogs/s390_device_activation"
+
+Yast.import "Label"
+Yast.import "Lan"
+
+module Y2Network
+  module Widgets
+    class InterfaceButton < CWM::PushButton
+      include Yast::Logger
+
+      abstract_method :label
+      abstract_method :help
+      # @param table [InterfacesTable]
+      def initialize(table)
+        textdomain "network"
+
+        @table = table
+      end
+
+      # @see CWM::AbstractWidget#init
+      def init
+        disable? ? disable : enable
+      end
+
+      def config
+        Yast::Lan.yast_config
+      end
+
+      def connection_config
+        config.connections.by_name(@table.value)
+      end
+
+      def item
+        connection_config || selected_interface(config)
+      end
+
+      def selected_interface(config)
+        config.interfaces.by_name(@table.value) || config.s390_devices.by_id(@table.value)
+      end
+
+      def disable?
+        return true unless @table.value
+        return true unless connection_config
+      end
+    end
+  end
+end

--- a/src/lib/y2network/widgets/interface_button.rb
+++ b/src/lib/y2network/widgets/interface_button.rb
@@ -63,8 +63,7 @@ module Y2Network
       end
 
       def disable?
-        return true unless @table.value
-        return true unless connection_config
+        false
       end
     end
   end

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -101,7 +101,7 @@ module Y2Network
     private
 
       def refresh_handlers
-        @handlers.each { |h| h.init }
+        @handlers.each(&:init)
       end
 
       def note(interface, conn)

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -19,7 +19,6 @@
 
 require "yast"
 require "cwm/table"
-require "network/wicked"
 require "y2network/presenters/interface_summary"
 require "y2network/presenters/s390_group_device_summary"
 
@@ -30,8 +29,6 @@ Yast.import "UI"
 module Y2Network
   module Widgets
     class InterfacesTable < CWM::Table
-      include Yast::Wicked
-
       def initialize(description)
         textdomain "network"
 
@@ -140,7 +137,7 @@ module Y2Network
       end
 
       def interface_protocol(connection)
-        return _("Not Configured") if connection.nil?
+        return _("Not configured") if connection.nil?
 
         bootproto = connection.bootproto.name
 
@@ -155,7 +152,7 @@ module Y2Network
       def configuration_for(interface, connection)
         return interface_protocol(connection) unless connection.nil?
 
-        firmware_configured?(interface) ? _("Configured by firmware") : _("Not Configured")
+        interface.firmware_configured? ? _("Configured by firmware") : _("Not configured")
       end
 
       def selected_item

--- a/test/wicked_test.rb
+++ b/test/wicked_test.rb
@@ -107,6 +107,11 @@ describe Yast::Wicked do
     let(:stdout) { instance_double("Yast::Execute") }
     let(:output) { "ibft    eth1 eth1.10\nibft\teth2 ibft0\nnbft    nbft0\nredfish usb0 usb0.42" }
     let(:ibft_interfaces) { ["eth1", "eth1.10"] }
+    let(:interfaces_by_extension) do
+      { "ibft"    => ["eth1", "eth1.10", "eth2", "ibft0"],
+        "nbft"    => ["nbft0"],
+        "redfish" => ["usb0", "usb0.42"] }
+    end
 
     before do
       allow(Yast::Execute).to receive(:stdout).and_return(stdout)
@@ -115,11 +120,7 @@ describe Yast::Wicked do
     end
 
     it "returns an array of the interfaces configured by firmware" do
-      expect(subject.firmware_interfaces_by_extension).to eql(
-        { "ibft" => ["eth1", "eth1.10", "eth2", "ibft0"],
-          "nbft" => ["nbft0"],
-          "redfish" => ["usb0", "usb0.42"]}
-      )
+      expect(subject.firmware_interfaces_by_extension).to eql(interfaces_by_extension)
     end
 
     context "when `wicked firmware interfaces` is not present" do

--- a/test/wicked_test.rb
+++ b/test/wicked_test.rb
@@ -102,4 +102,60 @@ describe Yast::Wicked do
       end
     end
   end
+
+  describe "#firmware_interfaces_by_extension" do
+    let(:stdout) { instance_double("Yast::Execute") }
+    let(:output) { "ibft    eth1 eth1.10\nibft\teth2 ibft0\nnbft    nbft0\nredfish usb0 usb0.42" }
+    let(:ibft_interfaces) { ["eth1", "eth1.10"] }
+
+    before do
+      allow(Yast::Execute).to receive(:stdout).and_return(stdout)
+      allow(stdout).to receive(:locally!).and_return(output)
+      allow(subject).to receive(:ibft_interfaces).and_return(ibft_interfaces)
+    end
+
+    it "returns an array of the interfaces configured by firmware" do
+      expect(subject.firmware_interfaces_by_extension).to eql(
+        { "ibft" => ["eth1", "eth1.10", "eth2", "ibft0"],
+          "nbft" => ["nbft0"],
+          "redfish" => ["usb0", "usb0.42"]}
+      )
+    end
+
+    context "when `wicked firmware interfaces` is not present" do
+      let(:output) { "" }
+
+      it "returns an empty hash" do
+        expect(subject.firmware_interfaces_by_extension).to eql({})
+      end
+    end
+  end
+
+  describe "#firmware_configured_by?" do
+    let(:stdout) { instance_double("Yast::Execute") }
+    let(:output) { "ibft    eth1 eth1.10\nibft\teth2 ibft0\nnbft    nbft0\nredfish usb0 usb0.42" }
+    let(:ibft_interfaces) { ["eth1", "eth1.10"] }
+
+    before do
+      allow(Yast::Execute).to receive(:stdout).and_return(stdout)
+      allow(stdout).to receive(:locally!).and_return(output)
+      allow(subject).to receive(:ibft_interfaces).and_return(ibft_interfaces)
+    end
+
+    it "returns an array of the interfaces configured by firmware" do
+      expect(subject.firmware_configured_by?("nbft0")).to eql("nbft")
+      expect(subject.firmware_configured_by?("eth1.10")).to eql("ibft")
+      expect(subject.firmware_configured_by?("usb0.42")).to eql("redfish")
+      expect(subject.firmware_configured_by?("wlan0")).to be_nil
+    end
+
+    context "when `wicked firmware interfaces` is not present" do
+      let(:output) { "" }
+
+      it "returns an empty hash" do
+        expect(subject.firmware_interfaces_by_extension).to eql({})
+      end
+    end
+  end
+
 end

--- a/test/wicked_test.rb
+++ b/test/wicked_test.rb
@@ -51,7 +51,7 @@ describe Yast::Wicked do
   describe "#parse_ntp_servers" do
     before do
       allow(Yast::NetworkService).to receive(:is_wicked).and_return(true)
-      allow(::File).to receive(:file?).and_return(true, false)
+      allow(File).to receive(:file?).and_return(true, false)
       allow(Yast::SCR).to receive("Execute").and_return("stdout" => <<~WICKED_OUTPUT
         10.100.2.10
         10.100.2.11
@@ -108,9 +108,9 @@ describe Yast::Wicked do
     let(:output) { "ibft    eth1 eth1.10\nibft\teth2 ibft0\nnbft    nbft0\nredfish usb0 usb0.42" }
     let(:ibft_interfaces) { ["eth1", "eth1.10"] }
     let(:interfaces_by_extension) do
-      { "ibft"    => ["eth1", "eth1.10", "eth2", "ibft0"],
-        "nbft"    => ["nbft0"],
-        "redfish" => ["usb0", "usb0.42"] }
+      { ibft:    ["eth1", "eth1.10", "eth2", "ibft0"],
+        nbft:    ["nbft0"],
+        redfish: ["usb0", "usb0.42"] }
     end
 
     before do
@@ -144,9 +144,9 @@ describe Yast::Wicked do
     end
 
     it "returns an array of the interfaces configured by firmware" do
-      expect(subject.firmware_configured_by?("nbft0")).to eql("nbft")
-      expect(subject.firmware_configured_by?("eth1.10")).to eql("ibft")
-      expect(subject.firmware_configured_by?("usb0.42")).to eql("redfish")
+      expect(subject.firmware_configured_by?("nbft0")).to eql(:nbft)
+      expect(subject.firmware_configured_by?("eth1.10")).to eql(:ibft)
+      expect(subject.firmware_configured_by?("usb0.42")).to eql(:redfish)
       expect(subject.firmware_configured_by?("wlan0")).to be_nil
     end
 

--- a/test/y2network/presenters/interface_summary_test.rb
+++ b/test/y2network/presenters/interface_summary_test.rb
@@ -40,9 +40,11 @@ describe Y2Network::Presenters::InterfaceSummary do
   let(:interfaces) do
     Y2Network::InterfacesCollection.new(
       [
-        double(Y2Network::Interface, hardware: nil, name: "vlan1"),
-        double(Y2Network::Interface, hardware: double.as_null_object, name: "eth1"),
-        double(Y2Network::Interface, hardware: double.as_null_object, name: "eth0")
+        double(Y2Network::Interface, hardware: nil, name: "vlan1", firmware_configured?: false),
+        double(Y2Network::Interface, hardware: double.as_null_object, name: "eth1",
+          firmware_configured?: false),
+        double(Y2Network::Interface, hardware: double.as_null_object, name: "eth0",
+          firmware_configured?: false)
       ]
     )
   end
@@ -75,7 +77,7 @@ describe Y2Network::Presenters::InterfaceSummary do
   describe "#text" do
     it "returns a summary in text form" do
       text = presenter.text
-      expect(text).to be_a(::String)
+      expect(text).to be_a(String)
     end
 
     context "when a remote IP address is configured" do

--- a/test/y2network/wicked/interfaces_reader_test.rb
+++ b/test/y2network/wicked/interfaces_reader_test.rb
@@ -103,6 +103,20 @@ describe Y2Network::Wicked::InterfacesReader do
     it "reads bonding interfaces"
     it "reads interfaces configuration"
 
+    context "when the interface is configured by hardware" do
+      let(:firmware_interfaces ) { { :ibft => ["eth0"] } }
+
+      before do
+        allow(reader).to receive(:firmware_interfaces_by_extension).and_return(firmware_interfaces)
+      end
+
+      it "sets the extensions used for the configuring it" do
+        eth0 = reader.interfaces.by_name("eth0")
+        expect(eth0.firmware_configured_by).to eql(:ibft)
+        expect(eth0.firmware_configured?).to eql(true)
+      end
+    end
+
     context "when a physical interface type is unknown" do
       before do
         allow(Yast::SCR).to receive(:Dir).with(Yast::Path.new(".network.section"))

--- a/test/y2network/wicked/interfaces_reader_test.rb
+++ b/test/y2network/wicked/interfaces_reader_test.rb
@@ -104,7 +104,7 @@ describe Y2Network::Wicked::InterfacesReader do
     it "reads interfaces configuration"
 
     context "when the interface is configured by hardware" do
-      let(:firmware_interfaces ) { { :ibft => ["eth0"] } }
+      let(:firmware_interfaces) { { ibft: ["eth0"] } }
 
       before do
         allow(reader).to receive(:firmware_interfaces_by_extension).and_return(firmware_interfaces)

--- a/test/y2network/widgets/boot_protocol_test.rb
+++ b/test/y2network/widgets/boot_protocol_test.rb
@@ -40,16 +40,6 @@ describe Y2Network::Widgets::BootProtocol do
   end
 
   describe "#init" do
-    context "for other types then eth" do
-      let(:builder) { Y2Network::InterfaceConfigBuilder.for("br") }
-
-      it "hides iBFT checkbox" do
-        expect(Yast::UI).to receive(:ReplaceWidget).with(:bootproto_rp, Empty())
-
-        subject.init
-      end
-    end
-
     context "static configuration" do
       before do
         builder.boot_protocol = "static"
@@ -169,17 +159,7 @@ describe Y2Network::Widgets::BootProtocol do
     context "none configuration selected" do
       let(:value) { "none" }
 
-      it "sets bootproto to ibft if ibft is selected" do
-        allow(Yast::UI).to receive(:QueryWidget).with(Id(:bootproto_ibft), :Value).and_return(true)
-
-        subject.store
-
-        expect(builder.boot_protocol.name).to eq "ibft"
-      end
-
       it "sets bootproto to none if ibft is not selected" do
-        allow(Yast::UI).to receive(:QueryWidget).with(Id(:bootproto_ibft), :Value).and_return(false)
-
         subject.store
 
         expect(builder.boot_protocol.name).to eq "none"

--- a/test/y2network/widgets/delete_interface_test.rb
+++ b/test/y2network/widgets/delete_interface_test.rb
@@ -34,7 +34,9 @@ describe Y2Network::Widgets::DeleteInterface do
   let(:eth0) { Y2Network::Interface.new("eth0") }
   let(:br0) { Y2Network::VirtualInterface.new("br0", type: Y2Network::InterfaceType::BRIDGE) }
   let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, br0]) }
-  let(:connections) { Y2Network::ConnectionConfigsCollection.new([eth0_conn, br0_conn]) }
+  let(:conn_collection) { [eth0_conn, br0_conn] }
+  let(:connections) { Y2Network::ConnectionConfigsCollection.new(conn_collection) }
+
   let(:eth0_conn) do
     Y2Network::ConnectionConfig::Ethernet.new.tap do |c|
       c.name = "eth0"
@@ -64,6 +66,15 @@ describe Y2Network::Widgets::DeleteInterface do
       it "does not disable the widget" do
         expect(subject).to_not receive(:disable)
         subject.init
+      end
+
+      context "but it is not configured" do
+        let(:conn_collection) { [] }
+
+        it "disables the widget" do
+          expect(subject).to receive(:disable)
+          subject.init
+        end
       end
     end
 

--- a/test/y2network/widgets/edit_interface_test.rb
+++ b/test/y2network/widgets/edit_interface_test.rb
@@ -32,7 +32,11 @@ describe Y2Network::Widgets::EditInterface do
     Y2Network::Config.new(interfaces: interfaces, connections: connections, source: :wicked)
   end
   let(:eth0) { Y2Network::PhysicalInterface.new("eth0") }
-  let(:eth1) { Y2Network::PhysicalInterface.new("eth1") }
+  let(:eth1) do
+    Y2Network::PhysicalInterface.new("eth1").tap do |i|
+      i.firmware_configured_by = :nbft
+    end
+  end
   let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, eth1]) }
   let(:eth0_conn) do
     Y2Network::ConnectionConfig::Ethernet.new.tap do |conn|
@@ -51,14 +55,34 @@ describe Y2Network::Widgets::EditInterface do
 
   describe "#init" do
     context "when an element is selected" do
-      it "does not disable the widget" do
-        expect(subject).to_not receive(:disable)
-        subject.init
+      context "and the selected interface is configured by firmware" do
+        let(:selected) { "eth1" }
+
+        it "disables the widget" do
+          expect(subject).to receive(:disable)
+          subject.init
+        end
+      end
+
+      context "and the selected interface is not configured by firmware" do
+        it "does not disable the widget" do
+          expect(subject).to_not receive(:disable)
+          subject.init
+        end
       end
     end
 
     context "when no element is selected" do
       let(:selected) { nil }
+
+      it "disables the widget" do
+        expect(subject).to receive(:disable)
+        subject.init
+      end
+    end
+
+    context "when the selected interface is configured by firmware" do
+      let(:selected) { "eth1" }
 
       it "disables the widget" do
         expect(subject).to receive(:disable)

--- a/test/y2network/widgets/interfaces_table_test.rb
+++ b/test/y2network/widgets/interfaces_table_test.rb
@@ -31,10 +31,13 @@ describe Y2Network::Widgets::InterfacesTable do
   let(:description) { double(:value= => nil) }
 
   let(:eth0) do
-    instance_double(Y2Network::Interface, name: "eth0", hardware: hwinfo, old_name: "eth1")
+    instance_double(Y2Network::Interface, name: "eth0", hardware: hwinfo, old_name: "eth1",
+      firmware_configured_by: nil, firmware_configured?: false)
   end
+
   let(:br0) do
-    instance_double(Y2Network::VirtualInterface, name: "br0", hardware: nil, old_name: nil)
+    instance_double(Y2Network::VirtualInterface, name: "br0", hardware: nil, old_name: nil,
+      firmware_configured_by: nil, firmware_configured?: false)
   end
   let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, br0]) }
   let(:hwinfo) do
@@ -176,6 +179,18 @@ describe Y2Network::Widgets::InterfacesTable do
 
       it "includes a warning in the description" do
         expect(description).to receive(:value=).with(/The device is not configured./)
+        subject.handle
+      end
+    end
+
+    context "when the device is configured by hardware" do
+      let(:eth0) do
+        instance_double(Y2Network::Interface, name: "eth0", hardware: hwinfo, old_name: "eth1",
+          firmware_configured_by: :redfish, firmware_configured?: true)
+      end
+
+      it "shows which firmware extension configured the device in the description" do
+        expect(description).to receive(:value=).with(/configured by: <\/b>redfish/)
         subject.handle
       end
     end


### PR DESCRIPTION
## Problem

When an interface is configured by firmware there is no information in the description allowing also to configure it through the UI which could be problematic therefore the buttons should be disabled in order to prevent the user to shoot himself in the foot.

- [*bsc=1209589*](https://bugzilla.suse.com/show_bug.cgi?id=1209589)
- [*PBI*](https://trello.com/c/2AmgYNN6)


## Solution

1. The description of the selected interface will show information about the extension used for configuring it by firmware. 
2. The edit button will be disabled in case of configured by firmware
3. As a plus task the delete button will be disabled in case of not configured or configured by firmware interface.

## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

![Screenshot from 2023-05-04 09-30-20](https://user-images.githubusercontent.com/7056681/236188147-7df4da1f-4d87-434f-b6b0-49c4df993523.png)
