### PR TITLE
Installation crashes when writing VLAN configuration into NetworkManager

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jun 13 12:11:42 UTC 2023 - Michal Filka <mfilka@suse.com>
+
+- bsc#1211431
+  - Do not crash installation when storing vlan configuration into
+    NetworkManager
+- 4.3.87
+
+-------------------------------------------------------------------
 Thu Sep 29 09:15:47 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixed issue when writing the NetworkManager config without a

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.86
+Version:        4.3.87
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/network_manager/connection_config_writers/vlan.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/vlan.rb
@@ -28,7 +28,7 @@ module Y2Network
         # @see Y2Network::ConnectionConfigWriters::Base#update_file
         # @param conn [Y2Network::ConnectionConfig::Vlan] Configuration to write
         def update_file(conn)
-          file.vlan["id"] = conn.vlan_id
+          file.vlan["id"] = conn.vlan_id.to_s
           file.vlan["parent"] = conn.parent_device
           file.vlan["type"] = "vlan"
         end

--- a/test/y2network/network_manager/connection_config_writers/vlan_test.rb
+++ b/test/y2network/network_manager/connection_config_writers/vlan_test.rb
@@ -1,0 +1,45 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "y2network/network_manager/connection_config_writers/vlan"
+require "cfa/nm_connection"
+require "y2network/boot_protocol"
+require "y2network/startmode"
+require "y2network/connection_config/vlan"
+
+describe Y2Network::NetworkManager::ConnectionConfigWriters::Vlan do
+  subject(:handler) { described_class.new(file) }
+  let(:file) { CFA::NmConnection.new("bond0.nm_connection") }
+
+  let(:conn) do
+    Y2Network::ConnectionConfig::Vlan.new.tap do |c|
+      c.interface = "eth0.1006"
+      c.vlan_id = 1006
+    end
+  end
+
+  describe "#write" do
+    it "sets device and IP relevant attributes" do
+      handler.write(conn)
+      expect(file.vlan["type"]).to eql("vlan")
+      expect(file.vlan["id"]).to eql("1006")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Installation crashed when installing MicroOS (5.3) with configured vlan.

This bug is not MicroOS specific. First crucial prerequisite for the bug to happen was that target was configured to use NetworkManager as network service. The issue happened in test where user connected to installation source via vlan device. The configuration of the device itself is not important. What caused trouble was vlan id. Say you have device eth0.1006 where 1006 is vlan id. At the end of installation when network configuration is being stored installer crashed when writing NetworkManager's configuration via augeas to the target.

- [bsc#1211431](https://bugzilla.suse.com/show_bug.cgi?id=1211431)


## Solution

Problem was caused by storing vlan id in wrong format. YaST passed integer where String was expected

## Testing

- Tested manually
- Tested by the security team

