### PR TITLE
Fix drivers read

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 13 12:07:00 UTC 2023 - Knut Alejandro Anderssen González <kanderssen@suse.com>
+
+- Read all the driver modules from hwinfo instead of just the first
+  driver ones (bsc#1217652).
+- 4.5.22
+
+-------------------------------------------------------------------
 Tue Jul  4 11:31:05 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix typo when writing the wireless channel (bsc#1212976)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.5.21
+Version:        4.5.22
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/hwinfo.rb
+++ b/src/lib/y2network/hwinfo.rb
@@ -230,10 +230,10 @@ module Y2Network
     #
     # @return [Array<Driver>] List of drivers
     def drivers
-      driver = @hwinfo.fetch("drivers", []).first
-      return [] unless driver
+      drivers = @hwinfo.fetch("drivers", [])
+      return [] unless drivers.first
 
-      modules = driver.fetch("modules", [])
+      modules = drivers.map { |d| d.fetch("modules", []).flatten }
       modules.map { |m| Driver.new(*m) }
     end
 

--- a/test/data/hardware.yml
+++ b/test/data/hardware.yml
@@ -15,6 +15,11 @@
     modules:
     - - virtio_net
       - ''
+  - active: false
+    modprobe: true
+    modules:
+    - - virtio_net_test
+      - ''
   active: true
   module: virtio_net
   options: ''

--- a/test/y2network/hwinfo_test.rb
+++ b/test/y2network/hwinfo_test.rb
@@ -100,7 +100,7 @@ describe Y2Network::Hwinfo do
   describe "#drivers" do
     it "returns the list of kernel modules names" do
       expect(hwinfo.drivers).to eq(
-        [Y2Network::Driver.new("virtio_net", "")]
+        [Y2Network::Driver.new("virtio_net", ""), Y2Network::Driver.new("virtio_net_test", "")]
       )
     end
   end


### PR DESCRIPTION
## Problem

It was reported that yast2 lan does not show the proper kernel modules and that is mainly because yast2-network read only the modules of the first driver read by hwinfo.

- https://bugzilla.suse.com/show_bug.cgi?id=1217652

## Solution

Read all the modules from listed by hwinfo.

## Testing

- *Added a new unit test*
- *Tested manually*


