### PR TITLE
PoC: Guard secret attributes against leaking to the logs V1.0

### DIFF
--- a/src/lib/y2network/connection_config/wireless.rb
+++ b/src/lib/y2network/connection_config/wireless.rb
@@ -78,6 +78,7 @@ module Y2Network
       attr_accessor :client_key
       # @return [String] client private key password
       attr_accessor :client_key_password
+      alias_method :super_inspect, :inspect
 
       def initialize
         super
@@ -112,6 +113,28 @@ module Y2Network
       # @return [Boolean] return true if there is at least one not empty key
       def keys?
         !(keys || []).compact.all?(&:empty?)
+      end
+
+      # Return a clone of this object with all sensitive fields (passwords etc.) obscured.
+      # Use this for log output to avoid leaking passwords.
+      def sanitized
+        san = dup
+        san.wpa_psk = sanitized_field(san.wpa_psk)
+        san.wpa_password = sanitized_field(san.wpa_password)
+        san.client_key_password = sanitized_field(san.client_key_password)
+
+        san
+      end
+
+      # Sanitize one field if it is non-nil and non-empty.
+      def sanitized_field(orig)
+        return orig if orig.nil? || orig.empty?
+
+        "<sanitized>".freeze
+      end
+
+      def inspect
+        sanitized.super_inspect
       end
     end
   end

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -604,4 +604,52 @@ describe Y2Network::Config do
       expect(new_config.connections).to eq(updated_connections)
     end
   end
+
+  describe "#sanitized" do
+    let(:conn) do
+      Y2Network::ConnectionConfig::Wireless.new.tap do |c|
+        c.wpa_psk = "s3cr3t"
+        c.wpa_password = "s3cr3t"
+        c.client_key_password = "s3cr3t"
+      end
+    end
+
+    it "obscures the wpa_psk" do
+      expect(conn.wpa_psk).to eql("s3cr3t")
+      expect(conn.sanitized.wpa_psk).to eql("<sanitized>")
+    end
+
+    it "obscures the wpa_password" do
+      expect(conn.wpa_password).to eql("s3cr3t")
+      expect(conn.sanitized.wpa_password).to eql("<sanitized>")
+    end
+
+    it "obscures the client_key_password" do
+      expect(conn.client_key_password).to eql("s3cr3t")
+      expect(conn.sanitized.client_key_password).to eql("<sanitized>")
+    end
+
+    it "leaves the original untouched" do
+      expect(conn.sanitized.wpa_psk).to eql("<sanitized>")
+      expect(conn.wpa_psk).to eql("s3cr3t")
+    end
+  end
+
+  describe "#inspect" do
+    let(:conn) do
+      Y2Network::ConnectionConfig::Wireless.new.tap do |c|
+        c.wpa_psk = "s3cr3t"
+        c.wpa_password = "s3cr3t"
+        c.client_key_password = "s3cr3t"
+      end
+    end
+
+    it "does not leak a password" do
+      expect(conn.inspect).to_not match(/s3cr3t/)
+    end
+
+    it "contains <sanitized> instead of passwords" do
+      expect(conn.inspect).to match(/<sanitized>/)
+    end
+  end
 end


### PR DESCRIPTION
# Proof of Concept [_superseded_]

## Problem

Secret attributes of the wifi connection object might leak to the logs, e.g. if methods like `inspect()` are used.


## Fix

Use a custom `inspect()` method that clones the original object and sanitizes all fields that should not be logged verbatim (replacing each one with a special string `<sanitized>`).


## Related PR

**Superseded** by PR #1360 which uses `attr_secret` from `YaST2::SecretAttributes`.