### PR TITLE
Guard secret attributes against leaking to the logs [SLE-15-SP6]

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 13 14:20:25 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Guard secret attributes against leaking to the log (bsc#1221194)
+- 4.6.9
+
+-------------------------------------------------------------------
 Tue Jan 16 10:34:01 UTC 2024 - Knut Anderssen  <kanderssen@suse.com>
 
 - Consider firmware configured interfaces as non bridgeable

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.6.8
+Version:        4.6.9
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/connection_config/wireless.rb
+++ b/src/lib/y2network/connection_config/wireless.rb
@@ -19,12 +19,14 @@
 
 require "y2network/connection_config/base"
 require "yast2/equatable"
+require "yast2/secret_attributes"
 
 module Y2Network
   module ConnectionConfig
     # Configuration for wireless connections
     class Wireless < Base
       include Yast2::Equatable
+      include Yast2::SecretAttributes
 
       # wireless options
       #
@@ -37,13 +39,15 @@ module Y2Network
       attr_accessor :nwid
       # @return [Symbol] Authorization mode (:open, :shared, :psk, :eap)
       attr_accessor :auth_mode
+
       # FIXME: Consider moving keys to different classes.
       # @return [String] WPA preshared key
-      attr_accessor :wpa_psk
+      secret_attr :wpa_psk
       # @return [Integer]
       attr_accessor :key_length
+
       # @return [Array<String>] WEP keys
-      attr_accessor :keys
+      secret_attr :keys
       # @return [Integer] default WEP key
       attr_accessor :default_key
       # @return [String]
@@ -63,9 +67,10 @@ module Y2Network
       # FIXME: Consider an enum
       # @return [Integer] (0, 1, 2)
       attr_accessor :ap_scanmode
+
       # TODO: unify psk and password and write correct one depending on mode
       # @return [String]
-      attr_accessor :wpa_password
+      secret_attr :wpa_password
       # @return [String]
       attr_accessor :wpa_identity
       # @return [String] initial identity used for creating tunnel
@@ -76,8 +81,9 @@ module Y2Network
       attr_accessor :client_cert
       # @return [String] client private key used to encrypt for TLS
       attr_accessor :client_key
+
       # @return [String] client private key password
-      attr_accessor :client_key_password
+      secret_attr :client_key_password
 
       def initialize
         super

--- a/test/y2network/config_test.rb
+++ b/test/y2network/config_test.rb
@@ -604,4 +604,45 @@ describe Y2Network::Config do
       expect(new_config.connections).to eq(updated_connections)
     end
   end
+
+  context "secret attributes (passwords, keys)" do
+    let(:conn) do
+      Y2Network::ConnectionConfig::Wireless.new.tap do |c|
+        c.wpa_psk = "s3cr3t"
+        c.wpa_password = "s3cr3t"
+        c.client_key_password = "s3cr3t"
+      end
+    end
+
+    describe ".inspect" do
+      it "does not leak a password" do
+        expect(conn.inspect).to_not match(/s3cr3t/)
+      end
+
+      it "contains <secret> instead of passwords" do
+        expect(conn.inspect).to match(/<secret>/)
+      end
+    end
+
+    describe ".to_s" do
+      it "does not leak a password" do
+        # it's usually something like
+        # "#<Y2Network::ConnectionConfig::Wireless:0x000055b752576318>"
+        # so there shouldn't be any attributes - just making sure
+        expect(conn.to_s).to_not match(/s3cr3t/)
+      end
+    end
+
+    describe ".wpa_psk" do
+      it "returns the real password" do
+        expect(conn.wpa_psk).to eq("s3cr3t")
+      end
+    end
+
+    describe ".wpa_psk.to_s" do
+      it "returns the real password" do
+        expect(conn.wpa_psk.to_s).to eq("s3cr3t")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Target Branch

This is the merge PR of #1364 to **SLE-15-SP6**.

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1221194


## Trello

https://trello.com/c/6SAaaYZ3/


## Problem

Secret attributes of the wifi connection object might leak to the logs, e.g. if methods like `inspect()` are used.


## Solution

Mark them as secret with `secret_attr` from `YaST2::SecretAttributes`.


## Test

- Extended and executed the unit tests with packages from the same branch.


## Related PRs

- PoC PR: #1360
- PR for SLE-15-SP2: #1361
- Merge PR to SLE-15-SP3: #1362 
- Merge PR to SLE-15-SP4: #1363
- Merge PR to SLE-15-SP5: #1364