### PR TITLE
Dropped requirement on update-desktop-files

### DIFF
--- a/package/yast2-network.changes
+++ b/package/yast2-network.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 10 09:00:28 UTC 2026 - Michal Filka <mfilka@suse.com>
+
+- jsc#PED-14507
+  - Removed reference to update-desktop-files from spec file 
+  - 5.0.7
+-------------------------------------------------------------------
 Wed Oct  8 08:28:54 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix reading proxy with the latest security fix in ruby

--- a/package/yast2-network.spec
+++ b/package/yast2-network.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-network
-Version:        5.0.6
+Version:        5.0.7
 Release:        0
 Summary:        YaST2 - Network Configuration
 License:        GPL-2.0-only
@@ -28,7 +28,6 @@ Source0:        %{name}-%{version}.tar.bz2
 
 # testsuite
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
-BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools >= 3.1.15
 #for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)


### PR DESCRIPTION
Removed all references to update-desktop-files from the package's spec file. Bumped version