### PR TITLE
Fix typo when writing a wireless channel SLE-15-SP3

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul  4 11:31:05 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix typo when writing the wireless channel (bsc#1212976)
+- 4.3.88
+
+-------------------------------------------------------------------
 Tue Jun 13 12:11:42 UTC 2023 - Michal Filka <mfilka@suse.com>
 
 - bsc#1211431

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.3.87
+Version:        4.3.88
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
@@ -33,7 +33,7 @@ module Y2Network
           file.connection["type"] = "wifi"
           file.wifi["ssid"] = conn.essid unless conn.essid.to_s.empty?
           file.wifi["mode"] = MODE[conn.mode] || DEFAULT_MODE
-          file.wifi["channel"] = con.channel if conn.channel
+          file.wifi["channel"] = conn.channel.to_s if conn.channel
 
           write_auth_settings(conn)
         end

--- a/test/y2network/network_manager/connection_config_writers/wireless_test.rb
+++ b/test/y2network/network_manager/connection_config_writers/wireless_test.rb
@@ -39,6 +39,7 @@ describe Y2Network::NetworkManager::ConnectionConfigWriters::Wireless do
       c.auth_mode = :open
       c.ap = "00:11:22:33:44:55"
       c.ap_scanmode = 1
+      c.channel = 5
     end
   end
 
@@ -47,6 +48,7 @@ describe Y2Network::NetworkManager::ConnectionConfigWriters::Wireless do
       handler.write(conn)
       expect(file.wifi["ssid"]).to eql(conn.essid)
       expect(file.wifi["mode"]).to eql("infrastructure")
+      expect(file.wifi["channel"]).to eql("5")
       expect(file.ipv4["method"]).to eql("auto")
       expect(file.ipv6["method"]).to eql("auto")
     end


### PR DESCRIPTION
## Problem

There is a typo which breaks the wireless network manager writer when an specific wireless channel is specified.

- https://bugzilla.suse.com/show_bug.cgi?id=1212976

## Solution

Fixed typo

## Testing

- *Added a new unit test*
