### PR TITLE
doc/autoinstallation.md: Add quotes in keep_install_network example

### DIFF
--- a/doc/autoinstallation.md
+++ b/doc/autoinstallation.md
@@ -93,7 +93,7 @@ networking section is the same as:
 
 ```xml
 <networking>
-  <keep_install_network config:type=boolean>true</keep_install_network>
+  <keep_install_network config:type="boolean">true</keep_install_network>
 </networking>
 ```
 


### PR DESCRIPTION
The config type of keep_install_network needs to be quoted for valid XML.
