### PR TITLE
Summary fix when no interfaces are present in the system (bsc#1211161)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May  8 09:07:07 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix summary crash when there is no interface available
+  (bsc#1209589, bsc#1211161).
+- 4.5.19
+
+-------------------------------------------------------------------
 Thu May  4 11:21:13 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Display information about firmware configured interfaces and

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.5.18
+Version:        4.5.19
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/presenters/interface_summary.rb
+++ b/src/lib/y2network/presenters/interface_summary.rb
@@ -45,6 +45,8 @@ module Y2Network
       end
 
       def text
+        return "" if @name.to_s.empty?
+
         interface = @config.interfaces.by_name(@name)
         hardware = interface ? interface.hardware : nil
         descr = hardware ? hardware.description : ""
@@ -104,7 +106,7 @@ module Y2Network
             rich << Yast::HTML.Bold(dev_name) << "<br>"
           end
 
-          unless interface&.firmware_configured?
+          if interface && !interface.firmware_configured?
             rich << "<p>"
             rich << _("The device is not configured. Press <b>Edit</b>\nto configure.\n")
             rich << "</p>"

--- a/src/lib/y2network/presenters/interface_summary.rb
+++ b/src/lib/y2network/presenters/interface_summary.rb
@@ -104,14 +104,14 @@ module Y2Network
             rich << Yast::HTML.Bold(dev_name) << "<br>"
           end
 
-          unless interface.firmware_configured?
+          unless interface&.firmware_configured?
             rich << "<p>"
             rich << _("The device is not configured. Press <b>Edit</b>\nto configure.\n")
             rich << "</p>"
           end
         end
 
-        if interface.firmware_configured?
+        if interface&.firmware_configured?
           rich << "<p><b>" << _("The device is configured by: ") << "</b>"
           rich << interface.firmware_configured_by.to_s << "</p>"
         end

--- a/src/lib/y2network/widgets/interfaces_table.rb
+++ b/src/lib/y2network/widgets/interfaces_table.rb
@@ -165,6 +165,8 @@ module Y2Network
 
       def create_description
         summary = Presenters.const_get("#{summary_class_name}Summary")
+        return "" if value.to_s.empty?
+
         summary.new(value, config).text
       end
 

--- a/test/y2network/presenters/interface_summary_test.rb
+++ b/test/y2network/presenters/interface_summary_test.rb
@@ -76,8 +76,15 @@ describe Y2Network::Presenters::InterfaceSummary do
 
   describe "#text" do
     it "returns a summary in text form" do
-      text = presenter.text
-      expect(text).to be_a(String)
+      expect(presenter.text).to be_a(String)
+    end
+
+    context "when an empty name is given" do
+      let(:name) { "" }
+
+      it "returns an empty text" do
+        expect(presenter.text).to eql("")
+      end
     end
 
     context "when a remote IP address is configured" do


### PR DESCRIPTION
## Problem

When there are no interfaces at all the description of the selected one is still set which ends with a crash error introduced by #1327 

*Short description of the original problem.*

- [*bsc#1211161*](https://bugzilla.suse.com/show_bug.cgi?id=1211161)
- *[openQA link](https://openqa.opensuse.org/tests/3271807/modules/network_configuration/steps/2)*

## Solution

Do not set the description when there are no interfaces present on the system and only show the edit link when there is an interface.

## Testing

- *Added unit test*
- *Tested manually*

## Screenshots

| Before #1327  | with the provided fix |
| --- | --- |
| ![Screenshot from 2023-05-08 11-55-28](https://user-images.githubusercontent.com/7056681/236806868-13c1666d-12fb-4860-99eb-e5ad01bb1422.png) | ![No description interfaces table](https://user-images.githubusercontent.com/7056681/236791104-3bbfb686-0d86-4deb-8f6e-3501050a272f.png) |
