### PR TITLE
Do not set EAP auth when EAP mode is TLS (bsc#1211026) (master)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 10 07:29:32 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not write the EAP auth attribute when writing a wireless
+  wicked configuration using the EAP mode as TLS (bsc#1211026)
+- 4.6.3
+
+-------------------------------------------------------------------
 Mon May  8 09:07:07 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix summary crash when there is no interface available

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.6.2
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/wicked/connection_config_writers/wireless.rb
+++ b/src/lib/y2network/wicked/connection_config_writers/wireless.rb
@@ -60,7 +60,7 @@ module Y2Network
         # @param conn [Y2Network::ConnectionConfig::Base] Configuration to write
         def write_eap_auth_settings(conn)
           file.wireless_eap_mode = conn.eap_mode
-          file.wireless_eap_auth = conn.eap_auth
+          file.wireless_eap_auth = conn.eap_auth unless conn.eap_mode == "TLS"
           file.wireless_wpa_password = conn.wpa_password
           file.wireless_wpa_identity = conn.wpa_identity
           file.wireless_ca_cert = conn.ca_cert

--- a/test/y2network/wicked/connection_config_writers/wireless_test.rb
+++ b/test/y2network/wicked/connection_config_writers/wireless_test.rb
@@ -124,6 +124,18 @@ describe Y2Network::Wicked::ConnectionConfigWriters::Wireless do
         wireless_wpa_password: "example_passwd"
       )
     end
+
+    context "when the EAP mode is set to TLS" do
+      it "does not set the EAP auth" do
+        conn.eap_mode = "TLS"
+        handler.write(conn)
+        expect(file).to have_attributes(
+          wireless_auth_mode: "eap",
+          wireless_eap_mode:  "TLS",
+          wireless_eap_auth:  nil
+        )
+      end
+    end
   end
 
   context "WPA-PSK network configuration" do


### PR DESCRIPTION
It merges #1332 into master