### PR TITLE
Assign the global default route to an specific connection when possible

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov  7 10:10:01 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
+
+- Try to assign default global routes to an specific connection 
+  when  possible (bsc#1232531).
+- 4.5.25
+
+-------------------------------------------------------------------
 Wed Mar 13 14:20:25 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Guard secret attributes against leaking to the log (bsc#1221194)

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.5.24
+Version:        4.5.25
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/y2network/config_writer.rb
+++ b/src/lib/y2network/config_writer.rb
@@ -95,18 +95,21 @@ module Y2Network
     #
     # @param _config     [Y2Network::Config] configuration to write
     # @param _old_config [Y2Network::Config, nil] original configuration used for detecting changes
+    # @param _issues_list [Y2Issues::List] list of issues detected until the method is call
     def write_routing(_config, _old_config, _issues_list); end
 
     # Writes the connection configurations
     #
     # @param _config     [Y2Network::Config] configuration to write
     # @param _old_config [Y2Network::Config, nil] original configuration used for detecting changes
+    # @param _issues_list [Y2Issues::List] list of issues detected until the method is call
     def write_connections(_config, _old_config, _issues_list); end
 
     # Updates the DNS configuration
     #
     # @param config     [Y2Network::Config] Current config object
     # @param old_config [Y2Network::Config,nil] Config object with original configuration
+    # @param _issues_list [Y2Issues::List] list of issues detected until the method is call
     def write_dns(config, old_config, _issues_list)
       old_dns = old_config.dns if old_config
       writer = Y2Network::ConfigWriters::DNSWriter.new
@@ -117,6 +120,7 @@ module Y2Network
     #
     # @param config     [Y2Network::Config] Current config object
     # @param old_config [Y2Network::Config,nil] Config object with original configuration
+    # @param _issues_list [Y2Issues::List] list of issues detected until the method is call
     def write_hostname(config, old_config, _issues_list)
       old_hostname = old_config.hostname if old_config
       writer = Y2Network::ConfigWriters::HostnameWriter.new
@@ -128,6 +132,7 @@ module Y2Network
     #
     # @param config     [Y2Network::Config] Current config object
     # @param _old_config [Y2Network::Config,nil] Config object with original configuration
+    # @param _issues_list [Y2Issues::List] list of issues detected until the method is call
     def write_interfaces(config, _old_config, _issues_list)
       writer = Y2Network::ConfigWriters::InterfacesWriter.new(reload: !Yast::Lan.write_only)
       writer.write(config.interfaces)
@@ -137,6 +142,7 @@ module Y2Network
     #
     # @param config     [Y2Network::Config] Current config object
     # @param _old_config [Y2Network::Config,nil] Config object with original configuration
+    # @param _issues_list [Y2Issues::List] list of issues detected until the method is call
     def write_drivers(config, _old_config, _issues_list)
       Y2Network::Driver.write_options(config.drivers)
     end
@@ -146,6 +152,7 @@ module Y2Network
     # TODO: extract this behaviour to a separate class.
     #
     # @param routing [Y2Network::Routing] routing configuration
+    # @param issues_list [Y2Issues::List] list of issues detected until the method is call
     def write_ip_forwarding(routing, issues_list)
       sysctl_config = CFA::SysctlConfig.new
       sysctl_config.load

--- a/src/lib/y2network/connection_config/base.rb
+++ b/src/lib/y2network/connection_config/base.rb
@@ -196,6 +196,17 @@ module Y2Network
         bootproto ? bootproto.static? : true
       end
 
+      # Convenience method to check whether a connection is configured using
+      # the static bootproto and a valid IP address.
+      #
+      # @return [Boolean] whether the connection is configured with a valid
+      #   static IP address or not
+      def static_valid_ip?
+        return false unless bootproto.static?
+
+        ip && ip.address.to_s != "0.0.0.0"
+      end
+
       # Return the first hostname associated with the primary IP address.
       #
       # @return [String, nil] returns the hostname associated with the primary

--- a/src/lib/y2network/network_manager/config_writer.rb
+++ b/src/lib/y2network/network_manager/config_writer.rb
@@ -91,14 +91,16 @@ module Y2Network
 
         explicit = routes.select { |r| r.interface&.name == conn.name }
 
-        return explicit if !conn.static_valid_ip?
+        return explicit unless conn.static_valid_ip?
+
+        conn_network = (IPAddr.new conn.ip.address.to_s).to_range
 
         # select the routes without an specific interface and which gateway belongs to the
         # same network
         global = routes.select do |r|
           next if r.interface || !r.default? || !r.gateway
 
-          (IPAddr.new conn.ip.address.to_s).to_range.include?(IPAddr.new(r.gateway.to_s))
+          conn_network.include?(IPAddr.new(r.gateway.to_s))
         end
 
         explicit + global

--- a/src/lib/y2network/network_manager/config_writer.rb
+++ b/src/lib/y2network/network_manager/config_writer.rb
@@ -19,6 +19,7 @@
 
 require "y2network/config_writer"
 require "y2network/network_manager/connection_config_writer"
+require "y2issues"
 
 module Y2Network
   module NetworkManager
@@ -26,15 +27,32 @@ module Y2Network
     class ConfigWriter < Y2Network::ConfigWriter
     private # rubocop:disable Layout/IndentationWidth
 
+      # Updates the ip forwarding as the routes are written when writing the connections
+      #
+      # @param config     [Y2Network::Config] Current config object
+      # @param _old_config [Y2Network::Config,nil] Config object with original configuration
+      # @param issues_list [Y2Issues::List] list of issues detected until the method is call
+      def write_routing(config, _old_config, issues_list)
+        write_ip_forwarding(config.routing, issues_list)
+
+        routes = routes_for(nil, config.routing.routes)
+        return if routes.empty?
+
+        log.error "There are some routes that could need to be written manually: #{routes}"
+      end
+
       # Writes connections configuration
       #
       # @todo Handle old connections (removing those that are not needed, etc.)
       #
       # @param config     [Y2Network::Config] Current config object
       # @param _old_config [Y2Network::Config,nil] Config object with original configuration
+      # @param _issues_list [Y2Issues::List] list of issues detected until the method is call
       def write_connections(config, _old_config, _issues_list)
         writer = Y2Network::NetworkManager::ConnectionConfigWriter.new
         config.connections.each do |conn|
+          routes_for(conn, config.routing.routes)
+
           opts = {
             routes: routes_for(conn, config.routing.routes),
             parent: conn.find_parent(config.connections)
@@ -49,8 +67,9 @@ module Y2Network
       # to the configuration file (see bsc#1181701).
       #
       # @param config     [Y2Network::Config] Current config object
-      # @param old_config [Y2Network::Config,nil] Config object with original configuration
-      def write_dns(config, old_config, _issues_list)
+      # @param _old_config [Y2Network::Config,nil] Config object with original configuration
+      # @param _issues_list [Y2Issues::List] list of issues detected until the method is call
+      def write_dns(config, _old_config, _issues_list)
         static = config.connections.by_bootproto(Y2Network::BootProtocol::STATIC)
         return super if static.empty? || config.dns.nameservers.empty?
 
@@ -68,7 +87,21 @@ module Y2Network
       # @param routes [Array<Route>] List of routes to search in
       # @return [Array<Route>] List of routes for the given connection
       def routes_for(conn, routes)
-        routes.select { |r| r.interface&.name == conn.name }
+        return routes.reject(&:interface) if conn.nil?
+
+        explicit = routes.select { |r| r.interface&.name == conn.name }
+
+        return explicit if !conn.static_valid_ip?
+
+        # select the routes without an specific interface and which gateway belongs to the
+        # same network
+        global = routes.select do |r|
+          next if r.interface || !r.default? || !r.gateway
+
+          (IPAddr.new conn.ip.address.to_s).to_range.include?(IPAddr.new(r.gateway.to_s))
+        end
+
+        explicit + global
       end
 
       # Add the DNS settings to the nmconnection file corresponding to the give conn

--- a/src/lib/y2network/wicked/connection_config_writers/base.rb
+++ b/src/lib/y2network/wicked/connection_config_writers/base.rb
@@ -81,7 +81,7 @@ module Y2Network
         def add_ips(conn)
           file.ipaddrs.clear
           ips_to_add = conn.ip_aliases.clone
-          ips_to_add << conn.ip if static_valid_ip?(conn)
+          ips_to_add << conn.ip if conn.static_valid_ip?
           ips_to_add.each { |i| add_ip(i) }
         end
 
@@ -103,18 +103,6 @@ module Y2Network
           return if conn.hostnames.empty?
 
           Yast::Host.Update("", conn.hostname, conn.ip.address.address.to_s)
-        end
-
-        # Convenience method to check whether a connection is configured using
-        # the static bootproto and a valid IP address.
-        #
-        # @param conn [Y2Network::ConnectionConfig::Base] Connection to take settings from
-        # @return [Boolean] whether the connection is configured with a valid
-        #   static IP address or not
-        def static_valid_ip?(conn)
-          return false unless conn.bootproto.static?
-
-          conn.ip && conn.ip.address.address.to_s != "0.0.0.0"
         end
 
         # Converts the value into a string (or nil if empty)


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1232531

The default gateway is lost after installation if the gateway is configured manually and it’s not network interface specific. It’s the wicked to NM conversion that is not implemented in this case.


## Solution

When the default route does not belongs to any specific interface it will be associated to the connection which has an ip address belonging to the same network than the default route gateway.


## Testing

- *Added a new unit test*
- *Tested manually*


