### PR TITLE
Fix typo when writing wireless channel (SLE-15-SP5)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,17 @@
 -------------------------------------------------------------------
+Tue Jul  4 11:31:05 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix typo when writing the wireless channel (bsc#1212976)
+- 4.5.21
+
+-------------------------------------------------------------------
+Tue Jun 13 12:11:42 UTC 2023 - Michal Filka <mfilka@suse.com>
+
+- bsc#1211431
+  - Do not crash installation when storing vlan configuration into
+    NetworkManager
+
+-------------------------------------------------------------------
 Wed May 10 07:29:32 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not write the EAP auth attribute when writing a wireless

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.5.20
+Version:        4.5.21
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
+++ b/src/lib/y2network/network_manager/connection_config_writers/wireless.rb
@@ -33,7 +33,7 @@ module Y2Network
           file.connection["type"] = "wifi"
           file.wifi["ssid"] = conn.essid unless conn.essid.to_s.empty?
           file.wifi["mode"] = MODE[conn.mode] || DEFAULT_MODE
-          file.wifi["channel"] = con.channel if conn.channel
+          file.wifi["channel"] = conn.channel.to_s if conn.channel
 
           write_auth_settings(conn)
         end

--- a/test/y2network/network_manager/connection_config_writers/vlan_test.rb
+++ b/test/y2network/network_manager/connection_config_writers/vlan_test.rb
@@ -17,22 +17,29 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2network/network_manager/connection_config_writers/base"
+require_relative "../../../test_helper"
+require "y2network/network_manager/connection_config_writers/vlan"
+require "cfa/nm_connection"
+require "y2network/boot_protocol"
+require "y2network/startmode"
+require "y2network/connection_config/vlan"
 
-module Y2Network
-  module NetworkManager
-    module ConnectionConfigWriters
-      # This class is responsible for writing the information from a ConnectionConfig::Vlan
-      # object to the underlying system.
-      class Vlan < Base
-        # @see Y2Network::ConnectionConfigWriters::Base#update_file
-        # @param conn [Y2Network::ConnectionConfig::Vlan] Configuration to write
-        def update_file(conn)
-          file.vlan["id"] = conn.vlan_id.to_s
-          file.vlan["parent"] = conn.parent_device
-          file.vlan["type"] = "vlan"
-        end
-      end
+describe Y2Network::NetworkManager::ConnectionConfigWriters::Vlan do
+  subject(:handler) { described_class.new(file) }
+  let(:file) { CFA::NmConnection.new("bond0.nm_connection") }
+
+  let(:conn) do
+    Y2Network::ConnectionConfig::Vlan.new.tap do |c|
+      c.interface = "eth0.1006"
+      c.vlan_id = 1006
+    end
+  end
+
+  describe "#write" do
+    it "sets VLAN device attributes" do
+      handler.write(conn)
+      expect(file.vlan["type"]).to eql("vlan")
+      expect(file.vlan["id"]).to eql("1006")
     end
   end
 end

--- a/test/y2network/network_manager/connection_config_writers/vlan_test.rb
+++ b/test/y2network/network_manager/connection_config_writers/vlan_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2023] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/test/y2network/network_manager/connection_config_writers/wireless_test.rb
+++ b/test/y2network/network_manager/connection_config_writers/wireless_test.rb
@@ -39,6 +39,7 @@ describe Y2Network::NetworkManager::ConnectionConfigWriters::Wireless do
       c.auth_mode = :open
       c.ap = "00:11:22:33:44:55"
       c.ap_scanmode = 1
+      c.channel = 5
     end
   end
 
@@ -47,6 +48,7 @@ describe Y2Network::NetworkManager::ConnectionConfigWriters::Wireless do
       handler.write(conn)
       expect(file.wifi["ssid"]).to eql(conn.essid)
       expect(file.wifi["mode"]).to eql("infrastructure")
+      expect(file.wifi["channel"]).to eql("5")
       expect(file.ipv4["method"]).to eql("auto")
       expect(file.ipv6["method"]).to eql("auto")
     end


### PR DESCRIPTION
It merges #1337 & #1340 into SLE-15-SP5
