### PR TITLE
Fix new ruby

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct  8 08:28:54 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix reading proxy with the latest security fix in ruby
+  (bsc#1251273)
+- 5.0.6
+
+-------------------------------------------------------------------
 Wed Feb 12 10:41:47 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
 
 - Added a warn about a possible problem with the configured bond

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        5.0.5
+Version:        5.0.6
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only

--- a/src/lib/network/install_inf_convertor.rb
+++ b/src/lib/network/install_inf_convertor.rb
@@ -91,8 +91,10 @@ module Yast
 
       # save user name and password separately
       ex["proxy_user"] = proxy.user
-      proxy.user = nil
       ex["proxy_password"] = proxy.password
+      # reset user and password after it is read as it is reset after first write to user
+      # (bsc#1251273)
+      proxy.user = nil
       proxy.password = nil
       ex["#{proxyProto}_proxy"] = proxy.to_s
       # Use the proxy also for https and ftp


### PR DESCRIPTION
## Problem

With security fixed ruby write nil to user resets also password.

- obs https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:H/yast2-network/standard/x86_64
- bzilla https://bugzilla.suse.com/show_bug.cgi?id=1251273

## Solution

Reorder calling nil after password is read.