### PR TITLE
Backport sp6

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -2,6 +2,7 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.6
 
 -------------------------------------------------------------------
 Tue Jul  4 11:31:05 UTC 2023 - Knut Anderssen <kanderssen@suse.com>

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.6.0
+Version:        4.6.6
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.

## Solution

Just bump version as all fixes are already in SP5 under different version.