### PR TITLE
Do not consider firmware configured interfaces as bridgeable ones (bsc#1218595)

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 16 10:34:01 UTC 2024 - Knut Anderssen  <kanderssen@suse.com>
+
+- Consider firmware configured interfaces as non bridgeable
+  (bsc#1218595).
+- 4.5.23
+
+-------------------------------------------------------------------
 Wed Dec 13 12:07:00 UTC 2023 - Knut Alejandro Anderssen González <kanderssen@suse.com>
 
 - Read all the driver modules from hwinfo instead of just the first

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.5.22
+Version:        4.5.23
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/interface_config_builders/bridge.rb
+++ b/src/lib/y2network/interface_config_builders/bridge.rb
@@ -99,6 +99,8 @@ module Y2Network
       def bridgeable?(iface)
         # cannot report itself
         return false if iface.name == @name
+        # Do not add firmware configured interfaces (bsc#1218595)
+        return false if iface.firmware_configured?
         return true unless yast_config.configured_interface?(iface.name)
 
         config = yast_config.connections.by_name(iface.name)


### PR DESCRIPTION
## Problem

When YaST proposes a bridge configuration for virtualization it also consider firmware configured interfaces as candidate ports which is wrong (related to https://github.com/yast/yast-network/pull/1319)

- https://bugzilla.suse.com/show_bug.cgi?id=1218595



## Solution

Do not consider firmware configured interfaces as bridgeable ones.

