### PR TITLE
Added dialog for changing the bond ports naming schema to BusID (bsc#1233653) - SLE-15-SP6

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb 12 10:41:47 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Added a warn about a possible problem with the configured bond
+  ports configuration using a MAC based renaming schema allowing
+  the user to change all of them to use the BusID. (bsc#1233653)
+- 4.6.11
+
+-------------------------------------------------------------------
 Thu Nov  7 10:10:01 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Try to assign default global routes to an specific connection 

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        4.6.10
+Version:        4.6.11
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/include/network/lan/complex.rb
+++ b/src/include/network/lan/complex.rb
@@ -194,7 +194,16 @@ module Yast
         end
       end
 
+      if ret
+        bonding_fix.run if bonding_fix.needs_to_be_run?
+      end
+
       ret ? :next : :abort
+    end
+
+    def bonding_fix
+      require "y2network/dialogs/bonding_fix"
+      @bonding_fix ||= Y2Network::Dialogs::BondingFix.new(Lan.yast_config)
     end
 
     # Write settings dialog

--- a/src/lib/y2network/dialogs/bonding_fix.rb
+++ b/src/lib/y2network/dialogs/bonding_fix.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2025] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2network/dialogs/bonding_fix.rb
+++ b/src/lib/y2network/dialogs/bonding_fix.rb
@@ -141,7 +141,7 @@ module Y2Network
         invalid_bonds.each do |bond|
           bond.ports.each do |port|
             interface = iface_for(port)
-            interface.rename(interface.name, :bus_id)
+            interface&.rename(interface.name, :bus_id) if interface&.renaming_mechanism == :mac
           end
         end
         Yast::Lan.SetModified

--- a/src/lib/y2network/dialogs/bonding_fix.rb
+++ b/src/lib/y2network/dialogs/bonding_fix.rb
@@ -1,0 +1,179 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "cwm/popup"
+require "cwm/common_widgets"
+require "y2network/widgets/renaming_mechanism"
+
+module Y2Network
+  module Dialogs
+    # RichText with the config summary of the given bonds mainly focused in
+    # the ports naming mechanism
+    class BondingConfigSummary < CWM::RichText
+      include Presenters::InterfaceStatus
+      attr_reader :config
+      attr_reader :bonds
+
+      def initialize(config, bonds)
+        textdomain "network"
+
+        @config = config
+        @bonds = bonds
+      end
+
+      def init
+        self.value = summary
+      end
+
+    private
+
+      def summary
+        bonds.map { |b| bond_summary(b) }.join("<br>")
+      end
+
+      def port_summary(port)
+        interface = config.interfaces.by_name(port)
+        hardware = interface.hardware
+        text = "<b>" + port + "<b><br>"
+
+        if hardware.nil? || !hardware.exists?
+          text << "<b>" << _("No hardware information") << "</b><br>"
+        else
+          text << "<b>MAC : </b>" << hardware.mac << "<br>" if hardware.mac
+          text << "<b>BusID : </b>" << hardware.busid << "<br>" if hardware.busid
+          mechanism =
+            case interface&.renaming_mechanism
+            when :mac
+              "MAC"
+            when :bus_id
+              "BusID"
+            else
+              "None"
+            end
+          text << "<b>Renaming mechanism : </b>" << mechanism
+        end
+
+        text
+      end
+
+      def bond_summary(conn)
+        rich = "<b>" + _("Bond Name: %s") % conn.name + "</b><br>"
+        rich << "<b>" + _("Bond Ports") + "</b><br>"
+        rich << Yast::HTML.List(conn.ports.map { |p| port_summary(p) })
+        rich
+      end
+    end
+
+    # This widget allows to modify all the udev rules of the bond members using
+    # the bus_id instead of the mac address as the device matching key
+    class BondingFix < CWM::Popup
+      attr_reader :interface
+      attr_reader :config
+
+      # Constructor
+      #
+      # @param config [Y2Network::Config]
+      def initialize(config)
+        require "y2network/presenters/interface_summary"
+        textdomain "network"
+
+        @config = config
+      end
+
+      # @see CWM::AbstractWidget
+      def title
+        _("Bond ports using MAC address")
+      end
+
+      # @see CWM::CustomWidget
+      def contents
+        HBox(
+          HSpacing(0.5),
+          VBox(
+            Label(intro),
+            MinSize(55, 14, bond_description),
+            Label(question)
+          ),
+          HSpacing(0.5)
+        )
+      end
+
+      def run
+        ret = super
+        apply_renaming if ret == :ok
+        ret
+      end
+
+      def needs_to_be_run?
+        !invalid_bonds.empty?
+      end
+
+    private
+
+      def iface_for(port)
+        config.interfaces.by_name(port)
+      end
+
+      def invalid_bonds
+        @config.connections.select do |conn|
+          conn.is_a?(Y2Network::ConnectionConfig::Bonding) &&
+            conn.ports.any? { |p| iface_for(p)&.renaming_mechanism == :mac }
+        end
+      end
+
+      def apply_renaming
+        invalid_bonds.each do |bond|
+          bond.ports.each do |port|
+            interface = iface_for(port)
+            interface.rename(interface.name, :bus_id)
+          end
+        end
+        Yast::Lan.SetModified
+      end
+
+      def intro
+        _("There are some bond ports using an udev rule based on MAC address for renaming\n" \
+          "the device which is not recommended and could cause some naming problem.")
+      end
+
+      def bond_description
+        @bond_description ||= BondingConfigSummary.new(config, invalid_bonds)
+      end
+
+      def question
+        _("Would you like to change the bond ports renaming mechanism to BusID?")
+      end
+
+      def ok_button_label
+        Yast::Label.YesButton
+      end
+
+      def cancel_button_label
+        Yast::Label.NoButton
+      end
+
+      # Returns the dialogs button
+      #
+      # @return [Array<Yast::Term>]
+      def buttons
+        [ok_button, cancel_button]
+      end
+    end
+  end
+end

--- a/src/lib/y2network/interface_config_builders/bonding.rb
+++ b/src/lib/y2network/interface_config_builders/bonding.rb
@@ -64,10 +64,26 @@ module Y2Network
         end
       end
 
+      # Returns whether any configuration of the given devices needs to be
+      # adapted in order to be added into a bonding
+
+      # @param devices [Array<String>] devices to check
+      # return [Boolean] true if there is a device config that needs
+      #   to be adaptated; false otherwise
+      def invalid_naming_schema?(devices)
+        devices.any? do |device|
+          interface = yast_config.interfaces.by_name(device)
+          next false unless interface
+
+          interface.renaming_mechanism == :mac
+        end
+      end
+
       # additionally it adapts configuration of devices to be included in a bonding if needed
       def save
         ports.each do |port|
           interface = yast_config.interfaces.by_name(port)
+          interface.renaming_mechanism = :bus_id if interface.renaming_mechanism == :mac
           next if valid_port_config?(port)
 
           connection = yast_config.connections.by_name(port)

--- a/src/lib/y2network/presenters/interface_summary.rb
+++ b/src/lib/y2network/presenters/interface_summary.rb
@@ -94,6 +94,10 @@ module Y2Network
           rich << "<b>(" << _("Not connected") << ")</b><br>" if !hardware.link
           rich << "<b>MAC : </b>" << hardware.mac << "<br>" if hardware.mac
           rich << "<b>BusID : </b>" << hardware.busid << "<br>" if hardware.busid
+          if interface.renaming_mechanism != :none
+            mechanism = (interface.renaming_mechanism == :mac) ? "MAC" : "BusID"
+            rich << "<b>Renaming mechanism : </b>" << mechanism << "<br>"
+          end
           # TODO: physical port id. Probably in hardware?
         end
 

--- a/src/lib/y2network/widgets/bond_port.rb
+++ b/src/lib/y2network/widgets/bond_port.rb
@@ -139,9 +139,16 @@ module Y2Network
                 "Adapt the configuration for bonding?\n"
             )
           )
-        else
-          true
+        elsif @settings.invalid_naming_schema?(selected_items || [])
+          return Yast::Popup.ContinueCancel(
+            _(
+              "At least one selected device is using a MAC address for renaming the device.\n" \
+                "Would you like to change the renaming mechanism to BusID?\n"
+            )
+          )
         end
+
+        true
       end
 
       def value

--- a/test/y2network/presenters/interface_summary_test.rb
+++ b/test/y2network/presenters/interface_summary_test.rb
@@ -40,11 +40,12 @@ describe Y2Network::Presenters::InterfaceSummary do
   let(:interfaces) do
     Y2Network::InterfacesCollection.new(
       [
-        double(Y2Network::Interface, hardware: nil, name: "vlan1", firmware_configured?: false),
+        double(Y2Network::Interface, hardware: nil, name: "vlan1", firmware_configured?: false,
+          renaming_mechanism: :none),
         double(Y2Network::Interface, hardware: double.as_null_object, name: "eth1",
-          firmware_configured?: false),
+          firmware_configured?: false, renaming_mechanism: :mac),
         double(Y2Network::Interface, hardware: double.as_null_object, name: "eth0",
-          firmware_configured?: false)
+          firmware_configured?: false, renaming_mechanism: :bus_id)
       ]
     )
   end
@@ -84,6 +85,13 @@ describe Y2Network::Presenters::InterfaceSummary do
 
       it "returns an empty text" do
         expect(presenter.text).to eql("")
+      end
+    end
+
+    context "when an interface is using some renaming mechanism" do
+      it "is shown in the summary" do
+        text = presenter.text
+        expect(text).to include("Renaming mechanism : </b>BusID")
       end
     end
 

--- a/test/y2network/widgets/interfaces_table_test.rb
+++ b/test/y2network/widgets/interfaces_table_test.rb
@@ -32,12 +32,12 @@ describe Y2Network::Widgets::InterfacesTable do
 
   let(:eth0) do
     instance_double(Y2Network::Interface, name: "eth0", hardware: hwinfo, old_name: "eth1",
-      firmware_configured_by: nil, firmware_configured?: false)
+      firmware_configured_by: nil, firmware_configured?: false, renaming_mechanism: naming)
   end
 
   let(:br0) do
     instance_double(Y2Network::VirtualInterface, name: "br0", hardware: nil, old_name: nil,
-      firmware_configured_by: nil, firmware_configured?: false)
+      firmware_configured_by: nil, firmware_configured?: false, renaming_mechanism: :none)
   end
   let(:interfaces) { Y2Network::InterfacesCollection.new([eth0, br0]) }
   let(:hwinfo) do
@@ -47,6 +47,7 @@ describe Y2Network::Widgets::InterfacesTable do
 
   let(:mac) { "01:23:45:67:89:ab" }
   let(:busid) { "0000:04:00.0" }
+  let(:naming) { :mac }
   let(:link) { false }
   let(:exists?) { true }
   let(:connections) { Y2Network::ConnectionConfigsCollection.new([eth0_conn, br0_conn]) }
@@ -124,6 +125,7 @@ describe Y2Network::Widgets::InterfacesTable do
 
     context "when there is no MAC address" do
       let(:mac) { nil }
+      let(:naming) { :none }
 
       it "does not include the MAC in the description" do
         expect(description).to receive(:value=) do |text|
@@ -150,6 +152,8 @@ describe Y2Network::Widgets::InterfacesTable do
     end
 
     context "when there is no hardware information" do
+      let(:naming) { :none }
+
       let(:exists?) { false }
 
       it "sets the description with 'no hardware information' warning" do
@@ -186,7 +190,7 @@ describe Y2Network::Widgets::InterfacesTable do
     context "when the device is configured by hardware" do
       let(:eth0) do
         instance_double(Y2Network::Interface, name: "eth0", hardware: hwinfo, old_name: "eth1",
-          firmware_configured_by: :redfish, firmware_configured?: true)
+          firmware_configured_by: :redfish, firmware_configured?: true, renaming_mechanism: naming)
       end
 
       it "shows which firmware extension configured the device in the description" do


### PR DESCRIPTION
## Problem

When a user does some change with the module writing down the configuration, YaST calls  `udevadm trigger --subsystem-match=net --action=add` at some point. 

If there is some bond port using the MAC address as the renaming schema (udev rule) the interface could be wrongly renamed by the udev-generator as it uses the *current MAC* of the NIC instead of the permanent one (the backup of the bond uses the same MAC of the active one).

- https://bugzilla.suse.com/show_bug.cgi?id=1233653

## Solution

In order to prevent the user to shoot himself in the foot a dialog has been implemented to warn the user allowing him to change the renaming mechanism of all the affected bond ports just accepting it.

## Testing

- *Tested manually*


## Screenshots

![image](https://github.com/user-attachments/assets/136ba97f-9b83-4315-907b-6d5cf5f8fc23)
